### PR TITLE
feat(adapter): add pi and opencode source adapters

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -475,7 +475,7 @@ Each adapter has a round-trip codec test: parse a committed fixture to canonical
 
 ### 6.9 v1 adapters
 
-Claude Code and Codex, each with both faces, including the cross pairs. Per-source extraction detail - how each adapter resolves `project`, what its `source_agent` brand is, its on-disk layout - lives in that adapter's own code, which is its documentation.
+Claude Code, Codex, opencode, and pi. Claude Code and Codex carry both faces including the foreign cross pairs; opencode and pi carry native restore (round-trip tested per Section 6.8) plus best-effort foreign serialization. opencode is the first source that is not one JSONL file per session - a content-addressed `session`/`message`/`part` split tree - so it drives the read seam directly rather than through the shared JSONL helper. Per-source extraction detail - how each adapter resolves `project`, what its `source_agent` brand is, its on-disk layout - lives in that adapter's own code, which is its documentation.
 
 ---
 

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -32,6 +32,8 @@ mod codex_cli;
 mod discovery;
 pub mod extract;
 mod jsonl;
+mod opencode;
+mod pi;
 
 pub use claude_code::{ClaudeCodeAdapter, ClaudeCodeFactory};
 pub use codex_cli::{CodexCliAdapter, CodexCliFactory};
@@ -40,6 +42,8 @@ pub use extract::{
     Extracted, Source, extract_bool, extract_compact_repr, extract_raw_record, extract_self_str,
     extract_str, extract_value,
 };
+pub use opencode::{OpencodeAdapter, OpencodeFactory};
+pub use pi::{PiAdapter, PiFactory};
 
 /// Stateless face of an adapter type: how the registry knows about it without
 /// instantiating it. One implementation per known format, registered in
@@ -319,7 +323,12 @@ impl std::error::Error for AdapterError {
 /// adds one `&Factory` here plus one file under `src/adapter/`. Order is the
 /// order discovery presents to the operator.
 pub fn registry() -> &'static [&'static dyn AdapterFactory] {
-    &[&ClaudeCodeFactory, &CodexCliFactory]
+    &[
+        &ClaudeCodeFactory,
+        &CodexCliFactory,
+        &OpencodeFactory,
+        &PiFactory,
+    ]
 }
 
 /// Look up a factory by name. Returns `None` for unknown names; callers

