### PR TITLE
docs(readme): add top quickstart + trigger v0.2.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@
 
 Lossless storage and hybrid search for AI agent sessions, across every agentic client.
 
+**Quickstart.** Install, ingest your local sessions, and add pond as an MCP server in any app:
+
+```sh
+brew install tenequm/tap/pond
+pond sync
+
+# add pond as an MCP server (pick your client):
+claude mcp add -s user pond -- pond mcp   # Claude Code
+codex mcp add pond -- pond mcp            # Codex
+```
+
 Pond keeps every AI conversation you've ever had intact and searchable, and lets you continue any of them in any supported tool. Your history, your search, your sessions - independent of the agent vendor that made them.
 
 One Rust binary that ingests sessions from any agentic client (Claude Code, Codex, and more on the roadmap) into a canonical Session / Message / Part interlingua, stores them in Lance on object storage, and serves hybrid search over them via HTTP+JSON and MCP. Two deployments: a personal pond on your laptop, or a multi-tenant backend for hosted agent infrastructure. No SQL, no extra database, no wrapper around Lance.


### PR DESCRIPTION
Adds the top-of-README quickstart (install, `pond sync`, register `pond mcp` in Claude Code / Codex).

The branch is intentionally named `release-plz-*` so that merging it triggers release-plz's `release` step (release_always=false), which publishes the already-prepared v0.2.1: `pond-db` to crates.io, tag v0.2.1, GitHub release, then publish-release builds binaries and pushes the Homebrew + NUR packages. release-plz preview confirmed next version = 0.2.1.