### PR TITLE
refactor(sessions): drop dead statuses_from_inserted smudge

### DIFF
--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -428,14 +428,18 @@ impl Store {
         Ok((rows, inserted))
     }
 
-    pub async fn upsert_sessions(&self, sessions: &[Session]) -> Result<Vec<UpsertStatus>> {
+    /// Test-helper convenience: single-table session upsert. Returns `()`
+    /// because per-row Inserted/Matched truth requires the pre-existence
+    /// scan that `upsert_session_batch` does for honest attribution; the
+    /// flat-write path here doesn't reconstruct that and callers (all in
+    /// tests) only assert on stored state.
+    pub async fn upsert_sessions(&self, sessions: &[Session]) -> Result<()> {
         if sessions.is_empty() {
-            return Ok(Vec::new());
+            return Ok(());
         }
         let batches = sessions_batches(sessions)?;
-        let inserted = merge_insert_chunks(&self.handle, Table::Sessions, batches).await?;
-        // Per-row outcomes; no fold here (see `pond index optimize`).
-        Ok(statuses_from_inserted(sessions.len(), inserted))
+        merge_insert_chunks(&self.handle, Table::Sessions, batches).await?;
+        Ok(())
     }
 
     /// Batched write path used by the adapter ingest loop and by the wire
@@ -705,9 +709,9 @@ impl Store {
         &self,
         session: &Session,
         messages: &[MessageWrite<'_>],
-    ) -> Result<Vec<UpsertStatus>> {
+    ) -> Result<()> {
         if messages.is_empty() {
-            return Ok(Vec::new());
+            return Ok(());
         }
 
         let rows = messages
@@ -720,17 +724,17 @@ impl Store {
             })
             .collect::<Vec<_>>();
         let batches = messages_batches(&rows)?;
-        let inserted = merge_insert_chunks(&self.handle, Table::Messages, batches).await?;
-        Ok(statuses_from_inserted(messages.len(), inserted))
+        merge_insert_chunks(&self.handle, Table::Messages, batches).await?;
+        Ok(())
     }
 
-    pub async fn upsert_parts(&self, parts: &[Part]) -> Result<Vec<UpsertStatus>> {
+    pub async fn upsert_parts(&self, parts: &[Part]) -> Result<()> {
         if parts.is_empty() {
-            return Ok(Vec::new());
+            return Ok(());
         }
         let batches = parts_batches(parts)?;
-        let inserted = merge_insert_chunks(&self.handle, Table::Parts, batches).await?;
-        Ok(statuses_from_inserted(parts.len(), inserted))
+        merge_insert_chunks(&self.handle, Table::Parts, batches).await?;
+        Ok(())
     }
 
     pub async fn get_session(&self, session_id: &str) -> Result<Option<SessionWithMessages>> {
@@ -2984,19 +2988,6 @@ fn in_predicate(column: &'static str, values: &[String]) -> Predicate {
 /// the configured model" - no per-row `embedding_model` filter needed.
 fn embedded_scope(filter: &Predicate) -> Predicate {
     Predicate::And(vec![Predicate::IsNotNull("vector"), filter.clone()])
-}
-
-fn statuses_from_inserted(total: usize, inserted_rows: u64) -> Vec<UpsertStatus> {
-    let inserted = usize::try_from(inserted_rows)
-        .unwrap_or(usize::MAX)
-        .min(total);
-    let mut statuses = Vec::with_capacity(total);
-    statuses.extend(std::iter::repeat_n(UpsertStatus::Inserted, inserted));
-    statuses.extend(std::iter::repeat_n(
-        UpsertStatus::Matched,
-        total.saturating_sub(inserted),
-    ));
-    statuses
 }
 
 // Bare logical table names: the lance-namespace Directory impl owns the


### PR DESCRIPTION
Cleanup follow-up to PR #26's `BatchCounts` refactor.

## What

Drop `statuses_from_inserted` and reshape the three flat-write helpers (`upsert_sessions`, `upsert_messages`, `upsert_parts`) to return `Result<()>` instead of a synthesized `Vec<UpsertStatus>`.

## Why

`statuses_from_inserted(total, inserted_rows)` fabricated per-row outcomes by marking the first K rows in input order as `Inserted` and the rest as `Matched`, regardless of which PKs were actually new. Wrong at the per-row level, harmless in practice because:

- No production code path called the three flat helpers after PR #26. The CLI sync path and HTTP `pond_ingest` both go through `IngestValidator` -> `upsert_session_batch`, which uses the pre-existence-scan approach for honest per-row truth.
- Every remaining caller is in tests (`#[cfg(test)] mod tests` blocks plus `tests/integration/`), and each test discards the returned Vec via `.await?` / `.await.is_err()`.

Per CLAUDE.md minimalism ("delete what stops earning its place"), the smudge function loses its place and the helpers shed an inaccurate return value.

## Diff

- `src/sessions.rs`: signatures flipped to `Result<()>`, `statuses_from_inserted` deleted, doc comment added on `upsert_sessions` explaining why per-row truth lives on `upsert_session_batch`.
- 9 line net delete, no test changes, no behavior changes.

## Verification

- `cargo fmt --check`: clean
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test`: 91 lib + 29 integration tests, all green