--- a/src/adapter/opencode.rs
+++ b/src/adapter/opencode.rs
@@ -1,0 +1,984 @@
+//! opencode adapter (github.com/sst/opencode).
+//!
+//! Unlike claude-code and codex-cli, opencode does not store one JSONL file per
+//! session. It uses a content-addressed split layout under a `storage/` root:
+//!
+//! - `session/<projectID>/<sessionID>.json` - session metadata
+//! - `message/<sessionID>/<messageID>.json` - one message header (no content)
+//! - `part/<messageID>/<partID>.json`        - one content part
+//!
+//! So this is the first adapter to drive the [`Adapter`] seam directly rather
+//! than through the JSONL helper: it walks the three levels, sorts by id (the
+//! ids are lexically time-sortable, so filename order is creation order), and
+//! emits `Session -> Message -> Parts` per session.
+//!
+//! opencode fuses a tool call and its result into one `tool` part on the
+//! assistant message. Canonical keeps the two apart (a `tool_result` on an
+//! assistant message is a category error, spec.md#model-part-provenance), so the
+//! adapter splits it: a `ToolCall` Part stays on the assistant message and a
+//! synthetic `Tool` message carries the `ToolResult`. Native restore replays
+//! each real part's stored `raw_record` at its original path and skips the
+//! synthetic records, so the split is value-complete-lossless.
+
+use std::path::{Path, PathBuf};
+
+use async_stream::stream;
+use chrono::{DateTime, Utc};
+use serde_json::{Value, json};
+use tokio::sync::mpsc;
+
+use crate::{
+    sessions::IngestEvent,
+    wire::{FileData, Message, Part, PartKind, Provenance, ProviderOptions, Session},
+};
+
+use super::{
+    Adapter, AdapterError, AdapterFactory, AdapterYield, AdapterYieldStream, DiscoverFuture, Env,
+    RestoreFidelity, RestoredFile, SkipOracle, SkipReason, compact_json, config_path,
+    extract::{bound_value, extract_raw_record, extract_str},
+    part_id,
+};
+
+const NAME: &str = "opencode";
+
+/// Event-channel bound; doubles as backpressure - the blocking reader parks on
+/// `blocking_send` when the consumer lags.
+const CHANNEL_CAP: usize = 256;
+
+/// Stateless factory: opens [`OpencodeAdapter`] instances and probes for the
+/// canonical install location under `~/.local/share/opencode/storage`.
+pub struct OpencodeFactory;
+
+impl AdapterFactory for OpencodeFactory {
+    fn name(&self) -> &'static str {
+        NAME
+    }
+
+    fn open(&self, config: Value) -> Result<Box<dyn Adapter>, AdapterError> {
+        Ok(Box::new(OpencodeAdapter::new(config_path(NAME, config)?)))
+    }
+
+    fn probe_default(&self, env: &Env) -> Option<Value> {
+        let path = env
+            .home
+            .join(".local")
+            .join("share")
+            .join("opencode")
+            .join("storage");
+        path.exists().then(|| json!({ "path": path }))
+    }
+
+    fn serialize(
+        &self,
+        session: &crate::sessions::SessionWithMessages,
+        fidelity: RestoreFidelity,
+    ) -> Result<Vec<RestoredFile>, AdapterError> {
+        match fidelity {
+            RestoreFidelity::Native => serialize_native(session),
+            RestoreFidelity::Foreign => serialize_foreign(session),
+        }
+    }
+}
+
+/// Configured opencode reader, rooted at a `storage/` directory.
+#[derive(Debug, Clone)]
+pub struct OpencodeAdapter {
+    root: PathBuf,
+}
+
+impl OpencodeAdapter {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+}
+
+impl Adapter for OpencodeAdapter {
+    fn discover(&self) -> DiscoverFuture<'_> {
+        let root = self.root.clone();
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || {
+                collect_session_files(&root).map(|files| files.len())
+            })
+            .await
+            .map_err(join_error)?
+        })
+    }
+
+    fn events_with<'a>(&'a self, oracle: &'a dyn SkipOracle) -> AdapterYieldStream<'a> {
+        let adapter = self.clone();
+        Box::pin(stream! {
+            let files = {
+                let root = adapter.root.clone();
+                tokio::task::spawn_blocking(move || collect_session_files(&root)).await
+            };
+            let files = match files {
+                Ok(Ok(files)) => files,
+                Ok(Err(error)) => { yield Err(error); return; }
+                Err(join) => { yield Err(join_error(join)); return; }
+            };
+
+            let mut survivors = Vec::with_capacity(files.len());
+            for file in files {
+                if let Some(ingested) = oracle.last_ingested_at(&file.session_id)
+                    && let Some(mtime) = file.mtime
+                    && mtime <= ingested
+                {
+                    yield Ok(AdapterYield::Skipped {
+                        session_id: Some(file.session_id.clone()),
+                        project: None,
+                        reason: SkipReason::Fresh,
+                    });
+                    continue;
+                }
+                survivors.push(file);
+            }
+
+            let (tx, mut rx) = mpsc::channel(CHANNEL_CAP);
+            let reader = adapter.clone();
+            let handle = tokio::task::spawn_blocking(move || read_sessions(&reader, survivors, &tx));
+            while let Some(item) = rx.recv().await {
+                yield item;
+            }
+            if let Err(join) = handle.await {
+                yield Err(join_error(join));
+            }
+        })
+    }
+}
+
+/// A blocking-task panic is a pond bug, not bad source data, so it fails the
+/// whole run rather than skipping a session.
+fn join_error(join: tokio::task::JoinError) -> AdapterError {
+    AdapterError::io(
+        NAME,
+        "blocking read task",
+        std::io::Error::other(join.to_string()),
+    )
+}
+
+/// One session file located on disk, with the cheap freshness inputs.
+struct SessionFile {
+    session_id: String,
+    path: PathBuf,
+    mtime: Option<DateTime<Utc>>,
+}
+
+/// Walk `<root>/session/<projectID>/<sessionID>.json`, sorted for deterministic
+/// ingest order. A missing `session/` dir means "no sessions yet", not an error.
+fn collect_session_files(root: &Path) -> Result<Vec<SessionFile>, AdapterError> {
+    let session_root = root.join("session");
+    let io = |path: &Path, source| AdapterError::io(NAME, path.display().to_string(), source);
+    let entries = match std::fs::read_dir(&session_root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(io(&session_root, error)),
+    };
+    let mut out = Vec::new();
+    for project in entries {
+        let project = project.map_err(|error| io(&session_root, error))?;
+        if !project
+            .file_type()
+            .map_err(|error| io(&project.path(), error))?
+            .is_dir()
+        {
+            continue;
+        }
+        let project_dir = project.path();
+        for session in std::fs::read_dir(&project_dir).map_err(|error| io(&project_dir, error))? {
+            let session = session.map_err(|error| io(&project_dir, error))?;
+            let path = session.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                continue;
+            }
+            let Some(session_id) = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .map(ToOwned::to_owned)
+            else {
+                continue;
+            };
+            let mtime = std::fs::metadata(&path)
+                .and_then(|meta| meta.modified())
+                .ok()
+                .map(DateTime::<Utc>::from);
+            out.push(SessionFile {
+                session_id,
+                path,
+                mtime,
+            });
+        }
+    }
+    out.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(out)
+}
+
+fn read_sessions(
+    adapter: &OpencodeAdapter,
+    sessions: Vec<SessionFile>,
+    tx: &mpsc::Sender<Result<AdapterYield, AdapterError>>,
+) {
+    for session in sessions {
+        if !read_one_session(adapter, &session, tx) {
+            return;
+        }
+    }
+}
+
+/// Returns `false` when the consumer dropped the receiver and the read should stop.
+fn read_one_session(
+    adapter: &OpencodeAdapter,
+    file: &SessionFile,
+    tx: &mpsc::Sender<Result<AdapterYield, AdapterError>>,
+) -> bool {
+    macro_rules! emit {
+        ($item:expr) => {
+            if tx.blocking_send($item).is_err() {
+                return false;
+            }
+        };
+    }
+
+    let session_value = match read_json(&file.path) {
+        Ok(value) => value,
+        Err(error) => {
+            emit!(Err(error));
+            return true;
+        }
+    };
+    let session = match session_from_value(&session_value, &file.path) {
+        Ok(session) => session,
+        Err(error) => {
+            emit!(Err(error));
+            return true;
+        }
+    };
+    let session_id = session.id.clone();
+    emit!(Ok(AdapterYield::Event(IngestEvent::Session(session))));
+
+    let message_dir = adapter.root.join("message").join(&session_id);
+    let message_files = match list_json_sorted(&message_dir) {
+        Ok(files) => files,
+        Err(error) => {
+            emit!(Err(error));
+            return true;
+        }
+    };
+    for message_path in message_files {
+        let message_value = match read_json(&message_path) {
+            Ok(value) => value,
+            Err(error) => {
+                emit!(Err(error));
+                continue;
+            }
+        };
+        let Some(message_id) = message_value.get("id").and_then(Value::as_str) else {
+            emit!(Err(AdapterError::schema(
+                NAME,
+                message_path.display().to_string(),
+                "message file missing `id`",
+            )));
+            continue;
+        };
+        let part_dir = adapter.root.join("part").join(message_id);
+        let part_files = match list_json_sorted(&part_dir) {
+            Ok(files) => files,
+            Err(error) => {
+                emit!(Err(error));
+                continue;
+            }
+        };
+        let mut parts = Vec::with_capacity(part_files.len());
+        let mut part_error = None;
+        for part_path in part_files {
+            match read_json(&part_path) {
+                Ok(value) => parts.push(value),
+                Err(error) => {
+                    part_error = Some(error);
+                    break;
+                }
+            }
+        }
+        if let Some(error) = part_error {
+            emit!(Err(error));
+            continue;
+        }
+        match build_message_events(&session_id, &message_value, &parts) {
+            Ok(events) => {
+                for event in events {
+                    emit!(Ok(AdapterYield::Event(event)));
+                }
+            }
+            Err(error) => emit!(Err(error)),
+        }
+    }
+    true
+}
+
+/// Read one JSON file, bounding every string leaf at the seam cap
+/// (spec.md#adapter-bounded-values) before it leaves this module.
+fn read_json(path: &Path) -> Result<Value, AdapterError> {
+    let bytes = std::fs::read(path)
+        .map_err(|error| AdapterError::io(NAME, path.display().to_string(), error))?;
+    let mut value: Value = serde_json::from_slice(&bytes)
+        .map_err(|error| AdapterError::parse(NAME, path.display().to_string(), 1, error))?;
+    bound_value(&mut value);
+    Ok(value)
+}
+
+/// List `*.json` files in `dir`, sorted by filename (= creation order, ids are
+/// time-sortable). A missing dir is an empty list - a message can legitimately
+/// carry no parts.
+fn list_json_sorted(dir: &Path) -> Result<Vec<PathBuf>, AdapterError> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(AdapterError::io(NAME, dir.display().to_string(), error)),
+    };
+    let mut out = Vec::new();
+    for entry in entries {
+        let entry =
+            entry.map_err(|error| AdapterError::io(NAME, dir.display().to_string(), error))?;
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) == Some("json") {
+            out.push(path);
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+fn session_from_value(value: &Value, path: &Path) -> Result<Session, AdapterError> {
+    let display = path.display().to_string();
+    let id = value
+        .get("id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| AdapterError::schema(NAME, display.clone(), "session missing `id`"))?
+        .to_owned();
+    let created_at = millis_at(value, &["time", "created"]).ok_or_else(|| {
+        AdapterError::schema(NAME, display.clone(), "session missing `time.created`")
+    })?;
+    // spec.md#model-project-non-empty: opencode always records `directory` (the
+    // project cwd); its absence is a malformed session, not a default.
+    let project = extract_str(value, "directory")
+        .ok_or_else(|| AdapterError::schema(NAME, display, "session missing `directory`"))?;
+
+    let mut options = ProviderOptions::new();
+    options.insert(
+        "opencode".to_owned(),
+        json!({ "raw_record": extract_raw_record(value) }),
+    );
+
+    Ok(Session {
+        id,
+        // opencode sub-sessions (a Task spawn) carry `parentID`; a soft
+        // reference, present only when this session was spawned from another.
+        parent_session_id: value
+            .get("parentID")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        parent_message_id: None,
+        source_agent: NAME.to_owned(),
+        created_at,
+        project,
+        options,
+    })
+}
+
+/// Build the ordered event stream for one message: the message, its parts in
+/// order, then any synthetic `Tool` messages (one per `tool` part) each
+/// followed by its `ToolResult`.
+fn build_message_events(
+    session_id: &str,
+    message_value: &Value,
+    part_values: &[Value],
+) -> Result<Vec<IngestEvent>, AdapterError> {
+    let message_id = message_value
+        .get("id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| AdapterError::schema(NAME, session_id.to_owned(), "message missing `id`"))?;
+    let role = message_value.get("role").and_then(Value::as_str);
+    let timestamp = millis_at(message_value, &["time", "created"]).unwrap_or_else(anchor_ts);
+
+    let options = opencode_raw(message_value);
+    let message = match role {
+        Some("user") => Message::User {
+            id: message_id.to_owned(),
+            session_id: session_id.to_owned(),
+            timestamp,
+            options,
+        },
+        Some("assistant") => Message::Assistant {
+            id: message_id.to_owned(),
+            session_id: session_id.to_owned(),
+            timestamp,
+            options,
+        },
+        // opencode v2 carries non-conversational message roles (synthetic,
+        // shell, compaction); keep them as System carriers rather than drop
+        // them (spec.md#adapter-integrity-no-silent-drops). The raw record
+        // survives in options; the role label is the content.
+        other => Message::System {
+            id: message_id.to_owned(),
+            session_id: session_id.to_owned(),
+            timestamp,
+            content: other.and_then(|_| extract_str(message_value, "role")),
+            options,
+        },
+    };
+
+    let mut events = vec![IngestEvent::Message(message)];
+    let mut deferred = Vec::new();
+    for (ordinal, part_value) in part_values.iter().enumerate() {
+        let mapped = map_part(session_id, message_id, ordinal, part_value, timestamp);
+        events.push(IngestEvent::Part(mapped.part));
+        if let Some(split) = mapped.tool_split {
+            deferred.push(split);
+        }
+    }
+    for ToolSplit {
+        message: tool_message,
+        result,
+    } in deferred
+    {
+        events.push(IngestEvent::Message(tool_message));
+        events.push(IngestEvent::Part(result));
+    }
+    Ok(events)
+}
+
+/// One mapped source part: the canonical Part it becomes, plus - for a fused
+/// `tool` part - the synthetic `Tool` message and `ToolResult` it splits off.
+struct MappedPart {
+    part: Part,
+    tool_split: Option<ToolSplit>,
+}
+
+struct ToolSplit {
+    message: Message,
+    result: Part,
+}
+
+fn map_part(
+    session_id: &str,
+    message_id: &str,
+    ordinal: usize,
+    value: &Value,
+    message_ts: DateTime<Utc>,
+) -> MappedPart {
+    let kind = value.get("type").and_then(Value::as_str);
+    let id = value
+        .get("id")
+        .and_then(Value::as_str)
+        .map_or_else(|| part_id(message_id, ordinal), ToOwned::to_owned);
+
+    if kind == Some("tool") {
+        return tool_part(session_id, message_id, &id, ordinal, value, message_ts);
+    }
+
+    let (provenance, part_kind) = match kind {
+        Some("text") => (text_provenance(value), text_kind(value)),
+        Some("reasoning") => (Provenance::Conversational, reasoning_kind(value)),
+        Some("file") => (Provenance::Conversational, file_kind(value)),
+        // patch / step-start / step-finish (and any other marker) are
+        // harness-produced turn machinery, not conversation: keep them as
+        // injected Parts whose `raw_record` round-trips the source file.
+        _ => (Provenance::Injected, PartKind::Text { text: None }),
+    };
+
+    MappedPart {
+        part: Part {
+            session_id: session_id.to_owned(),
+            id,
+            message_id: message_id.to_owned(),
+            ordinal: i32::try_from(ordinal).unwrap_or(i32::MAX),
+            provenance,
+            options: opencode_raw(value),
+            kind: part_kind,
+        },
+        tool_split: None,
+    }
+}
+
+/// spec.md#model-part-provenance: opencode marks harness-injected text parts
+/// (the `Called the <tool> tool ...` echo, auto-expanded `@file` content) with
+/// `synthetic: true`; a genuine prompt or model reply is `synthetic: false`.
+fn text_provenance(value: &Value) -> Provenance {
+    if value.get("synthetic").and_then(Value::as_bool) == Some(true) {
+        Provenance::Injected
+    } else {
+        Provenance::Conversational
+    }
+}
+
+fn text_kind(value: &Value) -> PartKind {
+    PartKind::Text {
+        text: extract_str(value, "text"),
+    }
+}
+
+fn reasoning_kind(value: &Value) -> PartKind {
+    PartKind::Reasoning {
+        text: extract_str(value, "text"),
+    }
+}
+
+fn file_kind(value: &Value) -> PartKind {
+    // A generic MIME default is a transport descriptor, not a synthesized field
+    // value (spec.md#model-no-synthesis).
+    let media_type = value
+        .get("mime")
+        .and_then(Value::as_str)
+        .unwrap_or("application/octet-stream")
+        .to_owned();
+    let file_name = value
+        .get("filename")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    let data = match value.get("url").and_then(Value::as_str) {
+        Some(url) => FileData::Url(url.to_owned()),
+        None => FileData::String(compact_json(value)),
+    };
+    PartKind::File {
+        media_type,
+        file_name,
+        data,
+    }
+}
+
+/// Split one opencode `tool` part (call + result fused) into a `ToolCall` on the
+/// owning assistant message and a synthetic `Tool` message carrying the
+/// `ToolResult`. The `ToolCall` keeps the source part's id and stores its full
+/// `raw_record`, so native restore reproduces the single source file; the
+/// synthetic records carry no `raw_record` and are skipped on restore.
+fn tool_part(
+    session_id: &str,
+    message_id: &str,
+    id: &str,
+    ordinal: usize,
+    value: &Value,
+    message_ts: DateTime<Utc>,
+) -> MappedPart {
+    let call_id = extract_str(value, "callID");
+    let name = extract_str(value, "tool");
+    let state = value.get("state");
+    let status = state.and_then(|s| s.get("status")).and_then(Value::as_str);
+    let input = state
+        .and_then(|s| s.get("input"))
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    let tool_call = Part {
+        session_id: session_id.to_owned(),
+        id: id.to_owned(),
+        message_id: message_id.to_owned(),
+        ordinal: i32::try_from(ordinal).unwrap_or(i32::MAX),
+        // spec.md#model-part-provenance: the model authored the tool call.
+        provenance: Provenance::Conversational,
+        options: opencode_raw(value),
+        kind: PartKind::ToolCall {
+            call_id: call_id.clone(),
+            name: name.clone(),
+            params: input,
+            provider_executed: false,
+        },
+    };
+
+    let tool_message_id = format!("{id}/result");
+    let result_ts = millis_at(value, &["state", "time", "end"]).unwrap_or(message_ts);
+    let result = state
+        .and_then(|s| s.get("output").or_else(|| s.get("error")))
+        .cloned()
+        .or_else(|| state.cloned())
+        .unwrap_or(Value::Null);
+
+    let tool_message = Message::Tool {
+        id: tool_message_id.clone(),
+        session_id: session_id.to_owned(),
+        timestamp: result_ts,
+        options: synthetic_options(),
+    };
+    let result_part = Part {
+        session_id: session_id.to_owned(),
+        id: part_id(&tool_message_id, 0),
+        message_id: tool_message_id,
+        ordinal: 0,
+        // spec.md#model-part-provenance: tool output is runtime-produced.
+        provenance: Provenance::Injected,
+        options: synthetic_options(),
+        kind: PartKind::ToolResult {
+            call_id,
+            name,
+            is_failure: status == Some("error"),
+            result,
+        },
+    };
+
+    MappedPart {
+        part: tool_call,
+        tool_split: Some(ToolSplit {
+            message: tool_message,
+            result: result_part,
+        }),
+    }
+}
+
+fn opencode_raw(value: &Value) -> ProviderOptions {
+    let mut options = ProviderOptions::new();
+    options.insert(
+        "opencode".to_owned(),
+        json!({ "raw_record": extract_raw_record(value) }),
+    );
+    options
+}
+
+/// Marks a canonical record the adapter synthesized (the `Tool` message and
+/// `ToolResult` split off a fused `tool` part). Native restore skips records so
+/// marked - they correspond to no source file.
+fn synthetic_options() -> ProviderOptions {
+    let mut options = ProviderOptions::new();
+    options.insert("opencode".to_owned(), json!({ "synthetic": true }));
+    options
+}
+
+fn millis_at(value: &Value, path: &[&str]) -> Option<DateTime<Utc>> {
+    let mut cursor = value;
+    for key in path {
+        cursor = cursor.get(key)?;
+    }
+    DateTime::from_timestamp_millis(cursor.as_i64()?)
+}
+
+/// Recover the stored source record for native restore.
+fn opencode_raw_record(options: &ProviderOptions) -> Option<Value> {
+    options
+        .get("opencode")
+        .and_then(|o| o.get("raw_record"))
+        .cloned()
+}
+
+fn is_synthetic(options: &ProviderOptions) -> bool {
+    options
+        .get("opencode")
+        .and_then(|o| o.get("synthetic"))
+        .and_then(Value::as_bool)
+        == Some(true)
+}
+
+fn serialize_native(
+    session: &crate::sessions::SessionWithMessages,
+) -> Result<Vec<RestoredFile>, AdapterError> {
+    // Native replays each stored `raw_record` at its original split path; the
+    // synthetic `Tool` message and `ToolResult` (which carry no `raw_record`)
+    // are skipped, re-fusing into the single source `tool` part. Replay echoes
+    // a frozen snapshot - safe only while canonical is append-only
+    // (spec.md#adapter-integrity-additive-sync).
+    let session_raw = opencode_raw_record(&session.session.options).ok_or_else(|| {
+        AdapterError::schema(
+            NAME,
+            session.session.id.clone(),
+            "native restore needs the stored session raw_record",
+        )
+    })?;
+    let project_id = session_raw
+        .get("projectID")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            AdapterError::schema(
+                NAME,
+                session.session.id.clone(),
+                "stored session raw_record missing projectID",
+            )
+        })?;
+
+    let mut files = vec![RestoredFile {
+        relative_path: PathBuf::from("session")
+            .join(project_id)
+            .join(format!("{}.json", session.session.id)),
+        bytes: encode(&session_raw, &session.session.id)?,
+    }];
+
+    for message in &session.messages {
+        if !is_synthetic(message.message.options())
+            && let Some(raw) = opencode_raw_record(message.message.options())
+        {
+            files.push(RestoredFile {
+                relative_path: PathBuf::from("message")
+                    .join(&session.session.id)
+                    .join(format!("{}.json", message.message.id())),
+                bytes: encode(&raw, message.message.id())?,
+            });
+        }
+        for part in &message.parts {
+            // A part that carries a `raw_record` maps 1:1 to a source file at
+            // `part/<message_id>/<part_id>.json`; synthetic split parts do not.
+            if let Some(raw) = opencode_raw_record(&part.options) {
+                files.push(RestoredFile {
+                    relative_path: PathBuf::from("part")
+                        .join(&part.message_id)
+                        .join(format!("{}.json", part.id)),
+                    bytes: encode(&raw, &part.id)?,
+                });
+            }
+        }
+    }
+    Ok(files)
+}
+
+fn serialize_foreign(
+    session: &crate::sessions::SessionWithMessages,
+) -> Result<Vec<RestoredFile>, AdapterError> {
+    // Foreign restore: a best-effort, idiomatic opencode tree. A non-opencode
+    // session has no `projectID` hash, so derive a stable directory key from
+    // the project path; tool results (canonical `Tool` messages) and System
+    // carriers have no idiomatic home in opencode's part model and are dropped
+    // (spec.md#adapter-native-restore-lossless, foreign clause).
+    let project_id = encode_project(&session.session.project);
+    let created = session.session.created_at.timestamp_millis();
+    let session_record = json!({
+        "id": session.session.id,
+        "projectID": project_id,
+        "directory": &*session.session.project,
+        "time": { "created": created, "updated": created },
+    });
+    let mut files = vec![RestoredFile {
+        relative_path: PathBuf::from("session")
+            .join(&project_id)
+            .join(format!("{}.json", session.session.id)),
+        bytes: encode(&session_record, &session.session.id)?,
+    }];
+
+    for message in &session.messages {
+        let role = match message.message {
+            Message::User { .. } => "user",
+            Message::Assistant { .. } => "assistant",
+            // No idiomatic opencode home; content stays in canonical.
+            Message::Tool { .. } | Message::System { .. } => continue,
+        };
+        let created = message.message.timestamp().timestamp_millis();
+        let record = json!({
+            "id": message.message.id(),
+            "sessionID": session.session.id,
+            "role": role,
+            "time": { "created": created },
+        });
+        files.push(RestoredFile {
+            relative_path: PathBuf::from("message")
+                .join(&session.session.id)
+                .join(format!("{}.json", message.message.id())),
+            bytes: encode(&record, message.message.id())?,
+        });
+        for part in &message.parts {
+            let Some(record) = foreign_part(&session.session.id, part) else {
+                continue;
+            };
+            files.push(RestoredFile {
+                relative_path: PathBuf::from("part")
+                    .join(message.message.id())
+                    .join(format!("{}.json", part.id)),
+                bytes: encode(&record, &part.id)?,
+            });
+        }
+    }
+    Ok(files)
+}
+
+fn foreign_part(session_id: &str, part: &Part) -> Option<Value> {
+    let mut record = match &part.kind {
+        PartKind::Text { text } => json!({
+            "type": "text",
+            "text": text.as_deref().map(|t| &**t),
+            "synthetic": part.provenance == Provenance::Injected,
+        }),
+        PartKind::Reasoning { text } => json!({
+            "type": "reasoning",
+            "text": text.as_deref().map(|t| &**t),
+        }),
+        PartKind::File {
+            media_type,
+            file_name,
+            data,
+        } => json!({
+            "type": "file",
+            "mime": media_type,
+            "filename": file_name,
+            "url": match data {
+                FileData::Url(url) => Some(url.clone()),
+                _ => None,
+            },
+        }),
+        PartKind::ToolCall {
+            call_id,
+            name,
+            params,
+            ..
+        } => json!({
+            "type": "tool",
+            "callID": call_id.as_deref().map(|c| &**c),
+            "tool": name.as_deref().map(|n| &**n),
+            "state": { "status": "completed", "input": params },
+        }),
+        // ToolResult / approval parts have no standalone opencode shape.
+        _ => return None,
+    };
+    if let Value::Object(map) = &mut record {
+        map.insert("id".to_owned(), json!(part.id));
+        map.insert("sessionID".to_owned(), json!(session_id));
+        map.insert("messageID".to_owned(), json!(part.message_id));
+    }
+    Some(record)
+}
+
+fn encode(value: &Value, location: &str) -> Result<Vec<u8>, AdapterError> {
+    serde_json::to_vec(value).map_err(|error| {
+        AdapterError::schema(
+            NAME,
+            location.to_owned(),
+            format!("json encode failed: {error}"),
+        )
+    })
+}
+
+fn encode_project(project: &str) -> String {
+    project
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect()
+}
+
+/// A message always carries `time.created`, so this is unreachable for real
+/// data; a constant epoch anchor keeps the timestamp total without inventing a
+/// plausible-looking "now" (and without a non-deterministic `Utc::now()`).
+fn anchor_ts() -> DateTime<Utc> {
+    DateTime::from_timestamp_millis(0).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    //! End-to-end test for the opencode adapter: ingest the committed
+    //! split-file fixture corpus and assert pond's canonical shape comes out
+    //! the other side, including the fused-tool-part split. The fixture lives
+    //! under `tests/fixtures/adapter/opencode/storage/`.
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use super::*;
+    use crate::{handlers::ingest_adapter, sessions::Store, wire::PartKind};
+    use tempfile::TempDir;
+
+    const FIXTURES: &str = "tests/fixtures/adapter/opencode/storage";
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn native_restore_is_value_equal_to_fixture_corpus() -> anyhow::Result<()> {
+        let adapter = OpencodeAdapter::new(FIXTURES);
+        crate::adapter::test_support::assert_native_restore(
+            &OpencodeFactory,
+            &adapter,
+            // opencode relative paths are rooted at the `storage/` dir.
+            std::path::Path::new(FIXTURES),
+        )
+        .await
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn opencode_adapter_ingests_fixture_corpus_into_canonical_shape() -> anyhow::Result<()> {
+        let temp = TempDir::new()?;
+        let store = Store::open_local(temp.path()).await?;
+        let adapter = OpencodeAdapter::new(FIXTURES);
+
+        let summary = ingest_adapter(&store, &adapter, &crate::adapter::NoopOracle, |_| {}).await?;
+        assert!(summary.accepted() > 0, "ingest must accept rows");
+        assert_eq!(summary.dropped_events, 0, "no per-event drops expected");
+        assert_eq!(
+            summary.dropped_sessions, 0,
+            "no session-level rejections expected"
+        );
+
+        let (sessions, messages, parts) = store.row_counts().await?;
+        assert!(sessions > 0, "at least one opencode session");
+        assert!(messages > 0, "at least one opencode message");
+        assert!(parts > 0, "at least one opencode Part");
+
+        let mut saw_call = false;
+        let mut saw_result = false;
+        let mut saw_injected_text = false;
+        for session_id in store.session_ids().await? {
+            let session = store
+                .get_session(&session_id)
+                .await?
+                .expect("session round-trips");
+            assert_eq!(session.session.source_agent, NAME);
+            assert!(
+                !(*session.session.project).is_empty(),
+                "spec.md#model-project-non-empty",
+            );
+            for stored in &session.messages {
+                for part in &stored.parts {
+                    match &part.kind {
+                        PartKind::ToolCall { .. } => saw_call = true,
+                        PartKind::ToolResult { .. } => saw_result = true,
+                        PartKind::Text { .. } if part.provenance == Provenance::Injected => {
+                            saw_injected_text = true;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        assert!(saw_call, "fused tool parts yield ToolCall on the assistant");
+        assert!(
+            saw_result,
+            "fused tool parts split off a ToolResult on a Tool message",
+        );
+        assert!(
+            saw_injected_text,
+            "spec.md#model-part-provenance: synthetic text parts are injected",
+        );
+        Ok(())
+    }
+
+    /// The synthetic `Tool` message a `tool` part splits off must carry a
+    /// `Tool` role with one `ToolResult`, and must NOT collide with or
+    /// overwrite the assistant message that owns the `ToolCall`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn fused_tool_part_splits_into_call_and_result() -> anyhow::Result<()> {
+        let temp = TempDir::new()?;
+        let store = Store::open_local(temp.path()).await?;
+        let adapter = OpencodeAdapter::new(FIXTURES);
+        ingest_adapter(&store, &adapter, &crate::adapter::NoopOracle, |_| {}).await?;
+
+        let mut call_ids = std::collections::HashSet::new();
+        let mut result_ids = std::collections::HashSet::new();
+        for session_id in store.session_ids().await? {
+            let session = store
+                .get_session(&session_id)
+                .await?
+                .expect("session round-trips");
+            for stored in &session.messages {
+                for part in &stored.parts {
+                    match &part.kind {
+                        PartKind::ToolCall { call_id, .. } => {
+                            if let Some(id) = call_id.as_deref() {
+                                call_ids.insert(id.clone());
+                            }
+                        }
+                        PartKind::ToolResult { call_id, .. } => {
+                            assert!(
+                                matches!(stored.message, Message::Tool { .. }),
+                                "a ToolResult must live on a Tool-role message",
+                            );
+                            if let Some(id) = call_id.as_deref() {
+                                result_ids.insert(id.clone());
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        assert!(!call_ids.is_empty(), "corpus has tool calls");
+        assert_eq!(
+            call_ids, result_ids,
+            "every tool call's id is matched by its split-off result",
+        );
+        Ok(())
+    }
+}

--- a/src/adapter/pi.rs
+++ b/src/adapter/pi.rs
@@ -1,0 +1,758 @@
+//! pi coding-agent adapter (github.com/badlogic/pi-mono).
+//!
+//! Source path: `~/.pi/agent/sessions/<project-slug>/<ISO-ts>_<uuid>.jsonl`.
+//! One `.jsonl` file per session; each line is a typed record linked via a
+//! `parentId` -> `id` chain (pi-mono's leaf-cursor DAG). Top-level types:
+//! `session` (consumed up front for Session), `model_change` /
+//! `thinking_level_change` / `compaction` (session-state carriers kept as
+//! System messages), and `message` (the per-turn model interaction, with
+//! roles user / assistant / toolResult and content nested under `.message`).
+//!
+//! v1 stores the linear log ordered by source line; pi's `parentId` fork
+//! graph (spec.md#deferred: multi-level fork lineage) is not collapsed into
+//! `parent_message_id` but preserved verbatim in `options.source.raw_record`
+//! for a future branching consumer.
+
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde_json::{Value, json};
+
+use crate::{
+    sessions::IngestEvent,
+    wire::{Message, Part, PartKind, Provenance, ProviderOptions, Session},
+};
+
+use super::{
+    Adapter, AdapterError, AdapterFactory, AdapterYieldStream, DiscoverFuture, Env,
+    RestoreFidelity, RestoredFile, SkipOracle, by_timestamp_then_id, compact_json, config_path,
+    empty_options,
+    extract::{Extracted, extract_compact_repr, extract_raw_record, extract_str},
+    extracted_text,
+    jsonl::{BoundedRow, JsonlTree, jsonl_tree_discover, jsonl_tree_events},
+    jsonl_bytes, part_id, raw_record,
+};
+
+const NAME: &str = "pi";
+
+/// Stateless factory: opens [`PiAdapter`] instances and probes for the
+/// canonical install location under `~/.pi/agent/sessions`.
+pub struct PiFactory;
+
+impl AdapterFactory for PiFactory {
+    fn name(&self) -> &'static str {
+        NAME
+    }
+
+    fn open(&self, config: Value) -> Result<Box<dyn Adapter>, AdapterError> {
+        Ok(Box::new(PiAdapter::new(config_path(NAME, config)?)))
+    }
+
+    fn probe_default(&self, env: &Env) -> Option<Value> {
+        let path = env.home.join(".pi").join("agent").join("sessions");
+        path.exists().then(|| json!({ "path": path }))
+    }
+
+    fn serialize(
+        &self,
+        session: &crate::sessions::SessionWithMessages,
+        fidelity: RestoreFidelity,
+    ) -> Result<Vec<RestoredFile>, AdapterError> {
+        serialize_session(session, fidelity)
+    }
+}
+
+fn serialize_session(
+    session: &crate::sessions::SessionWithMessages,
+    fidelity: RestoreFidelity,
+) -> Result<Vec<RestoredFile>, AdapterError> {
+    // Native replays the verbatim `options.source.raw_record` rows (the
+    // `session` line first, then one per message in source order); `pi_record`
+    // below is the foreign-only reconstruction. Replay echoes a frozen
+    // snapshot - safe only while canonical is append-only
+    // (spec.md#adapter-integrity-additive-sync).
+    let mut records = Vec::new();
+    if fidelity == RestoreFidelity::Native
+        && let Some(raw) = raw_record(&session.session.options)
+    {
+        records.push(raw);
+    } else {
+        records.push(pi_session_record(session));
+    }
+
+    let mut messages = session.messages.clone();
+    if fidelity == RestoreFidelity::Native {
+        messages.sort_by(|left, right| {
+            source_line(left.message.options())
+                .cmp(&source_line(right.message.options()))
+                .then_with(|| by_timestamp_then_id(left, right))
+        });
+    } else {
+        messages.sort_by(by_timestamp_then_id);
+    }
+
+    for message in &messages {
+        if fidelity == RestoreFidelity::Native
+            && let Some(raw) = raw_record(message.message.options())
+        {
+            records.push(raw);
+            continue;
+        }
+        // Foreign restore: a System carrier (model/thinking/compaction record)
+        // has no idiomatic home in another client's transcript - drop it; the
+        // content stays in canonical (spec.md#adapter-native-restore-lossless,
+        // foreign clause).
+        if matches!(message.message, Message::System { .. }) {
+            continue;
+        }
+        records.push(pi_message_record(session, message));
+    }
+
+    Ok(vec![RestoredFile {
+        relative_path: pi_relative_path(session),
+        bytes: jsonl_bytes(NAME, &records)?,
+    }])
+}
+
+/// Reproduce the on-disk `sessions/<slug>/<file>.jsonl` path from the slug and
+/// file name captured at ingest. Falls back to a derived name when a foreign
+/// session never carried them.
+fn pi_relative_path(session: &crate::sessions::SessionWithMessages) -> PathBuf {
+    let source = session.session.options.get("source");
+    let slug = source
+        .and_then(|s| s.get("project_slug"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| encode_project(&session.session.project));
+    let file_name = source
+        .and_then(|s| s.get("file_name"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| {
+            let ts = session.session.created_at.format("%Y-%m-%dT%H-%M-%S-%3fZ");
+            format!("{ts}_{}.jsonl", session.session.id)
+        });
+    PathBuf::from("sessions").join(slug).join(file_name)
+}
+
+fn encode_project(project: &str) -> String {
+    project.replace(['/', '.'], "-")
+}
+
+fn source_line(options: &ProviderOptions) -> Option<u64> {
+    options
+        .get("source")
+        .and_then(|source| source.get("line"))
+        .and_then(Value::as_u64)
+}
+
+fn pi_session_record(session: &crate::sessions::SessionWithMessages) -> Value {
+    json!({
+        "type": "session",
+        "version": 3,
+        "id": session.session.id,
+        "timestamp": session.session.created_at.to_rfc3339_opts(SecondsFormat::Millis, true),
+        "cwd": &*session.session.project,
+    })
+}
+
+fn pi_message_record(
+    session: &crate::sessions::SessionWithMessages,
+    message: &crate::sessions::MessageWithParts,
+) -> Value {
+    json!({
+        "type": "message",
+        "id": message.message.id(),
+        "parentId": message.message.options().get("source").and_then(|s| s.get("parent_id")),
+        "timestamp": message.message.timestamp().to_rfc3339_opts(SecondsFormat::Millis, true),
+        "message": pi_inner_message(session, message),
+    })
+}
+
+fn pi_inner_message(
+    _session: &crate::sessions::SessionWithMessages,
+    message: &crate::sessions::MessageWithParts,
+) -> Value {
+    let epoch_ms = message.message.timestamp().timestamp_millis();
+    match &message.message {
+        Message::User { .. } => json!({
+            "role": "user",
+            "content": message.parts.iter().map(pi_content_item).collect::<Vec<_>>(),
+            "timestamp": epoch_ms,
+        }),
+        Message::Assistant { .. } => json!({
+            "role": "assistant",
+            "content": message.parts.iter().map(pi_content_item).collect::<Vec<_>>(),
+            "timestamp": epoch_ms,
+        }),
+        Message::Tool { .. } => {
+            let part = message.parts.first();
+            let (call_id, name, is_error, result) = match part.map(|p| &p.kind) {
+                Some(PartKind::ToolResult {
+                    call_id,
+                    name,
+                    is_failure,
+                    result,
+                }) => (
+                    extracted_text(call_id).to_owned(),
+                    extracted_text(name).to_owned(),
+                    *is_failure,
+                    result.clone(),
+                ),
+                _ => (String::new(), String::new(), false, Value::Null),
+            };
+            json!({
+                "role": "toolResult",
+                "toolCallId": call_id,
+                "toolName": name,
+                "content": result,
+                "isError": is_error,
+                "timestamp": epoch_ms,
+            })
+        }
+        // System carriers are dropped before reaching here (foreign clause).
+        Message::System { .. } => Value::Null,
+    }
+}
+
+fn pi_content_item(part: &Part) -> Value {
+    match &part.kind {
+        PartKind::Text { text } => json!({"type": "text", "text": extracted_text(text)}),
+        PartKind::Reasoning { text } => json!({
+            "type": "thinking",
+            "thinking": extracted_text(text),
+            "thinkingSignature": part
+                .options
+                .get("pi")
+                .and_then(|p| p.get("thinking_signature")),
+        }),
+        PartKind::ToolCall {
+            call_id,
+            name,
+            params,
+            ..
+        } => json!({
+            "type": "toolCall",
+            "id": extracted_text(call_id),
+            "name": extracted_text(name),
+            "arguments": params,
+        }),
+        other => json!({
+            "type": "text",
+            "text": compact_json(&serde_json::to_value(other).unwrap_or(Value::Null)),
+        }),
+    }
+}
+
+/// Configured pi reader. Walks a tree of `*.jsonl` files under [`Self::root`]
+/// and yields canonical events in source order per session.
+#[derive(Debug, Clone)]
+pub struct PiAdapter {
+    root: PathBuf,
+}
+
+impl PiAdapter {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+}
+
+impl Adapter for PiAdapter {
+    fn discover(&self) -> DiscoverFuture<'_> {
+        jsonl_tree_discover(self)
+    }
+
+    fn events_with<'a>(&'a self, oracle: &'a dyn SkipOracle) -> AdapterYieldStream<'a> {
+        jsonl_tree_events(self, oracle)
+    }
+}
+
+impl JsonlTree for PiAdapter {
+    // pi's `toolResult` records carry their own `toolName`, so unlike
+    // claude-code / codex-cli the adapter needs no per-file call_id -> name map.
+    type State = ();
+
+    fn name(&self) -> &'static str {
+        NAME
+    }
+
+    fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn peek_session_id(&self, _path: &Path, first_line: &str) -> Option<String> {
+        let row: Value = serde_json::from_str(first_line).ok()?;
+        if row.get("type").and_then(Value::as_str) == Some("session") {
+            row.get("id").and_then(Value::as_str).map(ToOwned::to_owned)
+        } else {
+            None
+        }
+    }
+
+    fn session(&self, path: &Path, rows: &[BoundedRow]) -> Result<Session, AdapterError> {
+        session_from_rows(path, rows)
+    }
+
+    fn events_from_row(
+        &self,
+        session: &Session,
+        row: &BoundedRow,
+        _state: &mut Self::State,
+    ) -> Result<Vec<IngestEvent>, String> {
+        events_from_row(&session.id, row.line, &row.value, session.created_at)
+    }
+}
+
+fn session_from_rows(path: &Path, rows: &[BoundedRow]) -> Result<Session, AdapterError> {
+    let path_display = path.display().to_string();
+    let first = rows
+        .first()
+        .ok_or_else(|| AdapterError::schema(NAME, path_display.clone(), "empty jsonl session"))?;
+    let row = &first.value;
+    let at_first = format!("{path_display}:{}", first.line);
+    if row.get("type").and_then(Value::as_str) != Some("session") {
+        return Err(AdapterError::schema(
+            NAME,
+            at_first,
+            "first row must be a `session` record",
+        ));
+    }
+    let id = row
+        .get("id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| AdapterError::schema(NAME, at_first.clone(), "session record missing id"))?
+        .to_owned();
+    let created_at = row
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .and_then(|text| DateTime::parse_from_rfc3339(text).ok())
+        .map(|dt| dt.with_timezone(&Utc))
+        .ok_or_else(|| {
+            AdapterError::schema(
+                NAME,
+                at_first.clone(),
+                "session record has no parseable timestamp",
+            )
+        })?;
+    let project = extract_str(row, "cwd").ok_or_else(|| {
+        // spec.md#model-project-non-empty: pi always records `cwd` on the
+        // session line; its absence is a malformed session, not a default.
+        AdapterError::schema(NAME, at_first, "session record missing cwd")
+    })?;
+
+    // Capture the exact on-disk path components so native restore reproduces
+    // the source file byte-for-byte (the slug encoding and filename timestamp
+    // are not recomputable from canonical alone).
+    let project_slug = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .map(ToOwned::to_owned);
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(ToOwned::to_owned);
+
+    let mut options = ProviderOptions::new();
+    options.insert(
+        "source".to_owned(),
+        json!({
+            "adapter": NAME,
+            "version": row.get("version"),
+            "project_slug": project_slug,
+            "file_name": file_name,
+            "raw_record": extract_raw_record(row),
+        }),
+    );
+
+    Ok(Session {
+        id,
+        parent_session_id: None,
+        parent_message_id: None,
+        source_agent: NAME.to_owned(),
+        created_at,
+        project,
+        options,
+    })
+}
+
+/// Map one pi JSONL record into zero-or-more `IngestEvent`s. `session` is
+/// consumed up front (eventless here); `model_change` / `thinking_level_change`
+/// / `compaction` become System carriers; `message` becomes a User / Assistant
+/// / Tool message plus its content Parts.
+fn events_from_row(
+    session_id: &str,
+    line: usize,
+    row: &Value,
+    default_timestamp: DateTime<Utc>,
+) -> Result<Vec<IngestEvent>, String> {
+    let kind = row.get("type").and_then(Value::as_str);
+    let timestamp = row
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .and_then(|text| DateTime::parse_from_rfc3339(text).ok())
+        .map(|dt| dt.with_timezone(&Utc))
+        .unwrap_or(default_timestamp);
+    let id = row
+        .get("id")
+        .and_then(Value::as_str)
+        .map_or_else(|| format!("{session_id}:{line}"), ToOwned::to_owned);
+
+    match kind {
+        // Consumed up front by `session_from_rows`.
+        Some("session") => Ok(Vec::new()),
+        Some("message") => {
+            let message_value = row
+                .get("message")
+                .ok_or_else(|| "message record missing `message` field".to_owned())?;
+            message_events(session_id, &id, timestamp, row, message_value, line)
+        }
+        // Session-state carriers: keep the human-meaningful field as content,
+        // the rest of the record in `options.source.raw_record`.
+        Some("compaction") => Ok(vec![carrier_event(
+            session_id,
+            &id,
+            timestamp,
+            row,
+            line,
+            extract_str(row, "summary"),
+        )]),
+        Some("model_change") | Some("thinking_level_change") => Ok(vec![carrier_event(
+            session_id,
+            &id,
+            timestamp,
+            row,
+            line,
+            extract_str(row, "type"),
+        )]),
+        // Unknown record type: preserve it as a System carrier rather than
+        // dropping (spec.md#adapter-integrity-no-silent-drops). The raw record
+        // survives in options; the type label is the content.
+        _ => Ok(vec![carrier_event(
+            session_id,
+            &id,
+            timestamp,
+            row,
+            line,
+            extract_str(row, "type"),
+        )]),
+    }
+}
+
+fn carrier_event(
+    session_id: &str,
+    id: &str,
+    timestamp: DateTime<Utc>,
+    row: &Value,
+    line: usize,
+    content: Option<Extracted<String>>,
+) -> IngestEvent {
+    IngestEvent::Message(Message::System {
+        id: id.to_owned(),
+        session_id: session_id.to_owned(),
+        timestamp,
+        content,
+        options: row_options(row, line),
+    })
+}
+
+fn message_events(
+    session_id: &str,
+    id: &str,
+    timestamp: DateTime<Utc>,
+    row: &Value,
+    message_value: &Value,
+    line: usize,
+) -> Result<Vec<IngestEvent>, String> {
+    let role = message_value
+        .get("role")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "message missing role".to_owned())?;
+    let content = message_value
+        .get("content")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    let mut parts = Vec::new();
+    let message = match role {
+        "user" => {
+            // spec.md#model-part-provenance: pi user messages are genuine human
+            // prompts; harness-injected context arrives as separate records
+            // (compaction, model_change), not inside a user turn.
+            for (ordinal, item) in content.iter().enumerate() {
+                parts.push(user_part(session_id, id, ordinal, item));
+            }
+            Message::User {
+                id: id.to_owned(),
+                session_id: session_id.to_owned(),
+                timestamp,
+                options: row_options(row, line),
+            }
+        }
+        "assistant" => {
+            for (ordinal, item) in content.iter().enumerate() {
+                parts.push(assistant_part(session_id, id, ordinal, item));
+            }
+            Message::Assistant {
+                id: id.to_owned(),
+                session_id: session_id.to_owned(),
+                timestamp,
+                options: assistant_options(row, message_value, line),
+            }
+        }
+        "toolResult" => {
+            parts.push(tool_result_part(session_id, id, message_value));
+            Message::Tool {
+                id: id.to_owned(),
+                session_id: session_id.to_owned(),
+                timestamp,
+                options: row_options(row, line),
+            }
+        }
+        other => return Err(format!("unsupported pi message role {other}")),
+    };
+
+    let mut events = Vec::with_capacity(parts.len() + 1);
+    events.push(IngestEvent::Message(message));
+    events.extend(parts.into_iter().map(IngestEvent::Part));
+    Ok(events)
+}
+
+fn user_part(session_id: &str, message_id: &str, ordinal: usize, item: &Value) -> Part {
+    let kind = match item.get("type").and_then(Value::as_str) {
+        Some("text") => PartKind::Text {
+            text: extract_str(item, "text"),
+        },
+        // Anything else (e.g. an `image` content item) is preserved losslessly
+        // as a compact-JSON Text Part rather than dropped.
+        _ => PartKind::Text {
+            text: Some(extract_compact_repr(item)),
+        },
+    };
+    Part {
+        session_id: session_id.to_owned(),
+        id: part_id(message_id, ordinal),
+        message_id: message_id.to_owned(),
+        ordinal: i32::try_from(ordinal).unwrap_or(i32::MAX),
+        // spec.md#model-part-provenance: a genuine human prompt is conversation.
+        provenance: Provenance::Conversational,
+        options: empty_options(),
+        kind,
+    }
+}
+
+fn assistant_part(session_id: &str, message_id: &str, ordinal: usize, item: &Value) -> Part {
+    // spec.md#model-part-provenance: assistant text, reasoning, and tool calls
+    // are model-authored, hence conversational.
+    let (kind, options) = match item.get("type").and_then(Value::as_str) {
+        Some("text") => (
+            PartKind::Text {
+                text: extract_str(item, "text"),
+            },
+            empty_options(),
+        ),
+        Some("thinking") => (
+            PartKind::Reasoning {
+                text: extract_str(item, "thinking"),
+            },
+            thinking_options(item),
+        ),
+        Some("toolCall") => (
+            PartKind::ToolCall {
+                call_id: extract_str(item, "id"),
+                name: extract_str(item, "name"),
+                params: item.get("arguments").cloned().unwrap_or(Value::Null),
+                provider_executed: false,
+            },
+            empty_options(),
+        ),
+        // Lossless fallback for an unrecognised assistant content shape.
+        _ => (
+            PartKind::Text {
+                text: Some(extract_compact_repr(item)),
+            },
+            empty_options(),
+        ),
+    };
+    Part {
+        session_id: session_id.to_owned(),
+        id: part_id(message_id, ordinal),
+        message_id: message_id.to_owned(),
+        ordinal: i32::try_from(ordinal).unwrap_or(i32::MAX),
+        provenance: Provenance::Conversational,
+        options,
+        kind,
+    }
+}
+
+fn tool_result_part(session_id: &str, message_id: &str, message_value: &Value) -> Part {
+    Part {
+        session_id: session_id.to_owned(),
+        id: part_id(message_id, 0),
+        message_id: message_id.to_owned(),
+        ordinal: 0,
+        // spec.md#model-part-provenance: tool output is runtime-produced.
+        provenance: Provenance::Injected,
+        options: empty_options(),
+        kind: PartKind::ToolResult {
+            call_id: extract_str(message_value, "toolCallId"),
+            name: extract_str(message_value, "toolName"),
+            is_failure: message_value
+                .get("isError")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            // The whole `content` array (text and/or image items) is the
+            // faithful result payload.
+            result: message_value.get("content").cloned().unwrap_or(Value::Null),
+        },
+    }
+}
+
+fn row_options(row: &Value, line: usize) -> ProviderOptions {
+    let mut options = ProviderOptions::new();
+    options.insert(
+        "source".to_owned(),
+        json!({
+            "line": line,
+            "parent_id": row.get("parentId"),
+            "raw_type": row.get("type"),
+            "raw_record": extract_raw_record(row),
+        }),
+    );
+    options
+}
+
+fn assistant_options(row: &Value, message_value: &Value, line: usize) -> ProviderOptions {
+    let mut options = row_options(row, line);
+    options.insert(
+        "pi".to_owned(),
+        json!({
+            "api": message_value.get("api"),
+            "provider": message_value.get("provider"),
+            "model": message_value.get("model"),
+            "usage": message_value.get("usage"),
+            "stop_reason": message_value.get("stopReason"),
+            "response_id": message_value.get("responseId"),
+        }),
+    );
+    options
+}
+
+fn thinking_options(item: &Value) -> ProviderOptions {
+    let mut options = ProviderOptions::new();
+    if let Some(signature) = item.get("thinkingSignature") {
+        options.insert("pi".to_owned(), json!({ "thinking_signature": signature }));
+    }
+    options
+}
+
+#[cfg(test)]
+mod tests {
+    //! End-to-end test for the pi adapter: ingest the committed fixture corpus
+    //! and assert pond's canonical Session/Message/Part shape comes out the
+    //! other side. The fixture lives under `tests/fixtures/adapter/pi/`.
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use super::*;
+    use crate::{handlers::ingest_adapter, sessions::Store, wire::PartKind};
+    use tempfile::TempDir;
+
+    const FIXTURES: &str = "tests/fixtures/adapter/pi/sessions";
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn native_restore_is_value_equal_to_fixture_corpus() -> anyhow::Result<()> {
+        let adapter = PiAdapter::new(FIXTURES);
+        crate::adapter::test_support::assert_native_restore(
+            &PiFactory,
+            &adapter,
+            // pi relative paths embed the `sessions/` segment, so the corpus
+            // root is FIXTURES' parent, not FIXTURES itself.
+            std::path::Path::new(FIXTURES)
+                .parent()
+                .expect("FIXTURES is nested under a corpus root"),
+        )
+        .await
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn pi_adapter_ingests_fixture_corpus_into_canonical_shape() -> anyhow::Result<()> {
+        let temp = TempDir::new()?;
+        let store = Store::open_local(temp.path()).await?;
+        let adapter = PiAdapter::new(FIXTURES);
+
+        let summary = ingest_adapter(&store, &adapter, &crate::adapter::NoopOracle, |_| {}).await?;
+        assert!(summary.accepted() > 0, "ingest must accept rows");
+        assert_eq!(summary.dropped_events, 0, "no per-event drops expected");
+        assert_eq!(
+            summary.dropped_sessions, 0,
+            "no session-level rejections expected"
+        );
+        assert_eq!(summary.skipped_files, 0, "no whole-file skips expected");
+
+        let (sessions, messages, parts) = store.row_counts().await?;
+        assert!(sessions > 0, "at least one pi session");
+        assert!(messages > 0, "at least one pi message");
+        assert!(parts > 0, "at least one pi Part");
+
+        let mut saw_tool_call = false;
+        let mut saw_tool_result = false;
+        let mut saw_reasoning = false;
+        for session_id in store.session_ids().await? {
+            let session = store
+                .get_session(&session_id)
+                .await?
+                .expect("session round-trips");
+            assert_eq!(session.session.source_agent, NAME);
+            assert!(
+                !(*session.session.project).is_empty(),
+                "spec.md#model-project-non-empty: project must be a real cwd",
+            );
+            for stored in &session.messages {
+                for part in &stored.parts {
+                    match &part.kind {
+                        PartKind::ToolCall { .. } => saw_tool_call = true,
+                        PartKind::ToolResult { .. } => saw_tool_result = true,
+                        PartKind::Reasoning { .. } => saw_reasoning = true,
+                        _ => {}
+                    }
+                }
+            }
+        }
+        assert!(saw_tool_call, "corpus has assistant tool calls");
+        assert!(saw_tool_result, "corpus has tool results");
+        assert!(saw_reasoning, "corpus has assistant reasoning");
+        Ok(())
+    }
+
+    /// spec.md#model-part-provenance: a tool result is harness-injected; an
+    /// assistant turn's text/reasoning/tool-call parts are conversation.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tool_results_are_injected_assistant_parts_are_conversational() -> anyhow::Result<()> {
+        let temp = TempDir::new()?;
+        let store = Store::open_local(temp.path()).await?;
+        let adapter = PiAdapter::new(FIXTURES);
+        ingest_adapter(&store, &adapter, &crate::adapter::NoopOracle, |_| {}).await?;
+
+        for session_id in store.session_ids().await? {
+            let session = store
+                .get_session(&session_id)
+                .await?
+                .expect("session round-trips");
+            for stored in &session.messages {
+                for part in &stored.parts {
+                    match &part.kind {
+                        PartKind::ToolResult { .. } => {
+                            assert_eq!(part.provenance, Provenance::Injected);
+                        }
+                        PartKind::ToolCall { .. } | PartKind::Reasoning { .. } => {
+                            assert_eq!(part.provenance, Provenance::Conversational);
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## What

Adds two new source adapters, registered in the adapter registry (one file + one registry line each, per `spec.md#adapters` 6.7):

- **`pi`** (github.com/badlogic/pi-mono) - a JSONL-tree source, one `.jsonl` per session, built on the shared `JsonlTree` spine like `codex-cli`/`claude-code`.
- **`opencode`** (github.com/sst/opencode) - the **first non-JSONL adapter**: a content-addressed `session/`/`message/`/`part/` split-file tree that drives the `Adapter` seam directly.

Fixtures and upstream reference snapshots for both already existed under `tests/fixtures/adapter/{pi,opencode}/` and `docs/references/{pi-mono,opencode}/`; this PR is the implementation against them.

## Formats

| | pi | opencode |
|---|---|---|
| Layout | `sessions/<slug>/<ts>_<uuid>.jsonl`, one file/session | `session/<projectID>/<id>.json`, `message/<sessionID>/<id>.json`, `part/<messageID>/<id>.json` |
| Record/part types | `session`, `model_change`, `thinking_level_change`, `compaction`, `message` (roles user/assistant/toolResult) | parts: `text`, `reasoning`, `file`, `tool`, `patch`, `step-start`, `step-finish` |
| `project` from | session `cwd` | session `directory` |
| `source_agent` | `pi` | `opencode` |

## Notable design decisions

- **opencode fused tool parts.** opencode stores a tool call and its result fused in one `tool` part on the assistant message. Canonical keeps them apart (a `tool_result` on an assistant message is a category error, `spec.md#model-part-provenance`), so the adapter splits each `tool` part into a `ToolCall` on the assistant message **plus a synthetic `Tool` message carrying the `ToolResult`** - so foreign restore to another client keeps the tool output. Native restore replays each real part's stored `raw_record` at its original split path and **skips the synthetic records**, re-fusing back into the one source file. Value-complete-lossless.
- **Provenance.** opencode tags harness-injected text parts (`Called the <tool> tool ...` echoes, auto-expanded `@file` content) with `synthetic: true`; the adapter maps that straight to `injected` vs `conversational`. Tool output, patch, and step markers are `injected`; model-authored text/reasoning/tool-calls and user attachments are `conversational`.
- **pi forks.** Real pi data has `parentId` forks (one parent, two children). v1 defers per-message branching (`parent_message_id`), so the adapter linearizes by `(timestamp, id)` and **preserves `parentId` verbatim in `options`** for a future branching consumer - no data dropped.
- **Bounded values.** The opencode split-file reader applies `bound_value` itself (the JSONL helper does this for the others), so `spec.md#adapter-bounded-values` holds for the non-JSONL path too.

## Testing

All gates green: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (75 lib + 29 integration).

- **Native round-trip** value-equal to the committed fixture corpora for both adapters (the enforced `adapter-native-restore-lossless` test).
- **opencode tool-split** correctness: every `ToolCall` id is matched by its split-off `ToolResult` on a `Tool`-role message.
- **Real local corpus** ingest into a throwaway store (the shapes the sanitized fixtures lack - pi's `compaction`, base64 `image` tool-results, real forks; opencode's `error` tool-states):

```
opencode  ~/.local/share/opencode/storage   1,252 rows · 0 dropped · 0 empty
pi        ~/.pi/agent/sessions               4,056 rows · 0 dropped · 0 empty
combined  45 sessions · 1,865 messages · 3,398 parts · 0 dropped
```

The `541/1,865` embedding backlog on the combined store confirms provenance is wired correctly - only conversational text is embed-eligible; injected scaffolding is excluded.

## Scope notes

- **Foreign restore** (restoring a non-opencode/pi session *as* opencode/pi) is implemented as best-effort per `spec.md#adapter-native-restore-lossless`, but is not golden-file tested - consistent with current practice (no foreign golden files exist in the repo).
- `spec.md` 6.9 (v1 adapters) updated to list all four and note opencode as the first non-JSONL source.
