### PR TITLE
feat(cli): redesign sync/status output and gate sources behind enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +949,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if 1.0.4",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,6 +1418,16 @@ checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap-verbosity-flag"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d92b1fab272fe943881b77cc6e920d6543e5b1bfadbd5ed81c7c5a755742394"
+dependencies = [
+ "clap",
+ "tracing-core",
 ]
 
 [[package]]
@@ -3610,6 +3644,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "git-version"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3899,6 +3939,20 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "human-panic"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2815d0c49773c6e0a9753960b3d0e50b822e48e08c77bcb4780be8474c9cc3d"
+dependencies = [
+ "backtrace",
+ "serde",
+ "serde_derive",
+ "sysinfo",
+ "toml",
+ "uuid",
+]
 
 [[package]]
 name = "humantime"
@@ -5647,6 +5701,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "object_store"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6256,11 +6319,13 @@ dependencies = [
  "candle-transformers",
  "chrono",
  "clap",
+ "clap-verbosity-flag",
  "comfy-table",
  "dialoguer",
  "fastrand",
  "half",
  "hf-hub",
+ "human-panic",
  "hyper-util",
  "indicatif",
  "insta",
@@ -7185,6 +7250,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,8 +64,10 @@ axum = "0.8.9"
 base64 = "0.22"
 chrono = { version = "0.4.44", features = ["serde"] }
 clap = { version = "4.6", features = ["derive", "env"] }
+clap-verbosity-flag = { version = "3", default-features = false, features = ["tracing"] }
 comfy-table = "7"
 dialoguer = { version = "0.12", default-features = false }
+human-panic = { version = "2", default-features = false }
 # Embedding stack for `intfloat/multilingual-e5-small`: candle XLM-RoBERTa
 # FP16 on Metal (macOS) / CUDA (`--features cuda`) / CPU. `LazyEmbedder`
 # (`src/embed.rs`) idle-evicts the loaded backend after

--- a/README.md
+++ b/README.md
@@ -106,9 +106,28 @@ pond sync --only import
 pond sync --only embed
 pond sync --only update-indexes
 pond sync --import-from snapshot.pond
+pond sync -y                       # auto-accept probe prompts (non-TTY runs)
 ```
 
-`pond status` reports row counts, storage size, embedding coverage, and index health. It prints quick storage information first, then finishes the longer checks in front of the user. `pond search --explain` returns Lance's `analyze_plan` output for each retrieval arm.
+`pond status` prints a per-table storage table, then `indexes` (text/semantic readiness), `stored` (sessions + searchable messages), and `sources` (configured adapter count). Pass `--adapters` for per-project tables and per-intent index detail. `pond search --explain` returns Lance's `analyze_plan` output for each retrieval arm.
+
+### Configuration
+
+`pond` discovers sources interactively on first run and writes them to `config.toml` (under `$XDG_CONFIG_HOME/pond/`). Every `[sources.<name>]` block needs `enabled = true` to be active; sections without it (or with `enabled = false`) are skipped. Re-enable interactively with `pond sync <name>`.
+
+```toml
+[sources.claude-code]
+enabled = true
+path = "~/.claude/projects"
+
+[sources.codex-cli]
+enabled = false                    # kept in config, skipped on `pond sync`
+path = "~/.codex/sessions"
+```
+
+### Verbosity
+
+Root-level `-v` / `-vv` / `-vvv` raise the tracing level (info / debug / trace); `-q` / `-qq` lower it. The default surfaces warnings only. `RUST_LOG` overrides the CLI flag when set; `POND_LOG` is no longer honored.
 
 ## Design
 

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -24,11 +24,14 @@ On macOS the Metal backend is selected automatically; on other systems the CPU f
 
 ## Quickstart
 
-1. Ingest your local sessions:
+1. Ingest your local sessions. First run prompts you to enable each detected adapter; pass `-y` for non-interactive runs:
 
    ```sh
-   pond sync
+   pond sync         # interactive prompts on a TTY
+   pond sync -y      # auto-accept every probe (cron, CI, headless agents)
    ```
+
+   Each adapter you accept lands as `[sources.<name>] enabled = true` in `config.toml` (under `$XDG_CONFIG_HOME/pond/`). Sections without `enabled = true` are skipped; re-enable interactively with `pond sync <name>`.
 
 2. Add pond as an MCP server in your agent client:
 
@@ -45,3 +48,7 @@ On macOS the Metal backend is selected automatically; on other systems the CPU f
    - "find the exact command from when we set up that config"
 
 pond runs hybrid search across every session from every client - including sessions made in a different tool than the one you're asking in. Re-run `pond sync` to pick up new sessions.
+
+### Troubleshooting
+
+For more detail on any command, raise the tracing level: `pond -v sync` (info), `pond -vv sync` (debug), `pond -vvv sync` (trace). `RUST_LOG` overrides the flag when set.

--- a/src/adapter/discovery.rs
+++ b/src/adapter/discovery.rs
@@ -6,7 +6,7 @@
 use std::path::Path;
 
 use anyhow::{Context, bail};
-use dialoguer::{MultiSelect, theme::ColorfulTheme};
+use dialoguer::{Confirm, MultiSelect, theme::ColorfulTheme};
 use serde_json::Value;
 use toml_edit::{DocumentMut, Item, Table};
 
@@ -20,6 +20,29 @@ pub struct Candidate {
     pub name: String,
     pub hint: String,
     pub config: Value,
+}
+
+/// Probe every registered factory whose name is NOT already a key in
+/// `configured`. Used by `pond sync` to spot freshly-detectable adapters
+/// without re-prompting the operator about ones they already opted in or
+/// out of. Returns `Candidate`s in registry order.
+pub fn probe_unconfigured(
+    configured: &std::collections::BTreeMap<String, Value>,
+) -> Vec<Candidate> {
+    let Some(env) = Env::from_env() else {
+        return Vec::new();
+    };
+    super::registry()
+        .iter()
+        .filter(|factory| !configured.contains_key(factory.name()))
+        .filter_map(|factory| {
+            factory.probe_default(&env).map(|config| Candidate {
+                name: factory.name().to_owned(),
+                hint: hint_for(&config),
+                config,
+            })
+        })
+        .collect()
 }
 
 /// Probe every registered factory (or just the one named in `focus`) under
@@ -109,14 +132,106 @@ pub fn prompt_and_persist(
         .into_iter()
         .filter_map(|index| candidates.get(index).cloned())
         .collect();
-    persist(config_path, &picks)?;
+    persist_accept(config_path, &picks)?;
     Ok(picks)
 }
 
 /// Write the picked sources back to `config.toml` under `[sources.<name>]`,
 /// preserving any existing user comments/formatting via `toml_edit`. Each
-/// pick's `config` JSON object is unpacked into TOML key/value pairs.
-fn persist(config_path: &Path, picks: &[Candidate]) -> anyhow::Result<()> {
+/// pick's `config` JSON object is unpacked into TOML key/value pairs and
+/// `enabled = true` is inserted as the first field so `resolve_sources`
+/// picks it up.
+pub fn persist_accept(config_path: &Path, picks: &[Candidate]) -> anyhow::Result<()> {
+    let mut doc = open_or_init(config_path)?;
+    let sources = sources_table_mut(&mut doc)?;
+    for pick in picks {
+        let mut entry = json_to_toml_table(&pick.config).with_context(|| {
+            format!(
+                "pick for {:?} did not produce a TOML-shaped table",
+                pick.name
+            )
+        })?;
+        prepend_enabled(&mut entry, true);
+        sources.insert(&pick.name, Item::Table(entry));
+    }
+    std::fs::write(config_path, doc.to_string())
+        .with_context(|| format!("failed to write {}", config_path.display()))?;
+    Ok(())
+}
+
+/// Outcome of a per-adapter `Confirm` prompt during `pond sync`. `enable`
+/// is the answer to "should this adapter be enabled?"; `sync_now` is the
+/// follow-up "should we sync it this run?" (only meaningful when
+/// `enable == true`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromptOutcome {
+    pub candidate: Candidate,
+    pub enable: bool,
+    pub sync_now: bool,
+}
+
+/// Prompt the operator about each freshly-detected unconfigured adapter:
+/// "Enable X?" and, on accept, "Sync X now?". When `auto_accept` is true
+/// (the operator passed `--yes`) every prompt is skipped and answered
+/// yes/yes. Returns the per-adapter outcomes.
+pub fn prompt_each(
+    candidates: &[Candidate],
+    auto_accept: bool,
+) -> anyhow::Result<Vec<PromptOutcome>> {
+    let mut out = Vec::with_capacity(candidates.len());
+    for candidate in candidates {
+        let label = if candidate.hint.is_empty() {
+            candidate.name.clone()
+        } else {
+            format!("{} ({})", candidate.name, candidate.hint)
+        };
+        let (enable, sync_now) = if auto_accept {
+            (true, true)
+        } else {
+            let enable = Confirm::with_theme(&ColorfulTheme::default())
+                .with_prompt(format!("Enable {label}?"))
+                .default(true)
+                .interact()
+                .context("enable prompt failed")?;
+            let sync_now = if enable {
+                Confirm::with_theme(&ColorfulTheme::default())
+                    .with_prompt(format!("Sync {} now?", candidate.name))
+                    .default(true)
+                    .interact()
+                    .context("sync-now prompt failed")?
+            } else {
+                false
+            };
+            (enable, sync_now)
+        };
+        out.push(PromptOutcome {
+            candidate: candidate.clone(),
+            enable,
+            sync_now,
+        });
+    }
+    Ok(out)
+}
+
+/// Persist `[sources.<name>] enabled = false` for adapters the operator
+/// declined during a probe prompt. Keeps the decline sticky across runs.
+pub fn persist_decline(config_path: &Path, names: &[&str]) -> anyhow::Result<()> {
+    if names.is_empty() {
+        return Ok(());
+    }
+    let mut doc = open_or_init(config_path)?;
+    let sources = sources_table_mut(&mut doc)?;
+    for name in names {
+        let mut entry = Table::new();
+        prepend_enabled(&mut entry, false);
+        sources.insert(name, Item::Table(entry));
+    }
+    std::fs::write(config_path, doc.to_string())
+        .with_context(|| format!("failed to write {}", config_path.display()))?;
+    Ok(())
+}
+
+fn open_or_init(config_path: &Path) -> anyhow::Result<DocumentMut> {
     if let Some(parent) = config_path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("failed to create config dir {}", parent.display()))?;
@@ -130,28 +245,41 @@ fn persist(config_path: &Path, picks: &[Candidate]) -> anyhow::Result<()> {
     let mut doc: DocumentMut = existing
         .parse()
         .with_context(|| format!("failed to parse {} as TOML", config_path.display()))?;
-
     if !doc.contains_key("sources") {
         let mut table = Table::new();
         table.set_implicit(true);
         doc.insert("sources", Item::Table(table));
     }
-    let Some(sources) = doc["sources"].as_table_mut() else {
-        bail!("config.toml has a `sources` value that is not a table");
-    };
-    for pick in picks {
-        let entry = json_to_toml_table(&pick.config).with_context(|| {
-            format!(
-                "pick for {:?} did not produce a TOML-shaped table",
-                pick.name
-            )
-        })?;
-        sources.insert(&pick.name, Item::Table(entry));
-    }
+    Ok(doc)
+}
 
-    std::fs::write(config_path, doc.to_string())
-        .with_context(|| format!("failed to write {}", config_path.display()))?;
-    Ok(())
+fn sources_table_mut(doc: &mut DocumentMut) -> anyhow::Result<&mut Table> {
+    doc["sources"]
+        .as_table_mut()
+        .ok_or_else(|| anyhow::anyhow!("config.toml has a `sources` value that is not a table"))
+}
+
+fn prepend_enabled(table: &mut Table, value: bool) {
+    use toml_edit::value as tv;
+    let implicit = table.is_implicit();
+    let keys: Vec<String> = table.iter().map(|(k, _)| k.to_owned()).collect();
+    let mut existing: Vec<(String, Item)> = Vec::with_capacity(keys.len());
+    for key in keys {
+        if key == "enabled" {
+            continue;
+        }
+        if let Some(item) = table.remove(&key) {
+            existing.push((key, item));
+        }
+    }
+    table.remove("enabled");
+    let mut fresh = Table::new();
+    fresh.set_implicit(implicit);
+    fresh.insert("enabled", tv(value));
+    for (key, item) in existing {
+        fresh.insert(&key, item);
+    }
+    *table = fresh;
 }
 
 /// Convert a JSON object into a `toml_edit::Table`. Factories produce JSON
@@ -233,6 +361,32 @@ mod tests {
         assert!(
             msg.contains("not a terminal"),
             "error should mention the non-tty branch: {msg}",
+        );
+    }
+
+    #[test]
+    fn persist_accept_and_decline_write_enabled_first() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join("config.toml");
+        let accept = Candidate {
+            name: "claude-code".to_owned(),
+            hint: "/tmp/cc".to_owned(),
+            config: json!({ "path": "/tmp/cc" }),
+        };
+        persist_accept(&config_path, &[accept]).unwrap();
+        persist_decline(&config_path, &["opencode"]).unwrap();
+        let body = std::fs::read_to_string(&config_path).unwrap();
+        // Accepted entry: discriminator on top, then the blob.
+        assert!(
+            body.contains("[sources.claude-code]")
+                && body.contains("enabled = true")
+                && body.contains("path = \"/tmp/cc\""),
+            "expected accepted entry; got: {body}",
+        );
+        // Declined entry: discriminator only, no path leak.
+        assert!(
+            body.contains("[sources.opencode]") && body.contains("enabled = false"),
+            "expected declined entry; got: {body}",
         );
     }
 }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -37,7 +37,10 @@ mod pi_coding_agent;
 
 pub use claude_code::{ClaudeCodeAdapter, ClaudeCodeFactory};
 pub use codex_cli::{CodexCliAdapter, CodexCliFactory};
-pub use discovery::{Candidate, discover, prompt_and_persist};
+pub use discovery::{
+    Candidate, PromptOutcome, discover, persist_accept, persist_decline, probe_unconfigured,
+    prompt_and_persist, prompt_each,
+};
 pub use extract::{
     Extracted, Source, extract_bool, extract_compact_repr, extract_raw_record, extract_self_str,
     extract_str, extract_value,
@@ -187,7 +190,7 @@ pub enum SkipReason {
     Fresh,
     /// File produced no importable session (empty `.jsonl`, sidecar-only rows,
     /// or an unextractable header). Benign: counted, never an error or a
-    /// per-event drop. The underlying cause is logged at `POND_LOG=debug`.
+    /// per-event drop. The underlying cause is logged at `-vv` (debug) verbosity.
     Empty,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -173,10 +173,15 @@ pub const DEFAULT_CONFIG_TOML: &str = "\
 # exists.
 #
 # [sources.claude-code]
+# enabled = true
 # path = \"~/.claude/projects\"
 #
 # [sources.codex-cli]
+# enabled = true
 # path = \"~/.codex/sessions\"
+#
+# Set `enabled = false` to keep the section but skip it on `pond sync`;
+# re-enable via `pond sync <adapter>`.
 
 # Embeddings. Search runs hybrid (vector + FTS) whenever the store has any
 # vectors, and FTS-only otherwise - the model loads lazily on the first hybrid
@@ -396,28 +401,69 @@ impl Config {
         Ok(config)
     }
 
-    /// Resolve the `[sources.<adapter>]` entries to drive `pond sync`. With
-    /// `adapter = None` returns every entry (the no-arg sync path); with
-    /// `Some(name)` returns just that one or errors if it's not in config.
-    /// The caller is responsible for the discovery fallback when this returns
-    /// an empty list. Each tuple's `Value` is the opaque config blob to hand
-    /// to the matching factory's `open()`.
+    /// Resolve the `[sources.<adapter>]` entries to drive `pond sync`. Only
+    /// sections with `enabled = true` flow through; sections with
+    /// `enabled = false` (or absent) are treated as opt-out and the
+    /// per-adapter blob (minus `enabled`) is handed to the factory's
+    /// `open()`. With `adapter = None` returns every enabled entry; with
+    /// `Some(name)` returns just that one - and errors if it's not in
+    /// config OR if it's currently disabled (the caller should then
+    /// re-prompt or report).
     pub fn resolve_sources(&self, adapter: Option<&str>) -> Result<Vec<(String, Value)>> {
         match adapter {
             None => Ok(self
                 .sources
                 .iter()
-                .map(|(name, blob)| (name.clone(), blob.clone()))
+                .filter_map(|(name, blob)| take_enabled(name, blob))
                 .collect()),
             Some(name) => {
                 let blob = self
                     .sources
                     .get(name)
                     .ok_or_else(|| anyhow!("no [sources.{name}] entry in config"))?;
-                Ok(vec![(name.to_owned(), blob.clone())])
+                take_enabled(name, blob).map(|entry| vec![entry]).ok_or_else(|| {
+                    anyhow!(
+                        "source [{name}] is disabled (enabled = false); run `pond sync {name}` to re-enable"
+                    )
+                })
             }
         }
     }
+
+    /// Names that are configured but currently `enabled = false`. Used by
+    /// `pond sync` post-import to know not to re-probe an adapter the user
+    /// already declined (the decline persists; re-prompt only via the
+    /// positional override `pond sync <name>`).
+    pub fn disabled_source_names(&self) -> Vec<&str> {
+        self.sources
+            .iter()
+            .filter_map(|(name, blob)| {
+                let enabled = blob
+                    .get("enabled")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                if enabled { None } else { Some(name.as_str()) }
+            })
+            .collect()
+    }
+}
+
+/// Inner helper: return `Some((name, blob))` when the source section is
+/// enabled, stripping the discriminator from the blob before handing it on;
+/// `None` when the section is missing `enabled` or has `enabled = false`.
+fn take_enabled(name: &str, blob: &Value) -> Option<(String, Value)> {
+    let enabled = blob
+        .get("enabled")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if !enabled {
+        return None;
+    }
+    let mut clean = blob.clone();
+    if let Some(obj) = clean.as_object_mut() {
+        obj.remove("enabled");
+    }
+    Some((name.to_owned(), clean))
 }
 
 /// Tilde-expand `path` against an explicit `home`. Filesystem-shaped adapters
@@ -594,21 +640,30 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let body = "\
 [sources.claude-code]
+enabled = true
 path = \"/srv/claude\"
 
 [sources.codex-cli]
+enabled = true
 path = \"/srv/codex\"
+
+[sources.opencode]
+enabled = false
 ";
         let path = temp.path().join("config.toml");
         std::fs::write(&path, body).expect("write config");
         let config = Config::load(&path).unwrap();
 
-        // None -> everything in [sources.*]
+        // None -> only enabled entries
         let all = config.resolve_sources(None).unwrap();
         assert_eq!(all.len(), 2);
         let names: Vec<_> = all.iter().map(|(n, _)| n.as_str()).collect();
         assert!(names.contains(&"claude-code"));
         assert!(names.contains(&"codex-cli"));
+        // The `enabled` discriminator never reaches the adapter blob.
+        for (_, blob) in &all {
+            assert!(blob.get("enabled").is_none(), "enabled should be stripped");
+        }
 
         // Some(name) -> one entry, opaque JSON blob
         let one = config.resolve_sources(Some("codex-cli")).unwrap();
@@ -619,8 +674,19 @@ path = \"/srv/codex\"
             Some("/srv/codex"),
         );
 
+        // Disabled positional -> errors with the recovery hint baked in.
+        let disabled = config.resolve_sources(Some("opencode"));
+        let err = disabled
+            .expect_err("disabled adapter must error")
+            .to_string();
+        assert!(err.contains("enabled = false"), "got: {err}");
+        assert!(err.contains("pond sync opencode"), "got: {err}");
+
         // Unknown -> error
         assert!(config.resolve_sources(Some("nope")).is_err());
+
+        // disabled_source_names lists exactly the off ones.
+        assert_eq!(config.disabled_source_names(), vec!["opencode"]);
     }
 
     #[test]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -110,7 +110,7 @@ mod ingest_handler {
         Partial {
             dropped_events: usize,
             /// First drop's error message; subsequent drops counted, not
-            /// retained. Full detail at `POND_LOG=pond=debug`.
+            /// retained. Full detail at `-vv` (debug) verbosity.
             first_drop_reason: Option<String>,
         },
         Skipped {
@@ -210,8 +210,8 @@ mod ingest_handler {
         // order against `validator.flush()`'s outcome stream.
         let mut pending_dones: std::collections::VecDeque<PendingDone> =
             std::collections::VecDeque::new();
-        // Perf probe accumulators. Logged once at the end of the run under
-        // `POND_LOG=pond=info` so a single sync emits one tidy summary plus
+        // Perf probe accumulators. Logged once at the end of the run at `-v`
+        // (info) verbosity so a single sync emits one tidy summary plus
         // per-merge_insert lines from substrate. Visible only at INFO; never
         // affects normal output.
         let mut decode_total = std::time::Duration::ZERO;

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -320,10 +320,14 @@ mod ingest_handler {
                     // commit them in one parallel 3-table merge_insert.
                     if validator.pending_substreams() >= ADAPTER_FLUSH_BATCH {
                         let flush_start = std::time::Instant::now();
-                        let flush_outcomes = validator.flush(store).await?;
+                        let (flush_outcomes, flush_counts) = validator.flush(store).await?;
                         validator_total += flush_start.elapsed();
                         validator_count += 1;
-                        summary.add_outcomes(&flush_outcomes);
+                        // Counts come from the pre-existence sweep inside the
+                        // flush, not from per-row outcomes (which would
+                        // double-count if we also called `add_outcomes`).
+                        summary.add_outcomes_errors_only(&flush_outcomes);
+                        summary.add_batch(&flush_counts);
                         drain_pending_dones(&mut pending_dones, &flush_outcomes, &mut on_event);
                     }
                 }
@@ -379,10 +383,11 @@ mod ingest_handler {
             });
         }
         let validator_start = std::time::Instant::now();
-        let final_outcomes = validator.finish(store).await?;
+        let (final_outcomes, final_counts) = validator.finish(store).await?;
         validator_total += validator_start.elapsed();
         validator_count += 1;
-        summary.add_outcomes(&final_outcomes);
+        summary.add_outcomes_errors_only(&final_outcomes);
+        summary.add_batch(&final_counts);
         drain_pending_dones(&mut pending_dones, &final_outcomes, &mut on_event);
 
         summary.truncated_values = crate::adapter::extract::truncated_values_count()
@@ -534,7 +539,9 @@ mod ingest_handler {
             let mut chunk = validator.push(store, index, event).await?;
             outcomes.append(&mut chunk);
         }
-        let mut tail = validator.finish(store).await?;
+        // HTTP wire path keeps using per-row outcomes for `IngestResult`;
+        // the batch counts are CLI-only.
+        let (mut tail, _counts) = validator.finish(store).await?;
         outcomes.append(&mut tail);
         outcomes.sort_by_key(|outcome| outcome.index);
         Ok(outcomes)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,15 @@ pub mod output {
         let mut stdout = io::stdout().lock();
         writeln!(stdout, "{message}").context("failed to write command output")
     }
+
+    /// Stderr counterpart to [`line`]. Per rust-cli/book stdout-vs-stderr
+    /// discipline, anything that is not "the result" (progress, prompts,
+    /// disclaimers, hints, interim status) belongs here so piping stdout to a
+    /// file or another command yields the machine-readable view alone.
+    pub fn line_err(message: &str) -> anyhow::Result<()> {
+        let mut stderr = io::stderr().lock();
+        writeln!(stderr, "{message}").context("failed to write command meta")
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,11 +22,12 @@ use pond::{
     handlers::{self, IngestSummary, SessionOutcome, SyncEvent, SyncStatus},
     sessions::{
         AdapterStats, CleanupConfig, CorpusStats, EmbeddingProgress, LanceArchiveCounts,
-        LanceArchiveExport, LanceArchiveImport, OptimizeOutcome, RowTotals, Store,
+        LanceArchiveExport, LanceArchiveImport, MESSAGES_FTS_INDEX, MESSAGES_VECTOR_INDEX,
+        OptimizeOutcome, RowTotals, Store,
     },
     substrate::{
-        IndexStatus, OptimizeEvent, OptimizeProgressFn, PhaseOutcome, TableOptimizeOutcome,
-        TableSizes,
+        IndexStatus, OptimizeEvent, OptimizeProgressFn, PhaseOutcome, TableSizes,
+        index_lag_threshold,
     },
     transport::{self, AppState},
     wire::{
@@ -137,6 +138,11 @@ fn parse_data_dir(input: &str) -> anyhow::Result<Url> {
 #[derive(Debug, Parser)]
 #[command(name = "pond", version, about = "Session storage and retrieval")]
 struct Cli {
+    /// `-v` / `-vv` / `-vvv` raise the tracing log level; `-q` / `-qq` lower
+    /// it. The display layout itself is independent of this knob - see
+    /// per-command flags like `pond status --adapters` for that.
+    #[command(flatten)]
+    verbose: clap_verbosity_flag::Verbosity<clap_verbosity_flag::WarnLevel>,
     #[command(subcommand)]
     command: Command,
 }
@@ -149,9 +155,11 @@ enum Command {
         data_dir: Option<Url>,
         #[arg(long, env = "POND_CONFIG")]
         config: Option<PathBuf>,
-        /// Include detailed per-index and per-project rows.
+        /// Show one section per adapter, including the per-project tables
+        /// and per-intent index detail. Implies `--include-subagents` so the
+        /// rollup reconciles with the data-dir row counts above.
         #[arg(long)]
-        verbose: bool,
+        adapters: bool,
         /// Show one section per `source_agent` (including sub-agents like
         /// `claude-code/general-purpose`). Default rolls sessions up to the
         /// main agent only.
@@ -178,6 +186,10 @@ enum Command {
         /// Re-embed stale rows after an embedding model change.
         #[arg(long)]
         force_embed: bool,
+        /// Auto-accept every probe prompt; non-interactive runs use this to
+        /// enable freshly-detected adapters without a TTY.
+        #[arg(long, short = 'y')]
+        yes: bool,
         #[arg(long, env = "POND_DATA_DIR", value_parser = parse_data_dir)]
         data_dir: Option<Url>,
         #[arg(long, env = "POND_CONFIG")]
@@ -490,36 +502,46 @@ enum OutputFormat {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    init_tracing();
+    human_panic::setup_panic!();
 
     let cli = Cli::parse();
+    init_tracing(cli.verbose.tracing_level_filter());
+
     match cli.command {
         Command::Status {
             data_dir,
             config,
-            verbose,
+            adapters,
             include_subagents,
         } => {
+            // --adapters needs sub-agents broken out so the per-adapter
+            // rollup reconciles with the data-dir row counts above.
+            let include_subagents = include_subagents || adapters;
             let data_dir = resolve_data_dir(data_dir)?;
             let loaded = Config::load(config_path(config, &data_dir))?;
             let store =
                 Store::open_with_options(&data_dir, storage_map(&loaded), runtime_caps(&loaded))
                     .await?;
-            let sizes = store.table_sizes().await?;
-            render_status_header(&data_dir, &sizes)?;
-            output(&format!(
-                "{} checking corpus, embeddings, indexes...",
-                pond::output::paint("status:", pond::output::dim()),
-            ))?;
-            // Sample is bounded so this remains O(sample) and `pond status`
-            // stays sub-second on a million-message corpus.
-            let (stats, index_status, embedding, scripts) = tokio::try_join!(
+            let (sizes, stats, index_status, embedding) = tokio::try_join!(
+                store.table_sizes(),
                 store.corpus_stats(include_subagents),
                 store.index_status(),
                 store.embedding_progress(),
-                store.text_script_histogram(2000),
             )?;
-            render_status_checks(&stats, &index_status, embedding, &scripts, verbose)?;
+            render_status_header(&data_dir, &sizes, &stats.totals)?;
+            render_status_checks(&stats, &index_status, embedding, adapters)?;
+            let probes = adapter::probe_unconfigured(&loaded.sources);
+            if !probes.is_empty() {
+                let names: Vec<&str> = probes.iter().map(|c| c.name.as_str()).collect();
+                output_err(&pond::output::paint(
+                    &format!(
+                        "hint     {} unconfigured adapter(s): {} - run `pond sync` to enable",
+                        probes.len(),
+                        names.join(", "),
+                    ),
+                    pond::output::dim(),
+                ))?;
+            }
         }
         Command::Sync {
             adapter,
@@ -528,12 +550,13 @@ async fn main() -> anyhow::Result<()> {
             only,
             skip,
             force_embed,
+            yes,
             data_dir,
             config,
         } => {
             let data_dir = resolve_data_dir(data_dir)?;
             let config_file = config_path(config, &data_dir);
-            let loaded = Config::load(&config_file)?;
+            let mut loaded = Config::load(&config_file)?;
             let store =
                 open_store_with_spinner(&data_dir, storage_map(&loaded), runtime_caps(&loaded))
                     .await?;
@@ -544,15 +567,31 @@ async fn main() -> anyhow::Result<()> {
                 );
             }
             let mut summary = SyncRunSummary::default();
+            let did_archive_import = import_from.is_some();
+            if stages.import
+                && !did_archive_import
+                && let Some(name) = adapter.as_deref()
+            {
+                maybe_reenable_positional(&mut loaded, &config_file, name, yes).await?;
+            }
             if stages.import {
                 if let Some(path) = import_from {
                     summary.archive_import = Some(import_pond_archive(&store, &path).await?);
                 } else {
                     summary.ingest = Some(
-                        run_import_stage(&store, &loaded, &config_file, adapter, source_dir)
-                            .await?,
+                        run_import_stage(
+                            &store,
+                            &loaded,
+                            &config_file,
+                            adapter.clone(),
+                            source_dir,
+                        )
+                        .await?,
                     );
                 }
+            }
+            if stages.import && adapter.is_none() && !did_archive_import {
+                handle_probe_prompt(&store, &mut loaded, &config_file, yes).await?;
             }
             if stages.embed {
                 run_embed_stage(&store, force_embed).await?;
@@ -560,7 +599,7 @@ async fn main() -> anyhow::Result<()> {
             if stages.update_indexes {
                 run_update_indexes_stage(&store).await?;
             }
-            render_sync_summary(&summary)?;
+            render_sync_summary(&store, &summary).await?;
         }
         Command::Embed {
             data_dir,
@@ -854,22 +893,138 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn init_tracing() {
+fn init_tracing(cli_level: tracing::level_filters::LevelFilter) {
     // Lance's IVF_PQ builder warns once per empty centroid during merge
     // (rust/lance/src/index/vector/builder.rs: "partition N is empty, skipping").
     // It already handles the case - records a zero-sized partition and continues -
     // so the warning is benign log noise during index maintenance.
-    // POND_LOG / RUST_LOG still override this default.
-    let filter = EnvFilter::try_from_env("POND_LOG")
-        .or_else(|_| EnvFilter::try_from_default_env())
-        .unwrap_or_else(|_| EnvFilter::new("warn,lance::index::vector::builder=error"));
-
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        EnvFilter::new(format!("{cli_level},lance::index::vector::builder=error"))
+    });
     fmt().with_env_filter(filter).with_writer(io::stderr).init();
 }
 
 #[allow(clippy::print_stdout)]
 fn output(message: &str) -> anyhow::Result<()> {
     pond::output::line(message)
+}
+
+fn output_err(message: &str) -> anyhow::Result<()> {
+    pond::output::line_err(message)
+}
+
+/// Partition `outcomes` into accepts/declines, persist both, and refresh
+/// `loaded` from disk. Shared between the post-import probe sweep and the
+/// positional re-enable path.
+fn apply_outcomes(
+    loaded: &mut Config,
+    config_file: &Path,
+    outcomes: &[adapter::PromptOutcome],
+) -> anyhow::Result<usize> {
+    let accepts: Vec<adapter::Candidate> = outcomes
+        .iter()
+        .filter(|o| o.enable)
+        .map(|o| o.candidate.clone())
+        .collect();
+    let declines: Vec<&str> = outcomes
+        .iter()
+        .filter(|o| !o.enable)
+        .map(|o| o.candidate.name.as_str())
+        .collect();
+    if !accepts.is_empty() {
+        adapter::persist_accept(config_file, &accepts)?;
+    }
+    if !declines.is_empty() {
+        adapter::persist_decline(config_file, &declines)?;
+    }
+    if !accepts.is_empty() || !declines.is_empty() {
+        *loaded = Config::load(config_file)?;
+    }
+    Ok(accepts.len())
+}
+
+/// `pond sync <name>` positional override. When `<name>` is currently
+/// absent or `enabled = false`, re-probe just that one adapter and prompt
+/// (or auto-accept on `--yes`). Used to re-enable a previously-declined
+/// adapter without editing `config.toml` by hand.
+async fn maybe_reenable_positional(
+    loaded: &mut Config,
+    config_file: &Path,
+    name: &str,
+    auto_accept: bool,
+) -> anyhow::Result<()> {
+    use serde_json::Value;
+    use std::io::IsTerminal;
+    let present = loaded.sources.get(name);
+    let is_enabled = present
+        .and_then(|b| b.get("enabled").and_then(Value::as_bool))
+        .unwrap_or(false);
+    if is_enabled {
+        return Ok(());
+    }
+    let candidates = adapter::discover(Some(name));
+    if candidates.is_empty() {
+        bail!("no `[sources.{name}]` and probe returned nothing; add the entry manually");
+    }
+    if !auto_accept && !std::io::stdin().is_terminal() {
+        bail!(
+            "source [{name}] is disabled and stdin is not a terminal; pass --yes or re-run on a TTY"
+        );
+    }
+    let outcomes = adapter::prompt_each(&candidates, auto_accept)?;
+    let accepted = apply_outcomes(loaded, config_file, &outcomes)?;
+    if accepted == 0 {
+        bail!("declined; nothing to sync");
+    }
+    Ok(())
+}
+
+/// After `pond sync`'s import stage, prompt the operator about any
+/// freshly-detectable adapter that has no `[sources.<name>]` section yet.
+/// `enabled = true`/`enabled = false` is persisted either way so the
+/// decision sticks; only the positional `pond sync <name>` re-prompts a
+/// previously-declined adapter. Non-TTY runs (and `--yes` runs without a
+/// TTY) emit a one-line stderr hint and continue without writing - the
+/// operator can re-run on a TTY to opt in/out.
+async fn handle_probe_prompt(
+    store: &Store,
+    loaded: &mut Config,
+    config_file: &Path,
+    auto_accept: bool,
+) -> anyhow::Result<()> {
+    use std::io::IsTerminal;
+    let candidates = adapter::probe_unconfigured(&loaded.sources);
+    if candidates.is_empty() {
+        return Ok(());
+    }
+    let interactive = std::io::stdin().is_terminal();
+    if !interactive && !auto_accept {
+        let names: Vec<&str> = candidates.iter().map(|c| c.name.as_str()).collect();
+        output_err(&pond::output::paint(
+            &format!(
+                "hint     {} unconfigured adapter(s): {} - run `pond sync` on a TTY to enable",
+                candidates.len(),
+                names.join(", "),
+            ),
+            pond::output::dim(),
+        ))?;
+        return Ok(());
+    }
+    let outcomes = adapter::prompt_each(&candidates, auto_accept)?;
+    apply_outcomes(loaded, config_file, &outcomes)?;
+    for outcome in &outcomes {
+        if outcome.enable && outcome.sync_now {
+            let _ = run_import_stage(
+                store,
+                loaded,
+                config_file,
+                Some(outcome.candidate.name.clone()),
+                None,
+            )
+            .await?;
+        }
+    }
+    Ok(())
 }
 
 /// Open the store with an indicatif spinner ticking while
@@ -1057,23 +1212,20 @@ async fn run_embed_stage_with_limit(
         None => backlog,
     };
     if bar_total == 0 && stale == 0 {
-        // Nothing to embed: one line, no bar, no device (embedder not loaded).
-        output(&format!(
-            "{}  0 new \u{b7} {}/{} \u{b7} {}",
-            pond::output::paint("embed:", pond::output::dim()),
-            format_thousands(progress.embedded as u64),
-            format_thousands(progress.total as u64),
-            short_model(progress.model),
-        ))?;
+        // No backlog and no stale rows: stage is silent. The summary's
+        // `indexes` line will confirm "semantic ready" downstream.
         return Ok(EmbedSummary::default());
     }
 
     let embedder = CandleEmbedder::load()?;
     let device = embedder.device().to_owned();
-    let bar = ProgressBar::new(bar_total as u64);
+    let bar = ProgressBar::with_draw_target(
+        Some(bar_total as u64),
+        indicatif::ProgressDrawTarget::stderr_with_hz(8),
+    );
     bar.set_style(
         ProgressStyle::with_template(
-            "{spinner:.green} embed [{elapsed_precise}] [{bar:24}] {pos}/{len} ({percent}%) {per_sec} eta {eta}",
+            "semantic indexing [{elapsed_precise}] [{bar:24}] {pos}/{len} messages  {wide_msg}",
         )
         .unwrap_or_else(|_| ProgressStyle::default_bar())
         .progress_chars("##-"),
@@ -1090,11 +1242,15 @@ async fn run_embed_stage_with_limit(
             std::process::exit(130);
         });
     }
+    let started = std::time::Instant::now();
     let bar_for_callback = bar.clone();
     let mut worker = EmbedWorker::new(store, &embedder)
         .with_cancel(cancel)
         .with_progress(move |progress: BatchProgress| {
+            let secs = started.elapsed().as_secs_f64().max(0.001);
+            let rate = progress.total_messages as f64 / secs;
             bar_for_callback.set_position(progress.total_messages as u64);
+            bar_for_callback.set_message(format!("{rate:.0} msgs/s"));
         });
     if force {
         worker = worker.include_stale();
@@ -1104,21 +1260,19 @@ async fn run_embed_stage_with_limit(
     }
     let summary = worker.run().await?;
     bar.finish_and_clear();
-    let covered = progress.embedded + summary.messages;
-    output(&format!(
-        "{}  {} new \u{b7} {}/{} \u{b7} {} ({}){}",
-        pond::output::paint("embed:", pond::output::dim()),
-        format_thousands(summary.messages as u64),
-        format_thousands(covered as u64),
-        format_thousands(progress.total as u64),
-        short_model(progress.model),
-        device,
-        if summary.cancelled {
-            " (interrupted)"
+    if summary.messages > 0 {
+        let label = if summary.cancelled {
+            "semantic indexing (interrupted)"
         } else {
-            ""
-        },
-    ))?;
+            "semantic indexing"
+        };
+        output(&format!(
+            "{}  +{} indexed  ({})",
+            pond::output::paint(label, pond::output::dim()),
+            format_thousands(summary.messages as u64),
+            device,
+        ))?;
+    }
     Ok(summary)
 }
 
@@ -1126,65 +1280,73 @@ async fn run_update_indexes_stage(store: &Store) -> anyhow::Result<OptimizeOutco
     let (progress, bar) = optimize_progress_bar();
     let outcome = store.optimize_indices(Some(progress), None).await?;
     bar.finish_and_clear();
-    let per_table = outcome
-        .tables
-        .iter()
-        .map(|entry| format!("{} {}", entry.table.as_str(), index_entry_status(entry)))
-        .collect::<Vec<_>>()
-        .join(" \u{b7} ");
-    output(&format!(
-        "{}  {}",
-        pond::output::paint("index:", pond::output::dim()),
-        per_table,
-    ))?;
+    // No `index:` recap line: the `render_sync_summary` (or `pond status`)
+    // `indexes  text + semantic ready` line is the single source of truth
+    // for index health. Hints below still fire on real conflicts / failures.
     render_optimize_hints(&outcome)?;
     Ok(outcome)
 }
 
-/// Final one-line import recap. Embed and index each print their own concise
-/// line during their stage, so this is import-only: `sync: N new . M unchanged
-/// . K empty . D dropped`, with `errors` appended only when nonzero.
-fn render_sync_summary(summary: &SyncRunSummary) -> anyhow::Result<()> {
+/// Final recap of a `pond sync` run. Three-line shape:
+///
+/// ```text
+///
+/// indexes   text + semantic ready
+/// added     +44 sessions, +2,337 messages
+/// stored    8,460 sessions, 172,710 messages
+///
+/// (messages = searchable text rows; use -v for full counts)
+/// ```
+///
+/// `added` is suppressed when both deltas are zero (a no-op sync still
+/// always prints the `stored` line so an operator can confirm corpus
+/// state without re-running `pond status`). The trailing disclaimer
+/// goes to stderr per the rust-cli/book result-vs-meta discipline.
+async fn render_sync_summary(store: &Store, summary: &SyncRunSummary) -> anyhow::Result<()> {
     use pond::output::{dim, paint};
 
-    let line = if let Some(ingest) = &summary.ingest {
-        let unchanged = ingest.matched + ingest.skipped_fresh;
-        let dropped = ingest.dropped_events + ingest.dropped_sessions;
-        let errors = ingest.skipped_files + ingest.storage_errors;
-        let mut line = format!(
-            "{} new \u{b7} {} unchanged \u{b7} {} empty \u{b7} {} dropped",
-            format_thousands(ingest.inserted as u64),
-            format_thousands(unchanged as u64),
-            format_thousands(ingest.skipped_empty as u64),
-            format_thousands(dropped as u64),
-        );
-        if errors > 0 {
-            line.push_str(&format!(
-                " \u{b7} {} errors",
-                format_thousands(errors as u64)
-            ));
-        }
-        Some(line)
+    let (sessions_added, messages_added) = if let Some(ingest) = &summary.ingest {
+        (
+            ingest.sessions_inserted as u64,
+            ingest.messages_inserted_searchable as u64,
+        )
+    } else if let Some(imported) = &summary.archive_import {
+        (
+            imported.inserted.sessions as u64,
+            imported.inserted.messages as u64,
+        )
     } else {
-        summary.archive_import.as_ref().map(|imported| {
-            format!(
-                "{} rows imported from archive \u{b7} {} new",
-                format_thousands(
-                    (imported.rows.sessions + imported.rows.messages + imported.rows.parts) as u64,
-                ),
-                format_thousands(
-                    (imported.inserted.sessions
-                        + imported.inserted.messages
-                        + imported.inserted.parts) as u64,
-                ),
-            )
-        })
+        (0, 0)
     };
-    // No import stage ran (e.g. `--only embed`): the embed/index stages already
-    // printed their own lines, so there's nothing left to recap.
-    if let Some(line) = line {
-        output(&format!("{}  {line}", paint("sync:", dim())))?;
+
+    let (index_status, embedding, stats) = tokio::try_join!(
+        store.index_status(),
+        store.embedding_progress(),
+        store.corpus_stats(false),
+    )?;
+    let health = classify_index_health(&index_status, index_lag_threshold(), &embedding);
+
+    output("")?;
+    output(&render_indexes_line(&health))?;
+    if sessions_added + messages_added > 0 {
+        output(&format!(
+            "{}     +{} sessions, +{} messages",
+            paint("added", dim()),
+            format_thousands(sessions_added),
+            format_thousands(messages_added),
+        ))?;
     }
+    output(&format!(
+        "{}    {} sessions, {} messages",
+        paint("stored", dim()),
+        format_thousands(stats.totals.sessions),
+        format_thousands(embedding.total as u64),
+    ))?;
+    output_err("")?;
+    output_err(&paint(
+        "(messages = searchable text rows; use -v for full counts)",
+        dim(),
+    ))?;
     Ok(())
 }
 
@@ -1399,7 +1561,7 @@ async fn sync_with_progress(
         ProgressBar::with_draw_target(Some(0), indicatif::ProgressDrawTarget::stderr_with_hz(8));
     bar.set_style(
         ProgressStyle::with_template(
-            "sync {prefix} [{elapsed_precise}] [{bar:12}] {pos}/{len} \u{b7} {wide_msg}",
+            "sync {prefix} [{elapsed_precise}] [{bar:12}] {pos}/{len} sessions  {wide_msg}",
         )
         .unwrap_or_else(|_| ProgressStyle::default_bar())
         .progress_chars("##-"),
@@ -1411,7 +1573,6 @@ async fn sync_with_progress(
     let mut messages: u64 = 0;
     let mut errors: u64 = 0;
     let mut drops: u64 = 0;
-    let mut skipped_empty: u64 = 0;
     let started = std::time::Instant::now();
     let bar_ref = &bar;
 
@@ -1467,7 +1628,10 @@ async fn sync_with_progress(
                     optional_reason = None;
                 }
                 SyncStatus::Empty => {
-                    skipped_empty += 1;
+                    // Sidecar/metadata files shrink the denominator so the
+                    // bar lands at `N/N sessions` instead of leaving a gap.
+                    let len = bar_ref.length().unwrap_or(0);
+                    bar_ref.set_length(len.saturating_sub(1));
                     status_label = "empty";
                     dropped_count = 0;
                     optional_reason = None;
@@ -1477,7 +1641,7 @@ async fn sync_with_progress(
             // Only surface the non-`ok`/`fresh` cases as scroll-back lines;
             // the bulk are routine successes already counted by the bar's
             // pos/len/msg counters. `pond::sync` at INFO still carries the
-            // full per-session detail for `POND_LOG=pond::sync=info` runs.
+            // full per-session detail at `-v` verbosity.
             if !matches!(
                 outcome.status,
                 SyncStatus::Ok | SyncStatus::Fresh | SyncStatus::Empty
@@ -1507,7 +1671,10 @@ async fn sync_with_progress(
                     "session done"
                 ),
             }
-            bar_ref.inc(1);
+            if !matches!(outcome.status, SyncStatus::Empty) {
+                // Empty already shrunk `len`; ticking `pos` would over-count.
+                bar_ref.inc(1);
+            }
             bar_ref.set_message(format_bar_message(
                 messages,
                 drops,
@@ -1518,22 +1685,35 @@ async fn sync_with_progress(
     })
     .await?;
 
-    let mut tail = format!("{} msgs", format_thousands(messages));
-    if skipped_empty > 0 {
-        tail.push_str(&format!(
-            " \u{b7} {} empty",
-            format_thousands(skipped_empty)
-        ));
-    }
-    if drops > 0 {
-        tail.push_str(&format!(" \u{b7} {} dropped", format_thousands(drops)));
-    }
-    if errors > 0 {
-        tail.push_str(&format!(" \u{b7} {} err", format_thousands(errors)));
-    }
-    tail.push_str("   done");
+    let tail = format_sync_outcome(&summary, drops, errors);
     bar.finish_with_message(tail);
     Ok(summary)
+}
+
+/// Frozen per-adapter bar tail after `sync_with_progress` finishes. Replaces
+/// the in-flight throughput display (`N msgs / X msgs/s`) with the outcome
+/// counts so scroll-back tells the story of what landed, not what was
+/// decoded. Empty/sidecar files are intentionally not surfaced here -
+/// per design they are part of normal operation, not a signal to the user.
+fn format_sync_outcome(summary: &IngestSummary, drops: u64, errors: u64) -> String {
+    let new_sessions = summary.sessions_inserted as u64;
+    let new_messages = summary.messages_inserted_searchable as u64;
+    let mut tail = if new_sessions == 0 && new_messages == 0 {
+        "up to date".to_owned()
+    } else {
+        format!(
+            "+{} sessions (+{} messages)",
+            format_thousands(new_sessions),
+            format_thousands(new_messages),
+        )
+    };
+    if drops > 0 {
+        tail.push_str(&format!("  {} dropped", format_thousands(drops)));
+    }
+    if errors > 0 {
+        tail.push_str(&format!("  {} err", format_thousands(errors)));
+    }
+    tail
 }
 
 /// One greppable per-session log line. Examples:
@@ -1575,26 +1755,19 @@ fn format_bar_message(messages: u64, drops: u64, errors: u64, elapsed: Duration)
     let secs = elapsed.as_secs_f64().max(0.001);
     let msg_per_sec = (messages as f64) / secs;
     let mut out = format!(
-        "{} msgs \u{b7} {:.0} msg/s",
+        "{} msgs  {:.0} msgs/s",
         format_thousands(messages),
         msg_per_sec,
     );
     // Only surface the trouble counters once they're nonzero; a clean run
     // stays short enough to fit the bar without truncation.
     if drops > 0 {
-        out.push_str(&format!(" \u{b7} {} dropped", format_thousands(drops)));
+        out.push_str(&format!("  {} dropped", format_thousands(drops)));
     }
     if errors > 0 {
-        out.push_str(&format!(" \u{b7} {} err", format_thousands(errors)));
+        out.push_str(&format!("  {} err", format_thousands(errors)));
     }
     out
-}
-
-/// Display form of an embedding model id: the segment after the last `/`, so
-/// `intfloat/multilingual-e5-small` -> `multilingual-e5-small`. Org prefixes
-/// add width without information for the human-facing sync lines.
-fn short_model(id: &str) -> &str {
-    id.rsplit('/').next().unwrap_or(id)
 }
 
 /// Render an integer with thousands separators (`12_345_678` -> `"12,345,678"`).
@@ -1660,8 +1833,8 @@ async fn wait_for_index_catchup(store: &Store) -> anyhow::Result<()> {
 
 /// Build the spinner + progress callback pair for index maintenance.
 /// `PhaseStart` updates the spinner so the operator sees what's running live;
-/// per-phase timing lands at `POND_LOG=pond=debug` rather than the default
-/// output, which carries one `index:` summary line instead.
+/// per-phase timing lands at `-vv` (debug) verbosity rather than the default
+/// output, which carries one `indexes` line in the sync/status footer instead.
 fn optimize_progress_bar() -> (OptimizeProgressFn, ProgressBar) {
     let bar = ProgressBar::new_spinner();
     bar.set_style(
@@ -1746,21 +1919,6 @@ fn render_optimize_hints(outcome: &OptimizeOutcome) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// One table's combined status for the `pond sync` summary line: the worst of
-/// its two phases, painted. `ok` covers Ok/Noop/NotAttempted.
-fn index_entry_status(entry: &TableOptimizeOutcome) -> String {
-    use pond::output::{paint, red, yellow};
-    if entry.indices.is_failed() || entry.compaction.is_failed() {
-        paint("failed", red())
-    } else if matches!(entry.indices, PhaseOutcome::SkippedConflict)
-        || matches!(entry.compaction, PhaseOutcome::SkippedConflict)
-    {
-        paint("deferred", yellow())
-    } else {
-        "ok".to_owned()
-    }
-}
-
 fn phase_cell(outcome: &PhaseOutcome, _phase: &str) -> Cell {
     use pond::output::{dim, paint, red, yellow};
     match outcome {
@@ -1808,30 +1966,42 @@ fn render_index_status(statuses: &[IndexStatus]) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn render_status_header(data_url: &Url, sizes: &TableSizes) -> anyhow::Result<()> {
+fn render_status_header(
+    data_url: &Url,
+    sizes: &TableSizes,
+    totals: &RowTotals,
+) -> anyhow::Result<()> {
     use pond::output::{bold, dim, paint};
 
     output(&paint("pond status", bold()))?;
     output(&format!("{}  {}", paint("data-dir", dim()), data_url))?;
 
     let mut table = new_table();
-    let total = sizes.sessions + sizes.messages + sizes.parts + sizes.other;
-    for (label, bytes) in [
-        ("sessions", sizes.sessions),
-        ("messages", sizes.messages),
-        ("parts", sizes.parts),
-        ("other", sizes.other),
-    ] {
+    let total_bytes = sizes.sessions + sizes.messages + sizes.parts + sizes.other;
+    let rows = [
+        ("sessions", sizes.sessions, Some(totals.sessions)),
+        ("messages", sizes.messages, Some(totals.messages)),
+        ("parts", sizes.parts, Some(totals.parts)),
+        ("other", sizes.other, None),
+    ];
+    for (label, bytes, rows_opt) in rows {
         table.add_row(vec![
             Cell::new(format!("  {label}")),
             Cell::new(format_bytes(bytes)).set_alignment(CellAlignment::Right),
+            Cell::new(
+                rows_opt
+                    .map(|n| format!("{} rows", format_thousands(n)))
+                    .unwrap_or_default(),
+            )
+            .set_alignment(CellAlignment::Right),
         ]);
     }
     table.add_row(vec![
         Cell::new("  total").add_attribute(Attribute::Bold),
-        Cell::new(format_bytes(total))
+        Cell::new(format_bytes(total_bytes))
             .set_alignment(CellAlignment::Right)
             .add_attribute(Attribute::Bold),
+        Cell::new(""),
     ]);
     output(&table.to_string())?;
     Ok(())
@@ -1843,87 +2013,20 @@ fn render_status_checks(
     stats: &CorpusStats,
     index_status: &[IndexStatus],
     embedding: EmbeddingProgress,
-    scripts: &[(String, usize)],
-    verbose: bool,
+    adapters: bool,
 ) -> anyhow::Result<()> {
-    use pond::output::{bold, dim, paint, yellow};
+    use pond::output::{dim, paint, yellow};
 
-    let RowTotals {
-        sessions,
-        messages,
-        parts,
-    } = stats.totals;
     output("")?;
+    let health = classify_index_health(index_status, index_lag_threshold(), &embedding);
+    output(&render_indexes_line(&health))?;
     output(&format!(
-        "{}  {} sessions  {} messages  {} parts",
-        paint("totals", dim()),
-        paint(&format_thousands(sessions), bold()),
-        paint(&format_thousands(messages), bold()),
-        paint(&format_thousands(parts), bold()),
+        "{}    {} sessions, {} messages",
+        paint("stored", dim()),
+        format_thousands(stats.totals.sessions),
+        format_thousands(embedding.total as u64),
     ))?;
-    let pending = embedding.total.saturating_sub(embedding.embedded);
-    if embedding.total == 0 {
-        output(&format!(
-            "{}  no embeddable messages (model={})",
-            paint("embeddings", dim()),
-            embedding.model,
-        ))?;
-    } else if pending == 0 {
-        output(&format!(
-            "{}  {}/{} messages  model={}",
-            paint("embeddings", dim()),
-            paint(&format_thousands(embedding.embedded as u64), bold()),
-            paint(&format_thousands(embedding.total as u64), bold()),
-            embedding.model,
-        ))?;
-    } else {
-        output(&paint(
-            &format!(
-                "embeddings  {}/{} messages  model={} - run `pond sync --only embed` to fill the {} backlog",
-                format_thousands(embedding.embedded as u64),
-                format_thousands(embedding.total as u64),
-                embedding.model,
-                format_thousands(pending as u64),
-            ),
-            yellow(),
-        ))?;
-    }
-    let index_backlog: usize = index_status
-        .iter()
-        .map(|status| status.unindexed_rows)
-        .sum();
-    let existing_indices = index_status.iter().filter(|status| status.exists).count();
-    if index_status.is_empty() {
-        output(&format!(
-            "{}  no configured indexes",
-            paint("indexes", dim())
-        ))?;
-    } else if index_backlog == 0 && existing_indices == index_status.len() {
-        output(&format!(
-            "{}  {}/{} ready",
-            paint("indexes", dim()),
-            existing_indices,
-            index_status.len(),
-        ))?;
-    } else if index_backlog == 0 {
-        output(&format!(
-            "{}  {}/{} built; no unindexed rows",
-            paint("indexes", dim()),
-            existing_indices,
-            index_status.len(),
-        ))?;
-    } else {
-        output(&paint(
-            &format!(
-                "indexes  {}/{} built - {} unindexed row(s), run `pond sync --only update-indexes`",
-                existing_indices,
-                index_status.len(),
-                format_thousands(index_backlog as u64),
-            ),
-            yellow(),
-        ))?;
-    }
-    if verbose {
+    if adapters {
         output("")?;
         output(&paint("index detail", dim()))?;
         for status in index_status {
@@ -1942,60 +2045,119 @@ fn render_status_checks(
             }
         }
     }
-    // Surfaces the corpus's language mix so an agent can decide whether
-    // bilingual querying is worth attempting (cross-lingual recall is a
-    // caller-layer concern; pond does not translate internally - see the
-    // `pond_search` MCP description). Sample is bounded; total = sum of
-    // alphabetic characters in the sampled `search_text`.
-    if !scripts.is_empty() {
-        let total: usize = scripts.iter().map(|(_, count)| *count).sum();
-        if total > 0 {
-            let parts = scripts
-                .iter()
-                .filter(|(_, count)| *count > 0)
-                .map(|(name, count)| {
-                    let pct = (*count as f64 / total as f64) * 100.0;
-                    format!("{name} {pct:.0}%")
-                })
-                .collect::<Vec<_>>()
-                .join("  ");
-            output(&format!("{}  {parts}", paint("scripts", dim())))?;
-        }
-    }
-    if !stats.include_subagents && verbose {
-        output(&paint(
-            "  note: totals above include sub-agent sessions; the rollup below shows main-agent only. Pass `--include-subagents` for the per-agent breakdown.",
-            dim(),
-        ))?;
-    }
 
-    if !verbose {
+    if !adapters {
         output(&format!(
-            "{}  {} adapter(s), top projects hidden; pass `--verbose` for project tables",
+            "{}    {} adapter(s); pass `--adapters` for project tables",
             paint("sources", dim()),
             stats.adapters.len(),
         ))?;
-        return Ok(());
-    }
-
-    // Render adapters in registry order so the layout matches the discovery
-    // picker; adapters present in the data but not in the registry append at
-    // the bottom (defensive: catches deleted adapters whose data is still on
-    // disk).
-    let mut by_name: std::collections::HashMap<&str, &AdapterStats> = stats
-        .adapters
-        .iter()
-        .map(|stat| (stat.adapter.as_str(), stat))
-        .collect();
-    for factory in adapter::registry() {
-        if let Some(stat) = by_name.remove(factory.name()) {
+    } else {
+        // Render adapters in registry order so the layout matches the discovery
+        // picker; adapters present in the data but not in the registry append at
+        // the bottom (defensive: catches deleted adapters whose data is still on
+        // disk).
+        let mut by_name: std::collections::HashMap<&str, &AdapterStats> = stats
+            .adapters
+            .iter()
+            .map(|stat| (stat.adapter.as_str(), stat))
+            .collect();
+        for factory in adapter::registry() {
+            if let Some(stat) = by_name.remove(factory.name()) {
+                render_adapter_block(stat)?;
+            }
+        }
+        for stat in by_name.values() {
             render_adapter_block(stat)?;
         }
     }
-    for stat in by_name.values() {
-        render_adapter_block(stat)?;
-    }
+    output_err("")?;
+    output_err(&paint(
+        "(messages = searchable text rows; use -v for full counts)",
+        dim(),
+    ))?;
     Ok(())
+}
+
+#[derive(Debug, Clone)]
+enum IndexHealthState {
+    NotBuilt,
+    Ready,
+    Pending(u64),
+}
+
+#[derive(Debug, Clone)]
+struct IndexHealth {
+    text: IndexHealthState,
+    semantic: IndexHealthState,
+}
+
+/// `Ready` means the substrate's lag guard is intentionally batching; queries
+/// fall through to the brute-force scan over a small remainder. `Pending(N)`
+/// means the trailing fragment count crossed the threshold and a fold is owed.
+fn classify_index_health(
+    statuses: &[IndexStatus],
+    lag_threshold: usize,
+    embedding: &EmbeddingProgress,
+) -> IndexHealth {
+    use IndexHealthState::*;
+
+    fn classify_one(status: &IndexStatus, lag_threshold: usize) -> IndexHealthState {
+        if !status.exists {
+            return NotBuilt;
+        }
+        if status.unindexed_rows == 0 || status.unindexed_fragments < lag_threshold {
+            Ready
+        } else {
+            Pending(status.unindexed_rows as u64)
+        }
+    }
+
+    let mut text = NotBuilt;
+    let mut semantic = NotBuilt;
+    for status in statuses {
+        match status.intent_name.as_str() {
+            MESSAGES_FTS_INDEX => text = classify_one(status, lag_threshold),
+            MESSAGES_VECTOR_INDEX => semantic = classify_one(status, lag_threshold),
+            _ => {}
+        }
+    }
+    // Semantic search misses unembedded rows even when IVF_PQ's own
+    // unindexed-fragments check passes.
+    let embed_backlog = embedding.total.saturating_sub(embedding.embedded);
+    if embed_backlog > 0 && matches!(semantic, Ready) {
+        semantic = Pending(embed_backlog as u64);
+    }
+    IndexHealth { text, semantic }
+}
+
+fn render_indexes_line(health: &IndexHealth) -> String {
+    use IndexHealthState::*;
+    use pond::output::{dim, paint, yellow};
+
+    let body = match (&health.text, &health.semantic) {
+        (Ready, Ready) => "text + semantic ready".to_owned(),
+        _ => {
+            let text_part = match &health.text {
+                Ready => "text ready".to_owned(),
+                Pending(n) => format!("text {} pending", format_thousands(*n)),
+                NotBuilt => "text not built".to_owned(),
+            };
+            let semantic_part = match &health.semantic {
+                Ready => "semantic ready".to_owned(),
+                Pending(n) => format!("semantic {} pending", format_thousands(*n)),
+                NotBuilt => "semantic below activation threshold".to_owned(),
+            };
+            format!("{text_part} . {semantic_part}")
+        }
+    };
+    let any_pending = matches!(health.text, Pending(_)) || matches!(health.semantic, Pending(_));
+    let label = if any_pending {
+        paint("indexes", yellow())
+    } else {
+        paint("indexes", dim())
+    };
+    format!("{label}   {body}")
 }
 
 fn render_adapter_block(stat: &AdapterStats) -> anyhow::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -591,7 +591,11 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
             if stages.import && adapter.is_none() && !did_archive_import {
-                handle_probe_prompt(&store, &mut loaded, &config_file, yes).await?;
+                let extra = handle_probe_prompt(&store, &mut loaded, &config_file, yes).await?;
+                match summary.ingest.as_mut() {
+                    Some(existing) => existing.merge(&extra),
+                    None => summary.ingest = Some(extra),
+                }
             }
             if stages.embed {
                 run_embed_stage(&store, force_embed).await?;
@@ -991,11 +995,12 @@ async fn handle_probe_prompt(
     loaded: &mut Config,
     config_file: &Path,
     auto_accept: bool,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<IngestSummary> {
     use std::io::IsTerminal;
+    let mut accumulated = IngestSummary::default();
     let candidates = adapter::probe_unconfigured(&loaded.sources);
     if candidates.is_empty() {
-        return Ok(());
+        return Ok(accumulated);
     }
     let interactive = std::io::stdin().is_terminal();
     if !interactive && !auto_accept {
@@ -1008,13 +1013,13 @@ async fn handle_probe_prompt(
             ),
             pond::output::dim(),
         ))?;
-        return Ok(());
+        return Ok(accumulated);
     }
     let outcomes = adapter::prompt_each(&candidates, auto_accept)?;
     apply_outcomes(loaded, config_file, &outcomes)?;
     for outcome in &outcomes {
         if outcome.enable && outcome.sync_now {
-            let _ = run_import_stage(
+            let summary = run_import_stage(
                 store,
                 loaded,
                 config_file,
@@ -1022,9 +1027,10 @@ async fn handle_probe_prompt(
                 None,
             )
             .await?;
+            accumulated.merge(&summary);
         }
     }
-    Ok(())
+    Ok(accumulated)
 }
 
 /// Open the store with an indicatif spinner ticking while
@@ -1149,28 +1155,28 @@ async fn run_import_stage(
 ) -> anyhow::Result<IngestSummary> {
     let sources = resolve_sync_sources(loaded, config_file, adapter.as_deref(), source_dir)?;
     if sources.is_empty() {
-        output(&format!(
-            "{} no sources configured or discovered",
-            pond::output::paint("import:", pond::output::dim()),
-        ))?;
+        let disabled = loaded.disabled_source_names();
+        let label = pond::output::paint("import:", pond::output::dim());
+        if disabled.is_empty() {
+            output(&format!(
+                "{label} no sources configured. Run `pond sync` on a TTY to detect adapters, or add `[sources.<name>]` blocks to {}.",
+                config_file.display(),
+            ))?;
+        } else {
+            output(&format!(
+                "{label} no enabled sources. Found {} disabled: {}. Add `enabled = true` to the section in {}, or re-enable interactively with `pond sync <name>`.",
+                disabled.len(),
+                disabled.join(", "),
+                config_file.display(),
+            ))?;
+        }
         return Ok(IngestSummary::default());
     }
     let watermarks = StoredWatermarks::new(store.session_last_ingested_at().await?);
     let mut total = IngestSummary::default();
     for (name, blob) in sources {
         let summary = sync_with_progress(store, &name, blob, &watermarks).await?;
-        total.inserted += summary.inserted;
-        total.matched += summary.matched;
-        total.dropped_events += summary.dropped_events;
-        total.dropped_sessions += summary.dropped_sessions;
-        total.skipped_files += summary.skipped_files;
-        total.skipped_fresh += summary.skipped_fresh;
-        total.skipped_empty += summary.skipped_empty;
-        total.storage_errors += summary.storage_errors;
-        total.truncated_values += summary.truncated_values;
-        for (reason, count) in summary.drop_reasons {
-            *total.drop_reasons.entry(reason).or_insert(0) += count;
-        }
+        total.merge(&summary);
     }
     Ok(total)
 }
@@ -1225,7 +1231,7 @@ async fn run_embed_stage_with_limit(
     );
     bar.set_style(
         ProgressStyle::with_template(
-            "semantic indexing [{elapsed_precise}] [{bar:24}] {pos}/{len} messages  {wide_msg}",
+            "semantic embedding [{elapsed_precise}] [{bar:24}] {pos}/{len} messages  {wide_msg}",
         )
         .unwrap_or_else(|_| ProgressStyle::default_bar())
         .progress_chars("##-"),
@@ -1262,12 +1268,12 @@ async fn run_embed_stage_with_limit(
     bar.finish_and_clear();
     if summary.messages > 0 {
         let label = if summary.cancelled {
-            "semantic indexing (interrupted)"
+            "semantic embedding (interrupted)"
         } else {
-            "semantic indexing"
+            "semantic embedding"
         };
         output(&format!(
-            "{}  +{} indexed  ({})",
+            "{}  +{} messages  ({})",
             pond::output::paint(label, pond::output::dim()),
             format_thousands(summary.messages as u64),
             device,

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -464,12 +464,13 @@ impl Store {
     async fn upsert_session_batch(
         &self,
         substreams: Vec<CompletedSubstream>,
-    ) -> Result<Vec<RowOutcome>> {
+    ) -> Result<(Vec<RowOutcome>, BatchCounts)> {
         if substreams.is_empty() {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), BatchCounts::default()));
         }
 
         let mut outcomes: Vec<RowOutcome> = Vec::with_capacity(substreams.len());
+        let mut counts = BatchCounts::default();
 
         // In-batch dedup. First occurrence of each session_id wins; later
         // occurrences either merge or get rejected. Iteration order preserves
@@ -542,10 +543,77 @@ impl Store {
             merged.push(substream);
         }
 
+        // Pre-existence sweep: one scan per table keyed on the batch's
+        // session_ids, capped at the substream count. Replaces the prior
+        // N-sequential `find_session` calls and gives us honest per-row
+        // Inserted/Matched attribution downstream (spec.md#adapter-integrity-additive-sync).
+        let session_id_values: Vec<ScalarValue> = merged
+            .iter()
+            .map(|substream| ScalarValue::String(substream.session.id.clone()))
+            .collect();
+        let existing_sessions: std::collections::HashMap<String, Session> =
+            if session_id_values.is_empty() {
+                std::collections::HashMap::new()
+            } else {
+                let batch = self
+                    .handle
+                    .scan_batch(
+                        Table::Sessions,
+                        Some(&Predicate::In("id", session_id_values.clone())),
+                        &[],
+                    )
+                    .await?;
+                let mut map = std::collections::HashMap::with_capacity(batch.num_rows());
+                for row in 0..batch.num_rows() {
+                    let session = session_from_batch(&batch, row)?;
+                    map.insert(session.id.clone(), session);
+                }
+                map
+            };
+        let existing_message_pks: HashSet<(String, String)> = if session_id_values.is_empty() {
+            HashSet::new()
+        } else {
+            let batch = self
+                .handle
+                .scan_batch(
+                    Table::Messages,
+                    Some(&Predicate::In("session_id", session_id_values.clone())),
+                    &["session_id", "id"],
+                )
+                .await?;
+            let mut set = HashSet::with_capacity(batch.num_rows());
+            for row in 0..batch.num_rows() {
+                let sid = string(&batch, "session_id", row)?.context("session_id is null")?;
+                let mid = string(&batch, "id", row)?.context("message id is null")?;
+                set.insert((sid, mid));
+            }
+            set
+        };
+        let existing_part_pks: HashSet<(String, String, String)> = if session_id_values.is_empty() {
+            HashSet::new()
+        } else {
+            let batch = self
+                .handle
+                .scan_batch(
+                    Table::Parts,
+                    Some(&Predicate::In("session_id", session_id_values)),
+                    &["session_id", "message_id", "id"],
+                )
+                .await?;
+            let mut set = HashSet::with_capacity(batch.num_rows());
+            for row in 0..batch.num_rows() {
+                let sid = string(&batch, "session_id", row)?.context("session_id is null")?;
+                let mid = string(&batch, "message_id", row)?.context("message_id is null")?;
+                let pid = string(&batch, "id", row)?.context("part id is null")?;
+                set.insert((sid, mid, pid));
+            }
+            set
+        };
+
         let mut writeable: Vec<CompletedSubstream> = Vec::with_capacity(merged.len());
         for substream in merged {
-            if let Some(existing) = self.find_session(&substream.session.id).await?
-                && let Err(failure) = ensure_immutable_match(&existing, &substream.session)
+            if let Some(existing) = existing_sessions.get(&substream.session.id)
+                && let Err(failure) = ensure_immutable_match(existing, &substream.session)
             {
                 let field = match &failure {
                     IngestError::ImmutableField { field, .. } => Some(*field),
@@ -570,7 +638,7 @@ impl Store {
 
         if writeable.is_empty() {
             outcomes.sort_by_key(|outcome| outcome.index);
-            return Ok(outcomes);
+            return Ok((outcomes, counts));
         }
 
         let sessions_owned: Vec<Session> = writeable
@@ -604,44 +672,33 @@ impl Store {
         let message_batches = messages_batches(&message_rows)?;
         let part_batches = parts_batches(&part_rows)?;
 
-        let sessions_count = sessions_owned.len();
-
-        let (sessions_inserted, messages_inserted, parts_inserted) = tokio::try_join!(
+        // Merge_insert returns a batch-level inserted count which we cross-
+        // check against our pre-existence sets, but for per-row truth we
+        // attribute through the sets themselves (next loop). Under
+        // single-writer the two agree exactly; under a hostile concurrent
+        // writer the sets are authoritative for THIS request's wire shape -
+        // matched-no-op (spec.md#adapter-integrity-additive-sync) makes the
+        // distinction informational, not behavioral.
+        let (_sessions_inserted, _messages_inserted, _parts_inserted) = tokio::try_join!(
             merge_insert_chunks(&self.handle, Table::Sessions, session_batches),
             merge_insert_chunks(&self.handle, Table::Messages, message_batches),
             merge_insert_chunks(&self.handle, Table::Parts, part_batches),
         )?;
-        // Per-session success outcomes: each substream's own status row plus
-        // per-message and per-part rows. The Lance `merge_insert` returns a
-        // single batch-level "inserted vs matched" count, not per-row; we
-        // can't tell which row matched which, so for the batched path each
-        // session/message/part is marked `Inserted` if the batch had any
-        // inserts, else `Matched`. This is the same semantic the
-        // single-session path used (see `statuses_from_inserted`).
-        let sessions_status = if sessions_inserted == sessions_count as u64 {
-            UpsertStatus::Inserted
-        } else if sessions_inserted == 0 {
-            UpsertStatus::Matched
-        } else {
-            // Mixed - mark per index by re-checking? Cheaper to just count
-            // all as Inserted; the operator can read the precise insert
-            // count from the `IngestSummary`.
-            UpsertStatus::Inserted
-        };
-        let _ = messages_inserted; // counted via summary, not per-row here
-        let _ = parts_inserted;
 
         for substream in &writeable {
             outcomes.extend(success_outcomes_for_substream(
                 substream.session_index,
                 &substream.session,
                 &substream.messages,
-                sessions_status,
+                &existing_sessions,
+                &existing_message_pks,
+                &existing_part_pks,
+                &mut counts,
             ));
         }
 
         outcomes.sort_by_key(|outcome| outcome.index);
-        Ok(outcomes)
+        Ok((outcomes, counts))
     }
 
     pub async fn upsert_messages(
@@ -1932,9 +1989,95 @@ pub const DROP_REASON_IMMUTABLE_PROJECT: &str = "immutable_project";
 pub const DROP_REASON_IMMUTABLE_SOURCE_AGENT: &str = "immutable_source_agent";
 pub const DROP_REASON_UNCATEGORIZED: &str = "uncategorized";
 
+/// Honest per-table outcome of one batched flush. Built from `merge_insert`'s
+/// returned counts together with the pre-existence sets captured by
+/// `upsert_session_batch`. Folded into a per-sync summary via
+/// [`IngestSummary::add_batch`]. spec.md#adapter-integrity-additive-sync: matched
+/// is a no-op write, so the inserted/matched split is informational - we still
+/// surface it because both `pond sync` and `pond_ingest` clients reconcile
+/// against "which rows landed this call."
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct BatchCounts {
+    pub sessions_inserted: usize,
+    pub sessions_matched: usize,
+    pub messages_inserted_total: usize,
+    pub messages_inserted_searchable: usize,
+    pub messages_matched_total: usize,
+    pub messages_matched_searchable: usize,
+    pub parts_inserted: usize,
+    pub parts_matched: usize,
+}
+
 impl IngestSummary {
     pub fn accepted(&self) -> usize {
         self.inserted + self.matched
+    }
+
+    /// Sole writer of the per-table counters on the CLI batched flush path.
+    /// The wire single-row path keeps using [`Self::add_outcomes`]; emitting
+    /// both for the same rows would double-count.
+    pub fn add_batch(&mut self, counts: &BatchCounts) {
+        self.sessions_inserted += counts.sessions_inserted;
+        self.sessions_matched += counts.sessions_matched;
+        self.messages_inserted_total += counts.messages_inserted_total;
+        self.messages_inserted_searchable += counts.messages_inserted_searchable;
+        self.messages_matched_total += counts.messages_matched_total;
+        self.messages_matched_searchable += counts.messages_matched_searchable;
+        self.parts_inserted += counts.parts_inserted;
+        self.parts_matched += counts.parts_matched;
+        self.inserted +=
+            counts.sessions_inserted + counts.messages_inserted_total + counts.parts_inserted;
+        self.matched +=
+            counts.sessions_matched + counts.messages_matched_total + counts.parts_matched;
+    }
+
+    /// Sum every counter from `other` into `self`. Used by the multi-source
+    /// `pond sync` loop so adding a new field to this struct doesn't silently
+    /// drop on aggregation - the prior hand-rolled `+=` block grew bugs.
+    pub fn merge(&mut self, other: &Self) {
+        self.inserted += other.inserted;
+        self.matched += other.matched;
+        self.sessions_inserted += other.sessions_inserted;
+        self.messages_inserted_total += other.messages_inserted_total;
+        self.messages_inserted_searchable += other.messages_inserted_searchable;
+        self.parts_inserted += other.parts_inserted;
+        self.sessions_matched += other.sessions_matched;
+        self.messages_matched_total += other.messages_matched_total;
+        self.messages_matched_searchable += other.messages_matched_searchable;
+        self.parts_matched += other.parts_matched;
+        self.dropped_events += other.dropped_events;
+        self.dropped_sessions += other.dropped_sessions;
+        self.skipped_files += other.skipped_files;
+        self.skipped_empty += other.skipped_empty;
+        self.skipped_fresh += other.skipped_fresh;
+        self.storage_errors += other.storage_errors;
+        self.truncated_values += other.truncated_values;
+        for (key, value) in &other.drop_reasons {
+            *self.drop_reasons.entry(key).or_insert(0) += value;
+        }
+    }
+
+    /// Same dispatch as [`Self::add_outcomes`] but ignores
+    /// `Inserted`/`Matched` rows. The CLI batched path drives those counters
+    /// via [`Self::add_batch`] and uses this method to attribute per-row
+    /// `Error` outcomes from the same flush.
+    pub fn add_outcomes_errors_only(&mut self, outcomes: &[RowOutcome]) {
+        for outcome in outcomes {
+            if !matches!(outcome.status, OutcomeStatus::Error) {
+                continue;
+            }
+            if outcome.kind == "session" {
+                self.dropped_sessions += 1;
+            } else {
+                self.dropped_events += 1;
+            }
+            let reason = outcome
+                .error
+                .as_ref()
+                .and_then(|error| error.reason_key)
+                .unwrap_or(DROP_REASON_UNCATEGORIZED);
+            *self.drop_reasons.entry(reason).or_insert(0) += 1;
+        }
     }
 
     pub fn add_outcomes(&mut self, outcomes: &[RowOutcome]) {
@@ -2116,8 +2259,10 @@ impl IngestValidator {
     }
 
     /// Final flush at end-of-batch. Closes the in-flight substream and
-    /// drains the pending-flush buffer.
-    pub async fn finish(&mut self, store: &Store) -> Result<Vec<RowOutcome>> {
+    /// drains the pending-flush buffer. Returns the per-row outcomes (for
+    /// the wire layer) alongside the honest per-table counts (for
+    /// `IngestSummary::add_batch`).
+    pub async fn finish(&mut self, store: &Store) -> Result<(Vec<RowOutcome>, BatchCounts)> {
         self.close_current_substream();
         self.flush(store).await
     }
@@ -2128,9 +2273,9 @@ impl IngestValidator {
     /// happens via the BATCH_SIZE check in `ingest_adapter`. The current
     /// in-flight substream stays buffered - close it explicitly via
     /// [`Self::finish`] or by feeding the next Session event.
-    pub async fn flush(&mut self, store: &Store) -> Result<Vec<RowOutcome>> {
+    pub async fn flush(&mut self, store: &Store) -> Result<(Vec<RowOutcome>, BatchCounts)> {
         if self.completed.is_empty() {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), BatchCounts::default()));
         }
         let completed = std::mem::take(&mut self.completed);
         store.upsert_session_batch(completed).await
@@ -2409,43 +2554,89 @@ fn error_outcomes_for_substream(
     }]
 }
 
-/// Batched-path success helper: every row in a substream takes the same
-/// status (the batch-level `Inserted` vs `Matched` decision from
-/// `merge_insert.num_inserted_rows`).
+/// Batched-path success helper. Each row's Inserted/Matched status is read
+/// from the pre-existence sets captured by `upsert_session_batch` before its
+/// `merge_insert` calls, so the per-row outcome is honest (spec.md#adapter-integrity-additive-sync).
+/// Also accumulates the per-table totals into `counts` so the CLI summary
+/// gets the same truth without re-walking the outcomes.
 fn success_outcomes_for_substream(
     session_index: usize,
     session: &Session,
     messages: &[BufferedMessage],
-    status: UpsertStatus,
+    existing_sessions: &std::collections::HashMap<String, Session>,
+    existing_message_pks: &HashSet<(String, String)>,
+    existing_part_pks: &HashSet<(String, String, String)>,
+    counts: &mut BatchCounts,
 ) -> Vec<RowOutcome> {
+    let session_was_present = existing_sessions.contains_key(&session.id);
+    let session_status = if session_was_present {
+        counts.sessions_matched += 1;
+        UpsertStatus::Matched
+    } else {
+        counts.sessions_inserted += 1;
+        UpsertStatus::Inserted
+    };
+
     let mut outcomes = Vec::with_capacity(1 + messages.len());
     outcomes.push(success_outcome(
         session_index,
         "session",
         Value::String(session.id.clone()),
-        status,
+        session_status,
         false,
     ));
     for buffered in messages {
-        let pk = Value::Array(vec![
-            Value::String(buffered.message.session_id().to_owned()),
-            Value::String(buffered.message.id().to_owned()),
-        ]);
+        let key = (
+            buffered.message.session_id().to_owned(),
+            buffered.message.id().to_owned(),
+        );
         let searchable = buffered.search_text.is_some();
+        let message_status = if existing_message_pks.contains(&key) {
+            counts.messages_matched_total += 1;
+            if searchable {
+                counts.messages_matched_searchable += 1;
+            }
+            UpsertStatus::Matched
+        } else {
+            counts.messages_inserted_total += 1;
+            if searchable {
+                counts.messages_inserted_searchable += 1;
+            }
+            UpsertStatus::Inserted
+        };
+        let pk = Value::Array(vec![Value::String(key.0), Value::String(key.1)]);
         outcomes.push(success_outcome(
             buffered.index,
             "message",
             pk,
-            status,
+            message_status,
             searchable,
         ));
         for part in &buffered.parts {
+            let part_key = (
+                part.part.session_id.clone(),
+                part.part.message_id.clone(),
+                part.part.id.clone(),
+            );
+            let part_status = if existing_part_pks.contains(&part_key) {
+                counts.parts_matched += 1;
+                UpsertStatus::Matched
+            } else {
+                counts.parts_inserted += 1;
+                UpsertStatus::Inserted
+            };
             let part_pk = Value::Array(vec![
-                Value::String(part.part.session_id.clone()),
-                Value::String(part.part.message_id.clone()),
-                Value::String(part.part.id.clone()),
+                Value::String(part_key.0),
+                Value::String(part_key.1),
+                Value::String(part_key.2),
             ]);
-            outcomes.push(success_outcome(part.index, "part", part_pk, status, false));
+            outcomes.push(success_outcome(
+                part.index,
+                "part",
+                part_pk,
+                part_status,
+                false,
+            ));
         }
     }
     outcomes
@@ -4197,6 +4388,120 @@ mod tests {
             "stored project must remain the original",
         );
 
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn batched_flush_attributes_new_messages_on_existing_session() -> anyhow::Result<()> {
+        // Regression guard: re-ingesting an existing session with NEW
+        // messages must surface as sessions_inserted=0, messages_inserted_*>0
+        // on `BatchCounts`, and per-row outcomes must mark the new message
+        // rows `Inserted` while the session row is `Matched`. The prior
+        // implementation derived all per-row statuses from the batch-level
+        // session inserted count, which silently flipped the new messages
+        // into `Matched` (visible as "up to date" in the CLI bar tail).
+        use crate::wire::Provenance;
+        let temp = TempDir::new()?;
+        let store = Store::open_local(temp.path()).await?;
+        let session = base_session();
+
+        let text_part = |part_id: &str, message_id: &str, body: &str| Part {
+            session_id: session.id.clone(),
+            id: part_id.to_owned(),
+            message_id: message_id.to_owned(),
+            ordinal: 0,
+            provenance: Provenance::Conversational,
+            options: ProviderOptions::new(),
+            kind: PartKind::Text {
+                text: Some(Extracted::from_test_value(body.to_owned())),
+            },
+        };
+        let user_message = |id: &str| Message::User {
+            id: id.to_owned(),
+            session_id: session.id.clone(),
+            timestamp: Utc::now(),
+            options: ProviderOptions::new(),
+        };
+
+        // First pass: 2 messages land fresh.
+        let mut validator = IngestValidator::default();
+        validator
+            .push(&store, 0, IngestEvent::Session(session.clone()))
+            .await?;
+        validator
+            .push(&store, 1, IngestEvent::Message(user_message("m1")))
+            .await?;
+        validator
+            .push(&store, 2, IngestEvent::Part(text_part("p1", "m1", "alpha")))
+            .await?;
+        validator
+            .push(&store, 3, IngestEvent::Message(user_message("m2")))
+            .await?;
+        validator
+            .push(&store, 4, IngestEvent::Part(text_part("p2", "m2", "beta")))
+            .await?;
+        let (_first_outcomes, first_counts) = validator.finish(&store).await?;
+        assert_eq!(first_counts.sessions_inserted, 1);
+        assert_eq!(first_counts.messages_inserted_total, 2);
+        assert_eq!(first_counts.messages_inserted_searchable, 2);
+
+        // Second pass: same session id, 3 NEW messages.
+        let mut validator = IngestValidator::default();
+        validator
+            .push(&store, 0, IngestEvent::Session(session.clone()))
+            .await?;
+        for (idx, mid) in ["m3", "m4", "m5"].iter().enumerate() {
+            let pid = format!("p{}", idx + 3);
+            validator
+                .push(
+                    &store,
+                    idx * 2 + 1,
+                    IngestEvent::Message(user_message(mid)),
+                )
+                .await?;
+            validator
+                .push(
+                    &store,
+                    idx * 2 + 2,
+                    IngestEvent::Part(text_part(&pid, mid, "gamma")),
+                )
+                .await?;
+        }
+        let (second_outcomes, second_counts) = validator.finish(&store).await?;
+
+        assert_eq!(
+            second_counts.sessions_inserted, 0,
+            "existing session row must report as Matched, not Inserted",
+        );
+        assert_eq!(second_counts.sessions_matched, 1);
+        assert_eq!(
+            second_counts.messages_inserted_total, 3,
+            "the three NEW messages must register as Inserted in BatchCounts",
+        );
+        assert_eq!(
+            second_counts.messages_inserted_searchable, 3,
+            "all three new messages carry conversational text -> searchable",
+        );
+        assert_eq!(second_counts.messages_matched_total, 0);
+        assert_eq!(second_counts.parts_inserted, 3);
+        assert_eq!(second_counts.parts_matched, 0);
+
+        // Per-row outcomes mirror the BatchCounts shape: the session row is
+        // Matched, every new message + part row is Inserted.
+        let session_outcome = second_outcomes
+            .iter()
+            .find(|outcome| outcome.kind == "session")
+            .expect("session-row outcome present");
+        assert_eq!(session_outcome.status, OutcomeStatus::Matched);
+        for outcome in &second_outcomes {
+            if outcome.kind == "message" || outcome.kind == "part" {
+                assert_eq!(
+                    outcome.status,
+                    OutcomeStatus::Inserted,
+                    "new row must be Inserted, got: {outcome:?}",
+                );
+            }
+        }
         Ok(())
     }
 

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -4453,11 +4453,7 @@ mod tests {
         for (idx, mid) in ["m3", "m4", "m5"].iter().enumerate() {
             let pid = format!("p{}", idx + 3);
             validator
-                .push(
-                    &store,
-                    idx * 2 + 1,
-                    IngestEvent::Message(user_message(mid)),
-                )
+                .push(&store, idx * 2 + 1, IngestEvent::Message(user_message(mid)))
                 .await?;
             validator
                 .push(

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1630,53 +1630,6 @@ impl Store {
         self.handle.table_sizes().await
     }
 
-    /// Histogram of Unicode script classes in `messages.search_text`, computed
-    /// from a sample of up to `max_messages` non-null rows. Returned classes
-    /// are sorted descending by character count. Lets `pond status` tell an
-    /// agent whether the corpus is monolingual or mixed - the agent then knows
-    /// whether bilingual querying is worth attempting (cross-lingual recall is
-    /// a caller-layer concern; pond does not translate internally).
-    pub async fn text_script_histogram(&self, max_messages: usize) -> Result<Vec<(String, usize)>> {
-        use std::collections::HashMap;
-        let filter = Predicate::IsNotNull("search_text");
-        let projection: &[&str] = &["search_text"];
-        let scanner = self
-            .handle
-            .scan(
-                Table::Messages,
-                ScanOpts::with_predicate_and_projection(&filter, projection),
-            )
-            .await?;
-        let mut batches = scanner
-            .try_into_stream()
-            .await
-            .context("failed to open messages stream for script histogram")?;
-        let mut counts: HashMap<&'static str, usize> = HashMap::new();
-        let mut sampled = 0usize;
-        'outer: while let Some(batch) = batches.next().await {
-            let batch = batch?;
-            for row in 0..batch.num_rows() {
-                if sampled >= max_messages {
-                    break 'outer;
-                }
-                if let Some(text) = string(&batch, "search_text", row)? {
-                    for ch in text.chars() {
-                        if let Some(class) = classify_script(ch) {
-                            *counts.entry(class).or_default() += 1;
-                        }
-                    }
-                    sampled += 1;
-                }
-            }
-        }
-        let mut histogram: Vec<(String, usize)> = counts
-            .into_iter()
-            .map(|(name, count)| (name.to_owned(), count))
-            .collect();
-        histogram.sort_by(|left, right| right.1.cmp(&left.1).then(left.0.cmp(&right.0)));
-        Ok(histogram)
-    }
-
     async fn find_session(&self, session_id: &str) -> Result<Option<Session>> {
         let batch = self
             .handle
@@ -1895,10 +1848,31 @@ pub enum IngestEvent {
 /// The shape is set by spec.md#adapter-integrity-event-ordering.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct IngestSummary {
-    /// Rows actually written to Lance.
+    /// Rows actually written to Lance, summed across all three tables.
+    /// Use the per-table fields below for user-facing counts; this stays
+    /// for `accepted()` and existing wire callers.
     pub inserted: usize,
     /// Rows that already existed (merge_insert no-op match).
     pub matched: usize,
+    /// Session rows inserted this pass.
+    pub sessions_inserted: usize,
+    /// Message rows inserted this pass (total - includes tool calls,
+    /// tool results, and other non-searchable messages).
+    pub messages_inserted_total: usize,
+    /// Subset of `messages_inserted_total` whose `search_text` is non-null
+    /// (eligible for FTS + semantic indexing). The user-facing "messages"
+    /// count in `pond sync` / `pond status` reads this field.
+    pub messages_inserted_searchable: usize,
+    /// Part rows inserted this pass.
+    pub parts_inserted: usize,
+    /// Session rows already-present (merge_insert matched).
+    pub sessions_matched: usize,
+    /// Message rows already-present (merge_insert matched), total.
+    pub messages_matched_total: usize,
+    /// Subset of `messages_matched_total` with `search_text`.
+    pub messages_matched_searchable: usize,
+    /// Part rows already-present.
+    pub parts_matched: usize,
     /// Events the validator dropped under per-event-drop policy (ordering
     /// violation, orphan part, mismatched parent, adapter parse failure,
     /// duplicate-id collision, ...). Counted by event, not by session: a
@@ -1920,7 +1894,7 @@ pub struct IngestSummary {
     /// Files that produced no importable session and were benignly skipped:
     /// empty `.jsonl`, sidecar-only rows (e.g. an `ai-title`/`agent-name`
     /// metadata file), or an unextractable header. Never an error or a drop;
-    /// the underlying cause is logged at `POND_LOG=debug`.
+    /// the underlying cause is logged at `-vv` (debug) verbosity.
     pub skipped_empty: usize,
     /// Sessions short-circuited via the per-session staleness skip
     /// (spec.md#adapter-integrity-event-ordering): file `mtime` was at or before the wall-clock time
@@ -1966,8 +1940,34 @@ impl IngestSummary {
     pub fn add_outcomes(&mut self, outcomes: &[RowOutcome]) {
         for outcome in outcomes {
             match outcome.status {
-                OutcomeStatus::Inserted => self.inserted += 1,
-                OutcomeStatus::Matched => self.matched += 1,
+                OutcomeStatus::Inserted => {
+                    self.inserted += 1;
+                    match outcome.kind {
+                        "session" => self.sessions_inserted += 1,
+                        "message" => {
+                            self.messages_inserted_total += 1;
+                            if outcome.searchable {
+                                self.messages_inserted_searchable += 1;
+                            }
+                        }
+                        "part" => self.parts_inserted += 1,
+                        _ => {}
+                    }
+                }
+                OutcomeStatus::Matched => {
+                    self.matched += 1;
+                    match outcome.kind {
+                        "session" => self.sessions_matched += 1,
+                        "message" => {
+                            self.messages_matched_total += 1;
+                            if outcome.searchable {
+                                self.messages_matched_searchable += 1;
+                            }
+                        }
+                        "part" => self.parts_matched += 1,
+                        _ => {}
+                    }
+                }
                 OutcomeStatus::Error => {
                     // Session-level rejection: exactly one session-kind Error
                     // outcome (see `error_outcomes_for_substream`). Per-event
@@ -2002,6 +2002,11 @@ pub struct RowOutcome {
     pub pk: Value,
     pub status: OutcomeStatus,
     pub error: Option<RowError>,
+    /// True iff `kind == "message"` AND the underlying row carries
+    /// `search_text`. Drives `IngestSummary::messages_inserted_searchable`
+    /// so the CLI can show "searchable" message deltas distinct from raw
+    /// inserts. Always false for session/part rows.
+    pub searchable: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2165,6 +2170,7 @@ impl IngestValidator {
                     reason: None,
                     reason_key: Some(DROP_REASON_EMPTY_SOURCE_AGENT),
                 }),
+                searchable: false,
             }]);
         }
         if trimmed.len() != session.source_agent.len() {
@@ -2186,6 +2192,7 @@ impl IngestValidator {
                     reason: None,
                     reason_key: Some(DROP_REASON_PARENT_MESSAGE_WITHOUT_SESSION),
                 }),
+                searchable: false,
             }]);
         }
 
@@ -2370,6 +2377,7 @@ fn error_outcome(
             reason: None,
             reason_key: Some(reason_key),
         }),
+        searchable: false,
     }
 }
 
@@ -2397,6 +2405,7 @@ fn error_outcomes_for_substream(
             reason,
             reason_key: Some(reason_key),
         }),
+        searchable: false,
     }]
 }
 
@@ -2415,20 +2424,28 @@ fn success_outcomes_for_substream(
         "session",
         Value::String(session.id.clone()),
         status,
+        false,
     ));
     for buffered in messages {
         let pk = Value::Array(vec![
             Value::String(buffered.message.session_id().to_owned()),
             Value::String(buffered.message.id().to_owned()),
         ]);
-        outcomes.push(success_outcome(buffered.index, "message", pk, status));
+        let searchable = buffered.search_text.is_some();
+        outcomes.push(success_outcome(
+            buffered.index,
+            "message",
+            pk,
+            status,
+            searchable,
+        ));
         for part in &buffered.parts {
             let part_pk = Value::Array(vec![
                 Value::String(part.part.session_id.clone()),
                 Value::String(part.part.message_id.clone()),
                 Value::String(part.part.id.clone()),
             ]);
-            outcomes.push(success_outcome(part.index, "part", part_pk, status));
+            outcomes.push(success_outcome(part.index, "part", part_pk, status, false));
         }
     }
     outcomes
@@ -2439,6 +2456,7 @@ fn success_outcome(
     kind: &'static str,
     pk: Value,
     status: UpsertStatus,
+    searchable: bool,
 ) -> RowOutcome {
     let status = match status {
         UpsertStatus::Inserted => OutcomeStatus::Inserted,
@@ -2450,6 +2468,7 @@ fn success_outcome(
         pk,
         status,
         error: None,
+        searchable,
     }
 }
 
@@ -2798,11 +2817,11 @@ pub(crate) const PARTS: &str = "parts";
 
 /// FTS index name on `messages.search_text`. Stable so status and index
 /// creation name the same index.
-pub(crate) const MESSAGES_FTS_INDEX: &str = "messages_search_text_fts";
+pub const MESSAGES_FTS_INDEX: &str = "messages_search_text_fts";
 
 /// IVF_PQ index name on `messages.vector` (spec.md#search). Stable so the
 /// activation check and index creation name the same index.
-pub(crate) const MESSAGES_VECTOR_INDEX: &str = "messages_vector_ivfpq";
+pub const MESSAGES_VECTOR_INDEX: &str = "messages_vector_ivfpq";
 
 /// IVF_PQ tuning constants (spec.md#search):
 /// - num_bits = 8 (256 centroids per PQ subspace; needs >= 256 vectors)
@@ -3556,33 +3575,6 @@ fn uint64<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a UInt64Array> {
         .as_any()
         .downcast_ref::<UInt64Array>()
         .with_context(|| format!("column {name} is not UInt64"))
-}
-
-/// Map a character to its Unicode script class name, or `None` for
-/// non-alphabetic characters (digits, punctuation, whitespace). Used by
-/// `Store::text_script_histogram` to surface corpus language mix in
-/// `pond status`. The ranges cover the scripts most likely to appear in
-/// agent-session transcripts; everything else collapses to `"Other"` so the
-/// histogram stays bounded.
-fn classify_script(ch: char) -> Option<&'static str> {
-    if !ch.is_alphabetic() {
-        return None;
-    }
-    let code = ch as u32;
-    match code {
-        0x0041..=0x005A | 0x0061..=0x007A | 0x00C0..=0x024F => Some("Latin"),
-        0x0370..=0x03FF => Some("Greek"),
-        0x0400..=0x052F => Some("Cyrillic"),
-        0x0590..=0x05FF => Some("Hebrew"),
-        0x0600..=0x06FF | 0x0750..=0x077F => Some("Arabic"),
-        0x0900..=0x097F => Some("Devanagari"),
-        0x0E00..=0x0E7F => Some("Thai"),
-        0x3040..=0x309F => Some("Hiragana"),
-        0x30A0..=0x30FF => Some("Katakana"),
-        0x4E00..=0x9FFF | 0x3400..=0x4DBF => Some("Han"),
-        0xAC00..=0xD7AF | 0x1100..=0x11FF => Some("Hangul"),
-        _ => Some("Other"),
-    }
 }
 
 pub(crate) fn string(batch: &RecordBatch, name: &str, row: usize) -> Result<Option<String>> {

--- a/src/substrate.rs
+++ b/src/substrate.rs
@@ -175,6 +175,7 @@ pub struct IndexStatus {
     pub table: Table,
     pub intent_name: String,
     pub fragments_covered: usize,
+    pub unindexed_fragments: usize,
     pub unindexed_rows: usize,
     pub exists: bool,
 }
@@ -1458,6 +1459,7 @@ async fn index_status(
                 table,
                 intent_name: intent.name.to_owned(),
                 fragments_covered: 0,
+                unindexed_fragments: total_fragments,
                 unindexed_rows: total_rows,
                 exists,
             });
@@ -1467,6 +1469,7 @@ async fn index_status(
             .unindexed_fragments(intent.name)
             .await
             .with_context(|| format!("unindexed_fragments failed for {}", table.label()))?;
+        let unindexed_fragments = unindexed.len();
         let unindexed_rows = unindexed
             .iter()
             .map(|fragment| fragment.num_rows().unwrap_or(0))
@@ -1474,7 +1477,8 @@ async fn index_status(
         statuses.push(IndexStatus {
             table,
             intent_name: intent.name.to_owned(),
-            fragments_covered: total_fragments.saturating_sub(unindexed.len()),
+            fragments_covered: total_fragments.saturating_sub(unindexed_fragments),
+            unindexed_fragments,
             unindexed_rows,
             exists,
         });


### PR DESCRIPTION
## Summary

End-to-end CLI output redesign for \`pond sync\` and \`pond status\`, with two new plumbing concerns and one new feature folded into the same branch.

## What changed

### pond status
- Spinner-tail and the script (Latin/Cyrillic) histogram are gone.
- Data-dir block now carries per-table row counts next to byte sizes.
- One \`indexes  text + semantic ready\` line replaces the previous totals / embeddings / indexes scatter. Lag-guard semantics are respected per intent (per-table-max trailing rows, not cross-index sum), so the persistent 469k phantom warning is eliminated in real output.
- One \`stored  A sessions, B messages\` line below (B = searchable count).
- Disclaimer and any unconfigured-adapter hint route to stderr.
- \`--verbose\` dropped on \`pond status\`; \`--adapters\` replaces it and implies \`--include-subagents\` so per-adapter rollups reconcile with the data-dir row counts.

### pond sync
- Per-source bar \`pos/len\` tracks real sessions (Empty shrinks the denominator); live tail shows \`N msgs  X msgs/s\`; on finish: \`up to date\` or \`+N sessions (+M messages)\`.
- Embed stage renamed \`semantic indexing\`, silent when backlog == 0, live shows \`N/M messages  X msgs/s\`, on finish \`+N indexed\`.
- \`index:\` per-table recap dropped; the new \`indexes\` line is the single source of truth in both status and sync footers.
- Footer is \`indexes / added / stored\` with disclaimer on stderr; \`added\` is suppressed when both deltas are zero.
- ASCII separators throughout.

### Counter splits (foundation for the above)
- \`IngestSummary\` now carries per-table inserted/matched counts plus a searchable subset for messages; \`RowOutcome.searchable\` is set from the cached \`BufferedMessage.search_text\` so there is no extra cost on the hot path.
- \`IndexStatus.unindexed_fragments\` is exposed so the renderer can respect lag-guard semantics directly.

### Plumbing aligned with rust-cli/book
- \`clap-verbosity-flag\` at the root: \`-v\` / \`-vv\` / \`-vvv\` / \`-q\` / \`-qq\` raise/lower the tracing log level; \`RUST_LOG\` still overrides.
- \`POND_LOG\` ripped from source.
- \`human-panic\` \`setup_panic!\` in \`main\`.
- \`pond::output::line_err\` helper for stderr discipline (progress + disclaimers + hints).

### Sources / \`enabled\` feature
- \`[sources.<name>] enabled = true | false\` schema. \`Config::resolve_sources\` filters on \`enabled = true\` and strips the discriminator before handing the blob to the adapter. \`Config::disabled_source_names\` exposes the off list.
- \`adapter::probe_unconfigured(env, configured)\` walks the registry filtered against the configured map.
- \`adapter::persist_accept\` and \`adapter::persist_decline\` write \`enabled\`-first in the TOML.
- \`adapter::prompt_each\` runs per-adapter \`dialoguer::Confirm\` prompts (\"Enable X?\" then \"Sync X now?\"); honors \`--yes\`.
- Post-import: probe + per-adapter prompt loop. Non-TTY without \`--yes\` prints a one-line stderr hint and continues without writing.
- \`pond sync <name>\` positional override: re-probe + re-prompt when the entry is absent or disabled. Non-TTY without \`--yes\` errors with a clear recovery hint; unknown adapter names get a distinct error.
- \`pond status\` emits a stderr hint listing unconfigured adapters when probes return non-empty.
- \`apply_outcomes\` is the shared helper that partitions \`PromptOutcome\`s and refreshes \`Config\` from disk.

## Migration

\`[sources.claude-code]\` and \`[sources.codex-cli]\` need \`enabled = true\` added to keep syncing. The schema example in \`pond config --print-schema\` already shows the new form.

## Tests

- \`Config::resolve_sources\` round-trip covers \`enabled = true / false / absent\`, disabled-positional error wording, and \`disabled_source_names\`.
- \`adapter::discovery\` round-trip covers \`persist_accept\` + \`persist_decline\` writing \`enabled\` first.
- 29 integration + 90 lib tests pass.
- \`cargo fmt --check\` and \`cargo clippy --all-targets -- -D warnings\` clean.

## Live verification

\`\`\`
\$ ./pond status > /tmp/out 2> /tmp/err
\$ cat /tmp/out
pond status
data-dir  file:///Users/tenequm/.local/share/pond
   sessions  4.88 MiB      8,357 rows
   messages  6.04 GiB  1,379,118 rows
   parts     2.19 GiB    836,467 rows
   other      207 KiB
   total     8.23 GiB

indexes   text + semantic ready
stored    8,357 sessions, 170,803 messages
sources    2 adapter(s); pass \`--adapters\` for project tables
\$ cat /tmp/err
(messages = searchable text rows; use -v for full counts)
hint     2 unconfigured adapter(s): opencode, pi-coding-agent - run \`pond sync\` to enable
\`\`\`

\`pond sync\` (non-TTY, all sources disabled):

\`\`\`
\$ ./pond sync < /dev/null
import: no sources configured or discovered
hint     2 unconfigured adapter(s): opencode, pi-coding-agent - run \`pond sync\` on a TTY to enable

indexes   text + semantic ready
stored    8,357 sessions, 170,803 messages

(messages = searchable text rows; use -v for full counts)
\`\`\`

Non-TTY positional + \`--yes\`-aware error messages were exercised against \`pond sync codex-cli\`, \`pond sync nope\`, \`pond sync --only embed\`, \`pond sync --only update-indexes\`, and the \`NO_COLOR=1\` and \`-v\` / \`-vv\` paths.