### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/tenequm/pond/compare/v0.3.0...v0.3.1) - 2026-06-04
+
+### Fixed
+
+- *(adapter)* recognize nested workflow-subagent transcripts
+
 ## [0.3.0](https://github.com/tenequm/pond/compare/v0.2.8...v0.3.0) - 2026-06-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6307,7 +6307,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pond-db"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 # crate). The library and binary stay `pond` via [lib]/[[bin]] below, so the
 # command and `use pond::...` are unchanged - only `cargo install pond-db` differs.
 name = "pond-db"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 # MSRV pinned to the toolchain we build and test with (rust-toolchain.toml).
 rust-version = "1.95"


### PR DESCRIPTION



## 🤖 New release

* `pond-db`: 0.3.0 -> 0.3.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/tenequm/pond/compare/v0.3.0...v0.3.1) - 2026-06-04

### Fixed

- *(adapter)* recognize nested workflow-subagent transcripts
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).