### PR TITLE
feat(mcp)!: add pond_sql_query read-only SQL tool (table/json/ndjson/parquet) + pond sql CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4282,6 +4282,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "io-uring"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4464,7 +4470,7 @@ dependencies = [
  "jiff",
  "nom 8.0.0",
  "num-traits",
- "ordered-float",
+ "ordered-float 5.3.0",
  "rand 0.9.4",
  "serde",
  "serde_json",
@@ -6055,6 +6061,15 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
@@ -6114,6 +6129,33 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parquet"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "half",
+ "hashbrown 0.17.1",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "thrift",
+ "twox-hash",
 ]
 
 [[package]]
@@ -6311,6 +6353,7 @@ version = "0.3.2"
 dependencies = [
  "anstyle",
  "anyhow",
+ "arrow-json",
  "async-stream",
  "axum",
  "base64 0.22.1",
@@ -6331,6 +6374,7 @@ dependencies = [
  "insta",
  "lance",
  "lance-arrow",
+ "lance-datafusion",
  "lance-file",
  "lance-index",
  "lance-io",
@@ -6338,6 +6382,7 @@ dependencies = [
  "lance-namespace",
  "lance-namespace-impls",
  "libc",
+ "parquet",
  "rmcp",
  "s3s",
  "s3s-fs",
@@ -8318,6 +8363,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if 1.0.4",
+]
+
+[[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float 2.10.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,9 @@ path = "src/main.rs"
 [dependencies]
 anstyle = "1"
 anyhow = "1.0.102"
+# ndjson export writer for `pond_sql_query` (already in the tree via the arrow
+# stack; named directly here for the `LineDelimitedWriter`).
+arrow-json = "58.3"
 async-stream = "0.3.6"
 axum = "0.8.9"
 base64 = "0.22"
@@ -82,6 +85,10 @@ hf-hub = { version = "0.5", default-features = false, features = ["ureq"] }
 indicatif = "0.18"
 lance = { version = "7.0.0", features = ["protoc"] }
 lance-arrow = "7.0.0"
+# `pond_sql_query` registers lance's JSON / contains_tokens UDFs on the SQL
+# SessionContext via `lance_datafusion::udf::register_functions`. Already in
+# the tree transitively; named here to reach that one function.
+lance-datafusion = "7.0.0"
 half = { version = "2.1", default-features = false }
 lance-file = "7.0.0"
 lance-index = "7.0.0"
@@ -89,6 +96,10 @@ lance-io = "7.0.0"
 lance-linalg = "7.0.0"
 lance-namespace = "7.0.0"
 lance-namespace-impls = "7.0.0"
+# Parquet export writer for `pond_sql_query`. The only genuinely new compiled
+# crate the SQL tool adds (lance reads/writes its own format, not parquet).
+# `arrow` feature only; results are written uncompressed via `ArrowWriter`.
+parquet = { version = "58.3", default-features = false, features = ["arrow"] }
 rmcp = { version = "1.7", features = ["transport-io", "transport-streamable-http-server"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"

--- a/benches/backend_bench.rs
+++ b/benches/backend_bench.rs
@@ -22,6 +22,7 @@ use pond::{
     embed::{EmbedWorker, Embedder, LazyEmbedder},
     handlers::pond_search,
     sessions::{MessageWrite, Store, embedding_dim},
+    substrate::MaintenancePolicy,
     wire::{
         Message, Part, PartKind, Provenance, ProviderOptions, SearchEnvelope, SearchFilters,
         SearchModeWire, SearchRequest, Session,
@@ -224,7 +225,10 @@ async fn run_bench(label: String, store: &Store, args: &Args, open_ms: u128) -> 
         embed_ms = Some(t.elapsed().as_millis());
 
         let t = Instant::now();
-        store.optimize_indices(None, None).await?.into_result()?;
+        store
+            .optimize_indices(None, &MaintenancePolicy::always_compact())
+            .await?
+            .into_result()?;
         index_ms = Some(t.elapsed().as_millis());
 
         let embedder = LazyEmbedder::from_loaded(Arc::new(FakeBackend) as Arc<dyn Embedder>);

--- a/benches/serve_mem_bench.rs
+++ b/benches/serve_mem_bench.rs
@@ -401,6 +401,7 @@ fn get_request(message_id: String) -> GetRequest {
         context_depth: 0,
         limit: 50,
         response_mode: pond::wire::ResponseMode::Conversational,
+        session_from: pond::wire::SessionFrom::Start,
         after_id: None,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod embed;
 pub mod handlers;
 pub mod sessions;
+pub mod sql;
 pub mod substrate;
 pub mod transport;
 pub mod wire;

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,15 @@ impl From<CliResponseMode> for ResponseMode {
     }
 }
 
+/// CLI surface for `pond sql --output`. Maps to `sql::Mode` / `sql::Format`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum CliSqlOutput {
+    Table,
+    Json,
+    Ndjson,
+    Parquet,
+}
+
 /// CLI surface for `pond get --from`. Maps 1:1 to wire `SessionFrom`.
 #[derive(Debug, Clone, Copy, ValueEnum)]
 enum CliSessionFrom {
@@ -387,6 +396,32 @@ enum Command {
         data_dir: Option<Url>,
         #[arg(long, env = "POND_CONFIG")]
         config: Option<PathBuf>,
+    },
+    /// Run ONE read-only SQL query over the stored corpus (sessions, messages,
+    /// parts). DataFusion / PostgreSQL-compatible. SELECT/WITH only; writes
+    /// and side-effecting statements are rejected. Same SQL surface as the
+    /// `pond_sql_query` MCP tool - see `schema://pond-sql` (via MCP) for the
+    /// full column list, indexed columns, pagination/drilling patterns, and
+    /// the function quick-reference.
+    Sql {
+        /// The SQL query. Wrap in quotes; remember to escape `$` in zsh/bash.
+        sql: String,
+        #[arg(long, env = "POND_DATA_DIR", value_parser = parse_data_dir)]
+        data_dir: Option<Url>,
+        #[arg(long, env = "POND_CONFIG")]
+        config: Option<PathBuf>,
+        /// Output format. table/json/ndjson go to stdout; parquet requires
+        /// `--output-file` (binary).
+        #[arg(long, value_enum, default_value_t = CliSqlOutput::Table)]
+        output: CliSqlOutput,
+        /// Inline row cap for table/json output. Default 100, max 1000.
+        /// Ignored for ndjson/parquet (which return every row).
+        #[arg(long, default_value_t = 100)]
+        limit: usize,
+        /// Write the export bytes here instead of stdout (required for
+        /// `--output parquet`; optional for ndjson). Ignored for table/json.
+        #[arg(long, short = 'o')]
+        output_file: Option<PathBuf>,
     },
 }
 
@@ -845,6 +880,84 @@ async fn main() -> anyhow::Result<()> {
                 "{} run `pond sync --only update-indexes` to rebuild search indexes",
                 pond::output::paint("hint", pond::output::dim()),
             ))?;
+        }
+        Command::Sql {
+            sql,
+            data_dir,
+            config,
+            output: format,
+            limit,
+            output_file,
+        } => {
+            if matches!(format, CliSqlOutput::Parquet) && output_file.is_none() {
+                bail!(
+                    "--output parquet requires --output-file <path> (binary, can't go to stdout)"
+                );
+            }
+            let data_dir = resolve_data_dir(data_dir)?;
+            let loaded = Config::load(config_path(config, &data_dir))?;
+            let store =
+                Store::open_with_options(&data_dir, storage_map(&loaded), runtime_caps(&loaded))
+                    .await?;
+            let mode = match format {
+                CliSqlOutput::Table => pond::sql::Mode::Inline,
+                CliSqlOutput::Json => pond::sql::Mode::InlineJson,
+                CliSqlOutput::Ndjson => pond::sql::Mode::Export(pond::sql::Format::Ndjson),
+                CliSqlOutput::Parquet => pond::sql::Mode::Export(pond::sql::Format::Parquet),
+            };
+            let inline_rows = limit.min(pond::sql::MAX_INLINE_ROWS);
+            let (sessions, messages, parts) = tokio::try_join!(
+                store.dataset(pond::substrate::Table::Sessions),
+                store.dataset(pond::substrate::Table::Messages),
+                store.dataset(pond::substrate::Table::Parts),
+            )?;
+            let tables = pond::sql::Tables {
+                sessions,
+                messages,
+                parts,
+            };
+            match pond::sql::run(&tables, &sql, mode, inline_rows).await {
+                Ok(pond::sql::Outcome::Inline(text)) => {
+                    output(&text)?;
+                }
+                Ok(pond::sql::Outcome::InlineJson(value)) => {
+                    // Pretty-print for the CLI - the structured payload is for
+                    // agents over MCP; humans reading stdout want it readable.
+                    output(&serde_json::to_string_pretty(&value)?)?;
+                }
+                Ok(pond::sql::Outcome::Export {
+                    bytes,
+                    format: _,
+                    rows,
+                    columns: _,
+                }) => match output_file {
+                    Some(path) => {
+                        fs::write(&path, &bytes)
+                            .with_context(|| format!("write export to {}", path.display()))?;
+                        output_err(&format!(
+                            "{} {} row(s), {} bytes -> {}",
+                            pond::output::paint("export:", pond::output::dim()),
+                            rows,
+                            bytes.len(),
+                            path.display()
+                        ))?;
+                    }
+                    None => {
+                        use std::io::Write;
+                        io::stdout().write_all(&bytes)?;
+                    }
+                },
+                Err(pond::sql::SqlError::Query(message)) => {
+                    output_err(&format!(
+                        "{} {message}",
+                        pond::output::paint("sql error:", pond::output::dim())
+                    ))?;
+                    std::process::exit(2);
+                }
+                Err(pond::sql::SqlError::Infra(error)) => {
+                    return Err(error);
+                }
+            }
         }
     }
 

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1127,6 +1127,28 @@ impl Store {
         self.handle.row_counts().await
     }
 
+    /// A point-in-time `Arc<Dataset>` for `table`, for registering as a
+    /// DataFusion `LanceTableProvider` in `pond_sql_query`. Goes through the
+    /// handle's freshness gate, so each query sees a current snapshot.
+    pub async fn dataset(&self, table: Table) -> Result<Arc<Dataset>> {
+        Ok(Arc::new(self.handle.dataset(table).await?))
+    }
+
+    /// Write a `pond_sql_query` export artifact.
+    pub async fn export_write(&self, name: &str, bytes: &[u8]) -> Result<()> {
+        self.handle.export_write(name, bytes).await
+    }
+
+    /// Read a `pond_sql_query` export artifact back.
+    pub async fn export_read(&self, name: &str) -> Result<Vec<u8>> {
+        self.handle.export_read(name).await
+    }
+
+    /// Local filesystem path of an export artifact on `file://` installs.
+    pub fn export_local_path(&self, name: &str) -> Option<std::path::PathBuf> {
+        self.handle.export_local_path(name)
+    }
+
     /// Compute the per-adapter / per-project rollup that drives
     /// `pond status`. One scan over `messages` projecting the three
     /// columns the rollup keys on (`source_agent`, `project`, `session_id`),

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1,0 +1,401 @@
+//! `pond_sql_query`: read-only DataFusion SQL over the three Lance tables
+//! (`sessions` / `messages` / `parts`), registered as `LanceTableProvider`s on
+//! a fresh per-call `SessionContext`. Read-only is enforced in two layers - a
+//! single-`SELECT` pre-parse and `sql_with_options` with DDL/DML/statements all
+//! disabled - so no statement that mutates the corpus or touches the filesystem
+//! (INSERT/UPDATE/DELETE/CREATE/DROP/COPY/CREATE EXTERNAL TABLE/SET) can run.
+//! Results render inline (row-capped) or export to a parquet/ndjson file the
+//! caller fetches via the `pond-sql-export://` resource (`src/transport.rs`).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::anyhow;
+use arrow_json::LineDelimitedWriter;
+use lance::Dataset;
+use lance::datafusion::LanceTableProvider;
+use lance::dataset::udtf::FtsQueryUDTFBuilder;
+use lance::deps::arrow_array::RecordBatch;
+use lance::deps::arrow_schema::{ArrowError, DataType};
+use lance::deps::datafusion::arrow::util::pretty::pretty_format_batches;
+use lance::deps::datafusion::execution::SessionStateBuilder;
+use lance::deps::datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use lance::deps::datafusion::prelude::{SQLOptions, SessionConfig, SessionContext};
+use lance::deps::datafusion::sql::parser::{DFParser, Statement as DfStatement};
+use lance::deps::datafusion::sql::sqlparser::ast::Statement as SqlStatement;
+use lance_datafusion::udf::register_functions;
+use parquet::arrow::ArrowWriter;
+
+/// Per-query memory ceiling for the DataFusion runtime. Not enforced on every
+/// operator (datafusion caveat), so the timeout below is the hard backstop.
+const MEM_LIMIT_BYTES: usize = 512 * 1024 * 1024;
+/// Wall-clock cap on `collect()`. DataFusion 53 has no built-in query timeout,
+/// so this `tokio::time::timeout` is the only guard against a runaway plan.
+const QUERY_TIMEOUT: Duration = Duration::from_secs(30);
+/// Byte budget for the inline (rendered table) result; rows are dropped to fit.
+const INLINE_BUDGET_BYTES: usize = 80_000;
+/// Hard ceiling on an export artifact: base64'd over `resources/read` it costs
+/// ~1.33x this in the response, so keep it well under any process envelope.
+const MAX_EXPORT_BYTES: usize = 100 * 1024 * 1024;
+/// Default inline row cap when the caller passes no `limit`.
+pub(crate) const DEFAULT_INLINE_ROWS: usize = 100;
+/// Upper bound on the caller-supplied inline `limit`.
+pub(crate) const MAX_INLINE_ROWS: usize = 1_000;
+
+/// Export serialization format. Vector columns are excluded and JSON columns
+/// are decoded to text before encoding (see [`displayable`]).
+#[derive(Debug, Clone, Copy)]
+pub enum Format {
+    Parquet,
+    Ndjson,
+}
+
+impl Format {
+    pub fn ext(self) -> &'static str {
+        match self {
+            Self::Parquet => "parquet",
+            Self::Ndjson => "ndjson",
+        }
+    }
+
+    pub fn mime(self) -> &'static str {
+        match self {
+            Self::Parquet => "application/vnd.apache.parquet",
+            Self::Ndjson => "application/x-ndjson",
+        }
+    }
+}
+
+/// How `pond_sql_query` returns results.
+#[derive(Debug, Clone, Copy)]
+pub enum Mode {
+    /// Render a row-capped table into the tool result.
+    Inline,
+    /// Write the full result to a file and return a `pond-sql-export://` link.
+    Export(Format),
+}
+
+/// The three Lance datasets, fetched fresh per call so each query sees a
+/// current snapshot (the handle freshness gate runs on each `Store::dataset`).
+pub struct Tables {
+    pub sessions: Arc<Dataset>,
+    pub messages: Arc<Dataset>,
+    pub parts: Arc<Dataset>,
+}
+
+/// Result of a successful `run`.
+pub enum Outcome {
+    /// A rendered, row-capped table.
+    Inline(String),
+    /// Encoded export bytes plus metadata for the caller's summary/resource.
+    Export {
+        bytes: Vec<u8>,
+        format: Format,
+        rows: usize,
+        columns: Vec<String>,
+    },
+}
+
+/// Two error channels: `Query` is caller-fixable (parse/plan/exec/limits) and
+/// the tool surfaces it as an `isError` result so the model self-corrects;
+/// `Infra` is an internal failure surfaced as a protocol error.
+pub enum SqlError {
+    Query(String),
+    Infra(anyhow::Error),
+}
+
+fn infra(error: ArrowError) -> SqlError {
+    SqlError::Infra(anyhow::Error::new(error))
+}
+
+/// Execute one read-only SQL query and return either a rendered table or
+/// encoded export bytes.
+pub async fn run(
+    tables: &Tables,
+    sql: &str,
+    mode: Mode,
+    inline_rows: usize,
+) -> Result<Outcome, SqlError> {
+    ensure_single_select(sql)?;
+    let ctx = build_context()?;
+    register(&ctx, tables)?;
+
+    // Defense in depth on top of the single-SELECT pre-parse: verify_plan walks
+    // the plan with subqueries and rejects any DDL/DML/COPY/Statement node.
+    let options = SQLOptions::new()
+        .with_allow_ddl(false)
+        .with_allow_dml(false)
+        .with_allow_statements(false);
+    let df = ctx
+        .sql_with_options(sql, options)
+        .await
+        .map_err(|error| SqlError::Query(format!("SQL error: {error}")))?;
+
+    // Captured before `collect()` consumes `df`, so an empty result still
+    // renders its column headers.
+    let result_schema = Arc::new(df.schema().as_arrow().clone());
+    let collected = tokio::time::timeout(QUERY_TIMEOUT, df.collect())
+        .await
+        .map_err(|_| {
+            SqlError::Query(format!(
+                "query exceeded the {}s limit; add a narrower WHERE or a LIMIT",
+                QUERY_TIMEOUT.as_secs()
+            ))
+        })?
+        .map_err(|error| SqlError::Query(format!("SQL error: {error}")))?;
+
+    let display: Vec<RecordBatch> = if collected.is_empty() {
+        vec![displayable(&RecordBatch::new_empty(result_schema)).map_err(infra)?]
+    } else {
+        collected
+            .iter()
+            .map(displayable)
+            .collect::<Result<_, _>>()
+            .map_err(infra)?
+    };
+
+    match mode {
+        Mode::Inline => Ok(Outcome::Inline(
+            render_inline(&display, inline_rows).map_err(infra)?,
+        )),
+        Mode::Export(format) => {
+            let rows = display.iter().map(RecordBatch::num_rows).sum();
+            let columns = display
+                .first()
+                .map(|batch| {
+                    batch
+                        .schema()
+                        .fields()
+                        .iter()
+                        .map(|field| field.name().clone())
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            let bytes = match format {
+                Format::Parquet => encode_parquet(&display)?,
+                Format::Ndjson => encode_ndjson(&display)?,
+            };
+            if bytes.len() > MAX_EXPORT_BYTES {
+                return Err(SqlError::Query(format!(
+                    "export is {} bytes, over the {MAX_EXPORT_BYTES} byte limit; \
+                     narrow the query or aggregate",
+                    bytes.len()
+                )));
+            }
+            Ok(Outcome::Export {
+                bytes,
+                format,
+                rows,
+                columns,
+            })
+        }
+    }
+}
+
+/// Read-only gate: parse the SQL and require exactly one top-level `Query`
+/// (SELECT/WITH/VALUES/UNION). This also rejects EXPLAIN/ANALYZE/DESCRIBE/SET
+/// and multi-statement input, which `SQLOptions` alone does not.
+fn ensure_single_select(sql: &str) -> Result<(), SqlError> {
+    let statements = DFParser::parse_sql(sql)
+        .map_err(|error| SqlError::Query(format!("SQL parse error: {error}")))?;
+    if statements.len() != 1 {
+        return Err(SqlError::Query(
+            "pond_sql_query runs exactly one statement; submit a single SELECT".to_owned(),
+        ));
+    }
+    match statements.front() {
+        Some(DfStatement::Statement(statement))
+            if matches!(statement.as_ref(), SqlStatement::Query(_)) =>
+        {
+            Ok(())
+        }
+        _ => Err(SqlError::Query(
+            "pond_sql_query is read-only: only a single SELECT/WITH query is allowed \
+             (no INSERT/UPDATE/DELETE/CREATE/DROP/COPY/EXPLAIN/SET)"
+                .to_owned(),
+        )),
+    }
+}
+
+fn build_context() -> Result<SessionContext, SqlError> {
+    let runtime = RuntimeEnvBuilder::new()
+        .with_memory_limit(MEM_LIMIT_BYTES, 1.0)
+        .build_arc()
+        .map_err(|error| SqlError::Infra(anyhow!("datafusion runtime init failed: {error}")))?;
+    let state = SessionStateBuilder::new()
+        .with_config(SessionConfig::new())
+        .with_runtime_env(runtime)
+        .with_default_features()
+        .build();
+    Ok(SessionContext::new_with_state(state))
+}
+
+fn register(ctx: &SessionContext, tables: &Tables) -> Result<(), SqlError> {
+    for (name, dataset) in [
+        ("sessions", &tables.sessions),
+        ("messages", &tables.messages),
+        ("parts", &tables.parts),
+    ] {
+        // LanceTableProvider (not the bare Dataset impl) so WHERE/projection/
+        // limit push into Lance's indexed scan; (false, false) hides _rowid /
+        // _rowaddr from the SQL schema.
+        let provider = LanceTableProvider::new(dataset.clone(), false, false);
+        ctx.register_table(name, Arc::new(provider))
+            .map_err(|error| SqlError::Infra(anyhow!("register table {name}: {error}")))?;
+    }
+    // `fts('messages', '{...}')` BM25 search-in-SQL, and lance's JSON /
+    // contains_tokens UDFs for filtering inside the JSON columns.
+    let fts = FtsQueryUDTFBuilder::builder()
+        .register_table("sessions", tables.sessions.clone())
+        .register_table("messages", tables.messages.clone())
+        .register_table("parts", tables.parts.clone())
+        .build();
+    ctx.register_udtf("fts", Arc::new(fts));
+    register_functions(ctx);
+    Ok(())
+}
+
+/// Decode lance JSONB columns to JSON text, then drop columns that don't render
+/// readably (the embedding `vector` FixedSizeList and any leftover binary).
+fn displayable(batch: &RecordBatch) -> Result<RecordBatch, ArrowError> {
+    let decoded = lance_arrow::json::convert_lance_json_to_arrow(batch)?;
+    let keep: Vec<usize> = decoded
+        .schema()
+        .fields()
+        .iter()
+        .enumerate()
+        .filter(|(_, field)| is_displayable(field.data_type()))
+        .map(|(index, _)| index)
+        .collect();
+    decoded.project(&keep)
+}
+
+fn is_displayable(data_type: &DataType) -> bool {
+    !matches!(
+        data_type,
+        DataType::FixedSizeList(_, _)
+            | DataType::Binary
+            | DataType::LargeBinary
+            | DataType::BinaryView
+            | DataType::FixedSizeBinary(_)
+    )
+}
+
+fn render_inline(display: &[RecordBatch], max_rows: usize) -> Result<String, ArrowError> {
+    let total: usize = display.iter().map(RecordBatch::num_rows).sum();
+    if total == 0 {
+        // Still render the header so the caller sees the result columns.
+        return Ok(format!("0 rows.\n{}", pretty_format_batches(display)?));
+    }
+    let mut shown = total.min(max_rows);
+    let mut table = pretty_format_batches(&limit_batches(display, shown))?.to_string();
+    while table.len() > INLINE_BUDGET_BYTES && shown > 1 {
+        shown = (shown / 2).max(1);
+        table = pretty_format_batches(&limit_batches(display, shown))?.to_string();
+    }
+    let mut out = format!("{total} row(s); showing {shown}.\n{table}");
+    if shown < total {
+        out.push_str(&format!(
+            "\n... {} row(s) omitted; add LIMIT/WHERE or set output=parquet|ndjson \
+             for the full result.",
+            total - shown
+        ));
+    }
+    Ok(out)
+}
+
+fn limit_batches(batches: &[RecordBatch], max_rows: usize) -> Vec<RecordBatch> {
+    let mut out = Vec::new();
+    let mut remaining = max_rows;
+    for batch in batches {
+        if remaining == 0 {
+            break;
+        }
+        if batch.num_rows() <= remaining {
+            remaining -= batch.num_rows();
+            out.push(batch.clone());
+        } else {
+            out.push(batch.slice(0, remaining));
+            remaining = 0;
+        }
+    }
+    out
+}
+
+fn encode_parquet(batches: &[RecordBatch]) -> Result<Vec<u8>, SqlError> {
+    let schema = batches
+        .first()
+        .map(RecordBatch::schema)
+        .ok_or_else(|| SqlError::Query("query returned no columns to export".to_owned()))?;
+    let mut buffer = Vec::new();
+    let mut writer = ArrowWriter::try_new(&mut buffer, schema, None)
+        .map_err(|error| SqlError::Infra(anyhow!("parquet init failed: {error}")))?;
+    for batch in batches {
+        writer
+            .write(batch)
+            .map_err(|error| SqlError::Infra(anyhow!("parquet write failed: {error}")))?;
+    }
+    writer
+        .close()
+        .map_err(|error| SqlError::Infra(anyhow!("parquet close failed: {error}")))?;
+    Ok(buffer)
+}
+
+fn encode_ndjson(batches: &[RecordBatch]) -> Result<Vec<u8>, SqlError> {
+    let mut buffer = Vec::new();
+    {
+        let mut writer = LineDelimitedWriter::new(&mut buffer);
+        let refs: Vec<&RecordBatch> = batches.iter().collect();
+        writer
+            .write_batches(&refs)
+            .map_err(|error| SqlError::Infra(anyhow!("ndjson write failed: {error}")))?;
+        writer
+            .finish()
+            .map_err(|error| SqlError::Infra(anyhow!("ndjson finish failed: {error}")))?;
+    }
+    Ok(buffer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rejected(sql: &str) -> bool {
+        matches!(ensure_single_select(sql), Err(SqlError::Query(_)))
+    }
+
+    #[test]
+    fn allows_single_select_and_cte() {
+        assert!(ensure_single_select("SELECT 1").is_ok());
+        assert!(ensure_single_select("SELECT role, count(*) FROM messages GROUP BY role").is_ok());
+        assert!(ensure_single_select("WITH t AS (SELECT 1 AS a) SELECT a FROM t").is_ok());
+    }
+
+    #[test]
+    fn rejects_writes_and_side_effects() {
+        assert!(rejected("INSERT INTO messages VALUES ('x')"));
+        assert!(rejected("UPDATE messages SET role = 'x'"));
+        assert!(rejected("DELETE FROM messages"));
+        assert!(rejected("CREATE TABLE t (x INT)"));
+        assert!(rejected("CREATE VIEW v AS SELECT 1"));
+        assert!(rejected("DROP TABLE messages"));
+        assert!(rejected(
+            "CREATE EXTERNAL TABLE t STORED AS PARQUET LOCATION '/etc'"
+        ));
+        assert!(rejected("COPY (SELECT 1) TO '/tmp/x.parquet'"));
+        assert!(rejected("SET a = 1"));
+        assert!(rejected("EXPLAIN SELECT 1"));
+        assert!(rejected("EXPLAIN ANALYZE SELECT 1"));
+    }
+
+    #[test]
+    fn rejects_multiple_statements() {
+        assert!(rejected("SELECT 1; SELECT 2"));
+        assert!(rejected("SELECT 1; DROP TABLE messages"));
+    }
+
+    #[test]
+    fn rejects_unparseable() {
+        assert!(rejected("NOT SQL AT ALL ;;"));
+    }
+}

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -8,7 +8,7 @@
 //! caller fetches via the `pond-sql-export://` resource (`src/transport.rs`).
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
 use arrow_json::LineDelimitedWriter;
@@ -22,9 +22,10 @@ use lance::deps::datafusion::execution::SessionStateBuilder;
 use lance::deps::datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use lance::deps::datafusion::prelude::{SQLOptions, SessionConfig, SessionContext};
 use lance::deps::datafusion::sql::parser::{DFParser, Statement as DfStatement};
-use lance::deps::datafusion::sql::sqlparser::ast::Statement as SqlStatement;
+use lance::deps::datafusion::sql::sqlparser::ast::{SetExpr, Statement as SqlStatement};
 use lance_datafusion::udf::register_functions;
 use parquet::arrow::ArrowWriter;
+use serde_json::{Map as JsonMap, Value as JsonValue, json};
 
 /// Per-query memory ceiling for the DataFusion runtime. Not enforced on every
 /// operator (datafusion caveat), so the timeout below is the hard backstop.
@@ -38,9 +39,9 @@ const INLINE_BUDGET_BYTES: usize = 80_000;
 /// ~1.33x this in the response, so keep it well under any process envelope.
 const MAX_EXPORT_BYTES: usize = 100 * 1024 * 1024;
 /// Default inline row cap when the caller passes no `limit`.
-pub(crate) const DEFAULT_INLINE_ROWS: usize = 100;
+pub const DEFAULT_INLINE_ROWS: usize = 100;
 /// Upper bound on the caller-supplied inline `limit`.
-pub(crate) const MAX_INLINE_ROWS: usize = 1_000;
+pub const MAX_INLINE_ROWS: usize = 1_000;
 
 /// Export serialization format. Vector columns are excluded and JSON columns
 /// are decoded to text before encoding (see [`displayable`]).
@@ -71,6 +72,13 @@ impl Format {
 pub enum Mode {
     /// Render a row-capped table into the tool result.
     Inline,
+    /// Return a row-capped JSON payload; the MCP layer surfaces it through
+    /// `structuredContent` (with a stringified text fallback for clients that
+    /// do not surface the structured channel). Empirically validated on Claude
+    /// Code 2.1.165: when both channels carry the same payload, the agent reads
+    /// the structured one and the text block is a soft-landing for other
+    /// clients (spec 2025-11-25 server SHOULD).
+    InlineJson,
     /// Write the full result to a file and return a `pond-sql-export://` link.
     Export(Format),
 }
@@ -85,8 +93,11 @@ pub struct Tables {
 
 /// Result of a successful `run`.
 pub enum Outcome {
-    /// A rendered, row-capped table.
+    /// A rendered, row-capped table (already includes the metrics footer).
     Inline(String),
+    /// A row-capped JSON payload with metadata fields (`total_rows`,
+    /// `shown_rows`, `truncated`, `elapsed_ms`, `columns`, `rows`).
+    InlineJson(JsonValue),
     /// Encoded export bytes plus metadata for the caller's summary/resource.
     Export {
         bytes: Vec<u8>,
@@ -99,6 +110,7 @@ pub enum Outcome {
 /// Two error channels: `Query` is caller-fixable (parse/plan/exec/limits) and
 /// the tool surfaces it as an `isError` result so the model self-corrects;
 /// `Infra` is an internal failure surfaced as a protocol error.
+#[derive(Debug)]
 pub enum SqlError {
     Query(String),
     Infra(anyhow::Error),
@@ -108,24 +120,42 @@ fn infra(error: ArrowError) -> SqlError {
     SqlError::Infra(anyhow::Error::new(error))
 }
 
-/// Execute one read-only SQL query and return either a rendered table or
-/// encoded export bytes.
+/// Execute one read-only SQL query and return either a rendered table, a JSON
+/// payload, or encoded export bytes.
 pub async fn run(
     tables: &Tables,
     sql: &str,
     mode: Mode,
     inline_rows: usize,
 ) -> Result<Outcome, SqlError> {
-    ensure_single_select(sql)?;
+    let parsed = parse_and_gate(sql)?;
+    if matches!(parsed.kind, StatementKind::Explain) && matches!(mode, Mode::Export(_)) {
+        return Err(SqlError::Query(
+            "EXPLAIN returns a plan, not a result set; use output=table (or json) to read it"
+                .to_owned(),
+        ));
+    }
+    if projection_mentions_vector(parsed.projection_query()) {
+        return Err(SqlError::Query(
+            "the `vector` column is not selectable from pond_sql_query (it is a \
+             FixedSizeList<f32> embedding, ~600 bytes per row and not useful in a result). \
+             For semantic search use pond_search. Filtering on it is allowed in WHERE \
+             (e.g. `vector IS NOT NULL`)."
+                .to_owned(),
+        ));
+    }
     let ctx = build_context()?;
     register(&ctx, tables)?;
 
-    // Defense in depth on top of the single-SELECT pre-parse: verify_plan walks
-    // the plan with subqueries and rejects any DDL/DML/COPY/Statement node.
+    // Defense in depth on top of the pre-parse gate: SQLOptions blocks DDL/DML
+    // at planning time. `allow_statements` stays false for a plain SELECT (the
+    // parse-time gate already rejects SET/SHOW etc.) but must be true for
+    // EXPLAIN, which DataFusion classifies as a Statement node. The inner
+    // query of an EXPLAIN was vetted by the gate above.
     let options = SQLOptions::new()
         .with_allow_ddl(false)
         .with_allow_dml(false)
-        .with_allow_statements(false);
+        .with_allow_statements(matches!(parsed.kind, StatementKind::Explain));
     let df = ctx
         .sql_with_options(sql, options)
         .await
@@ -134,6 +164,7 @@ pub async fn run(
     // Captured before `collect()` consumes `df`, so an empty result still
     // renders its column headers.
     let result_schema = Arc::new(df.schema().as_arrow().clone());
+    let started = Instant::now();
     let collected = tokio::time::timeout(QUERY_TIMEOUT, df.collect())
         .await
         .map_err(|_| {
@@ -143,6 +174,7 @@ pub async fn run(
             ))
         })?
         .map_err(|error| SqlError::Query(format!("SQL error: {error}")))?;
+    let elapsed = started.elapsed();
 
     let display: Vec<RecordBatch> = if collected.is_empty() {
         vec![displayable(&RecordBatch::new_empty(result_schema)).map_err(infra)?]
@@ -156,8 +188,13 @@ pub async fn run(
 
     match mode {
         Mode::Inline => Ok(Outcome::Inline(
-            render_inline(&display, inline_rows).map_err(infra)?,
+            render_inline(&display, inline_rows, elapsed).map_err(infra)?,
         )),
+        Mode::InlineJson => Ok(Outcome::InlineJson(render_inline_json(
+            &display,
+            inline_rows,
+            elapsed,
+        )?)),
         Mode::Export(format) => {
             let rows = display.iter().map(RecordBatch::num_rows).sum();
             let columns = display
@@ -192,10 +229,38 @@ pub async fn run(
     }
 }
 
-/// Read-only gate: parse the SQL and require exactly one top-level `Query`
-/// (SELECT/WITH/VALUES/UNION). This also rejects EXPLAIN/ANALYZE/DESCRIBE/SET
-/// and multi-statement input, which `SQLOptions` alone does not.
-fn ensure_single_select(sql: &str) -> Result<(), SqlError> {
+/// Top-level statement shape allowed past the read-only gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StatementKind {
+    /// A plain `Query` (SELECT/WITH/VALUES/UNION).
+    Query,
+    /// `EXPLAIN [ANALYZE] <query>` - planning info only, no mutation.
+    Explain,
+}
+
+/// Parsed top-level statement, normalized so downstream checks always see a
+/// projection-bearing `Query` regardless of whether the user wrote `SELECT`
+/// or `EXPLAIN SELECT`. DataFusion's parser wraps EXPLAIN in its own
+/// `DfStatement::Explain` variant (separate from sqlparser's
+/// `SqlStatement::Explain`), so the gate has to peel both layers.
+struct ParsedStatement {
+    kind: StatementKind,
+    query: lance::deps::datafusion::sql::sqlparser::ast::Query,
+}
+
+impl ParsedStatement {
+    fn projection_query(&self) -> &lance::deps::datafusion::sql::sqlparser::ast::Query {
+        &self.query
+    }
+}
+
+/// Read-only gate: parse the SQL and require exactly one top-level `Query` or
+/// `EXPLAIN <Query>`. Rejects DDL/DML/COPY/SET/SHOW and multi-statement input,
+/// which `SQLOptions` alone does not catch at planning time. EXPLAIN of a
+/// non-Query (e.g. `EXPLAIN INSERT ...`) is also rejected: EXPLAIN itself is
+/// read-only, but letting the inner shape be DDL/DML widens the surface area
+/// the gate has to reason about for no real agent gain.
+fn parse_and_gate(sql: &str) -> Result<ParsedStatement, SqlError> {
     let statements = DFParser::parse_sql(sql)
         .map_err(|error| SqlError::Query(format!("SQL parse error: {error}")))?;
     if statements.len() != 1 {
@@ -203,18 +268,70 @@ fn ensure_single_select(sql: &str) -> Result<(), SqlError> {
             "pond_sql_query runs exactly one statement; submit a single SELECT".to_owned(),
         ));
     }
-    match statements.front() {
-        Some(DfStatement::Statement(statement))
-            if matches!(statement.as_ref(), SqlStatement::Query(_)) =>
-        {
-            Ok(())
-        }
-        _ => Err(SqlError::Query(
-            "pond_sql_query is read-only: only a single SELECT/WITH query is allowed \
-             (no INSERT/UPDATE/DELETE/CREATE/DROP/COPY/EXPLAIN/SET)"
-                .to_owned(),
-        )),
+    let Some(front) = statements.front() else {
+        return Err(read_only_rejection());
+    };
+    match front {
+        DfStatement::Statement(boxed) => match boxed.as_ref() {
+            SqlStatement::Query(query) => Ok(ParsedStatement {
+                kind: StatementKind::Query,
+                query: query.as_ref().clone(),
+            }),
+            _ => Err(read_only_rejection()),
+        },
+        DfStatement::Explain(explain) => match explain.statement.as_ref() {
+            DfStatement::Statement(inner) => match inner.as_ref() {
+                SqlStatement::Query(query) => Ok(ParsedStatement {
+                    kind: StatementKind::Explain,
+                    query: query.as_ref().clone(),
+                }),
+                _ => Err(read_only_rejection()),
+            },
+            _ => Err(read_only_rejection()),
+        },
+        _ => Err(read_only_rejection()),
     }
+}
+
+fn read_only_rejection() -> SqlError {
+    SqlError::Query(
+        "pond_sql_query is read-only: only a single SELECT/WITH (or EXPLAIN of one) is \
+         allowed (no INSERT/UPDATE/DELETE/CREATE/DROP/COPY/SET)"
+            .to_owned(),
+    )
+}
+
+/// Reject any top-level projection that explicitly references the embedding
+/// `vector` column. Today such queries silently return an empty column (the
+/// FixedSizeList<f32> is stripped by `displayable`), which wastes agent tokens
+/// diagnosing. WHERE/HAVING references stay legal - the doc lets agents filter
+/// on it (e.g. `WHERE vector IS NOT NULL`); only projecting the column out is
+/// blocked. Heuristic: tokenize each top-level SELECT item and look for a bare
+/// `vector` identifier. Covers `SELECT vector`, `SELECT id, vector`,
+/// `SELECT m.vector`, and `SELECT array_length(vector)`. Wildcards (`*` /
+/// `messages.*`) keep the existing silent-strip behavior since they don't name
+/// the column explicitly.
+fn projection_mentions_vector(query: &lance::deps::datafusion::sql::sqlparser::ast::Query) -> bool {
+    walk_set_expr_for_vector(query.body.as_ref())
+}
+
+fn walk_set_expr_for_vector(expr: &SetExpr) -> bool {
+    match expr {
+        SetExpr::Select(select) => select
+            .projection
+            .iter()
+            .any(|item| mentions_vector_token(&item.to_string())),
+        SetExpr::Query(inner) => walk_set_expr_for_vector(inner.body.as_ref()),
+        SetExpr::SetOperation { left, right, .. } => {
+            walk_set_expr_for_vector(left) || walk_set_expr_for_vector(right)
+        }
+        _ => false,
+    }
+}
+
+fn mentions_vector_token(text: &str) -> bool {
+    text.split(|c: char| !c.is_alphanumeric() && c != '_')
+        .any(|token| token == "vector")
 }
 
 fn build_context() -> Result<SessionContext, SqlError> {
@@ -281,11 +398,19 @@ fn is_displayable(data_type: &DataType) -> bool {
     )
 }
 
-fn render_inline(display: &[RecordBatch], max_rows: usize) -> Result<String, ArrowError> {
+fn render_inline(
+    display: &[RecordBatch],
+    max_rows: usize,
+    elapsed: Duration,
+) -> Result<String, ArrowError> {
     let total: usize = display.iter().map(RecordBatch::num_rows).sum();
+    let elapsed_ms = elapsed.as_millis();
     if total == 0 {
         // Still render the header so the caller sees the result columns.
-        return Ok(format!("0 rows.\n{}", pretty_format_batches(display)?));
+        return Ok(format!(
+            "0 rows ({elapsed_ms} ms).\n{}",
+            pretty_format_batches(display)?
+        ));
     }
     let mut shown = total.min(max_rows);
     let mut table = pretty_format_batches(&limit_batches(display, shown))?.to_string();
@@ -293,15 +418,112 @@ fn render_inline(display: &[RecordBatch], max_rows: usize) -> Result<String, Arr
         shown = (shown / 2).max(1);
         table = pretty_format_batches(&limit_batches(display, shown))?.to_string();
     }
-    let mut out = format!("{total} row(s); showing {shown}.\n{table}");
+    let mut out = format!("{total} row(s) in {elapsed_ms} ms; showing {shown}.\n{table}");
     if shown < total {
         out.push_str(&format!(
-            "\n... {} row(s) omitted; add LIMIT/WHERE or set output=parquet|ndjson \
-             for the full result.",
+            "\n... {} row(s) omitted. To page: ORDER BY <indexed col> (e.g. timestamp, \
+             id), then in the next call add `WHERE (col, id) < (<last_col>, <last_id>)` - \
+             keyset pagination, see schema://pond-sql. For the full set: output=parquet \
+             or output=ndjson.",
             total - shown
         ));
     }
     Ok(out)
+}
+
+/// JSON sibling of `render_inline`: same row cap and byte-budget shrinking,
+/// returned as a `JsonValue` so the MCP layer can hand it to
+/// `CallToolResult::structured` (text fallback + structured channel in one
+/// call, see [`Mode::InlineJson`]).
+fn render_inline_json(
+    display: &[RecordBatch],
+    max_rows: usize,
+    elapsed: Duration,
+) -> Result<JsonValue, SqlError> {
+    let total: usize = display.iter().map(RecordBatch::num_rows).sum();
+    let columns: Vec<String> = display
+        .first()
+        .map(|batch| {
+            batch
+                .schema()
+                .fields()
+                .iter()
+                .map(|field| field.name().clone())
+                .collect()
+        })
+        .unwrap_or_default();
+    let elapsed_ms = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX);
+
+    if total == 0 {
+        return Ok(json!({
+            "total_rows": 0,
+            "shown_rows": 0,
+            "truncated": false,
+            "elapsed_ms": elapsed_ms,
+            "columns": columns,
+            "rows": [],
+        }));
+    }
+
+    let mut shown = total.min(max_rows);
+    let mut rows = batches_to_json_rows(&limit_batches(display, shown))?;
+    let mut serialized = serde_json::to_string(&rows)
+        .map_err(|error| SqlError::Infra(anyhow!("json serialize: {error}")))?;
+    while serialized.len() > INLINE_BUDGET_BYTES && shown > 1 {
+        shown = (shown / 2).max(1);
+        rows = batches_to_json_rows(&limit_batches(display, shown))?;
+        serialized = serde_json::to_string(&rows)
+            .map_err(|error| SqlError::Infra(anyhow!("json serialize: {error}")))?;
+    }
+
+    let mut payload = JsonMap::new();
+    payload.insert("total_rows".to_owned(), json!(total));
+    payload.insert("shown_rows".to_owned(), json!(shown));
+    payload.insert("truncated".to_owned(), json!(shown < total));
+    payload.insert("elapsed_ms".to_owned(), json!(elapsed_ms));
+    payload.insert("columns".to_owned(), json!(columns));
+    payload.insert("rows".to_owned(), JsonValue::Array(rows));
+    if shown < total {
+        payload.insert(
+            "next_steps".to_owned(),
+            json!(format!(
+                "{} row(s) omitted; ORDER BY + keyset (`WHERE (col, id) < \
+                 (<last_col>, <last_id>)`) to page, or output=parquet|ndjson for the \
+                 full set. See schema://pond-sql.",
+                total - shown
+            )),
+        );
+    }
+    Ok(JsonValue::Object(payload))
+}
+
+/// Convert RecordBatches to a JSON array of row objects via the existing
+/// NDJSON writer (handles all Arrow types, including the decoded JSON columns
+/// that come out of `displayable`).
+fn batches_to_json_rows(batches: &[RecordBatch]) -> Result<Vec<JsonValue>, SqlError> {
+    if batches.iter().all(|batch| batch.num_rows() == 0) {
+        return Ok(Vec::new());
+    }
+    let mut buffer = Vec::new();
+    {
+        let mut writer = LineDelimitedWriter::new(&mut buffer);
+        let refs: Vec<&RecordBatch> = batches.iter().collect();
+        writer
+            .write_batches(&refs)
+            .map_err(|error| SqlError::Infra(anyhow!("ndjson encode: {error}")))?;
+        writer
+            .finish()
+            .map_err(|error| SqlError::Infra(anyhow!("ndjson finish: {error}")))?;
+    }
+    let text = String::from_utf8(buffer)
+        .map_err(|error| SqlError::Infra(anyhow!("ndjson not utf-8: {error}")))?;
+    text.lines()
+        .filter(|line| !line.is_empty())
+        .map(|line| {
+            serde_json::from_str::<JsonValue>(line)
+                .map_err(|error| SqlError::Infra(anyhow!("ndjson parse: {error}")))
+        })
+        .collect()
 }
 
 fn limit_batches(batches: &[RecordBatch], max_rows: usize) -> Vec<RecordBatch> {
@@ -361,14 +583,47 @@ mod tests {
     use super::*;
 
     fn rejected(sql: &str) -> bool {
-        matches!(ensure_single_select(sql), Err(SqlError::Query(_)))
+        matches!(parse_and_gate(sql), Err(SqlError::Query(_)))
+    }
+
+    fn parses_as(sql: &str, expected: StatementKind) -> bool {
+        match parse_and_gate(sql) {
+            Ok(parsed) => matches!(
+                (&parsed.kind, &expected),
+                (StatementKind::Query, StatementKind::Query)
+                    | (StatementKind::Explain, StatementKind::Explain)
+            ),
+            Err(_) => false,
+        }
     }
 
     #[test]
     fn allows_single_select_and_cte() {
-        assert!(ensure_single_select("SELECT 1").is_ok());
-        assert!(ensure_single_select("SELECT role, count(*) FROM messages GROUP BY role").is_ok());
-        assert!(ensure_single_select("WITH t AS (SELECT 1 AS a) SELECT a FROM t").is_ok());
+        assert!(parses_as("SELECT 1", StatementKind::Query));
+        assert!(parses_as(
+            "SELECT role, count(*) FROM messages GROUP BY role",
+            StatementKind::Query
+        ));
+        assert!(parses_as(
+            "WITH t AS (SELECT 1 AS a) SELECT a FROM t",
+            StatementKind::Query
+        ));
+    }
+
+    #[test]
+    fn allows_explain_of_select() {
+        assert!(parses_as("EXPLAIN SELECT 1", StatementKind::Explain));
+        assert!(parses_as(
+            "EXPLAIN ANALYZE SELECT role FROM messages",
+            StatementKind::Explain
+        ));
+    }
+
+    #[test]
+    fn rejects_explain_of_non_query() {
+        // EXPLAIN of a side-effecting statement: the inner statement is what
+        // would matter; reject to keep the surface tight.
+        assert!(rejected("EXPLAIN INSERT INTO messages VALUES ('x')"));
     }
 
     #[test]
@@ -384,8 +639,6 @@ mod tests {
         ));
         assert!(rejected("COPY (SELECT 1) TO '/tmp/x.parquet'"));
         assert!(rejected("SET a = 1"));
-        assert!(rejected("EXPLAIN SELECT 1"));
-        assert!(rejected("EXPLAIN ANALYZE SELECT 1"));
     }
 
     #[test]
@@ -397,5 +650,31 @@ mod tests {
     #[test]
     fn rejects_unparseable() {
         assert!(rejected("NOT SQL AT ALL ;;"));
+    }
+
+    fn mentions_vector(sql: &str) -> bool {
+        match parse_and_gate(sql) {
+            Ok(parsed) => projection_mentions_vector(parsed.projection_query()),
+            Err(_) => false,
+        }
+    }
+
+    #[test]
+    fn explicit_vector_projection_is_rejected() {
+        assert!(mentions_vector("SELECT vector FROM messages"));
+        assert!(mentions_vector("SELECT id, vector FROM messages"));
+        assert!(mentions_vector("SELECT m.vector FROM messages m"));
+        assert!(mentions_vector("SELECT array_length(vector) FROM messages"));
+        assert!(mentions_vector("EXPLAIN SELECT vector FROM messages"));
+    }
+
+    #[test]
+    fn select_star_and_where_vector_are_allowed() {
+        // `SELECT *` falls through to the existing silent-strip in displayable.
+        assert!(!mentions_vector("SELECT * FROM messages"));
+        // Filtering on `vector` is documented as legal (`vector IS NOT NULL`).
+        assert!(!mentions_vector(
+            "SELECT id FROM messages WHERE vector IS NOT NULL"
+        ));
     }
 }

--- a/src/substrate.rs
+++ b/src/substrate.rs
@@ -696,6 +696,76 @@ impl Handle {
         &self.storage_options
     }
 
+    /// Object-store URI for a `pond_sql_query` export artifact:
+    /// `<location>/exports/<name>`. A sibling of the `*.lance` table dirs;
+    /// the Directory namespace tracks tables in its `__manifest` table rather
+    /// than by listing prefixes, so this prefix is never seen as a table
+    /// (lance-namespace-impls dir/manifest.rs). Never `register_table`'d.
+    fn export_uri(&self, name: &str) -> String {
+        format!(
+            "{}/exports/{name}",
+            self.location.as_str().trim_end_matches('/')
+        )
+    }
+
+    /// `ObjectStoreParams` carrying the handle's `storage_options` so raw
+    /// object-store opens (export I/O, `table_sizes` listing) inherit the same
+    /// credentials/region as the dataset opens. Empty options -> no accessor.
+    fn object_store_params(&self) -> ObjectStoreParams {
+        ObjectStoreParams {
+            storage_options_accessor: (!self.storage_options.is_empty()).then(|| {
+                Arc::new(StorageOptionsAccessor::with_static_options(
+                    self.storage_options.clone(),
+                ))
+            }),
+            ..Default::default()
+        }
+    }
+
+    /// Write a `pond_sql_query` export artifact, reusing the handle's
+    /// storage_options so S3 installs inherit the same credentials.
+    pub(crate) async fn export_write(&self, name: &str, bytes: &[u8]) -> Result<()> {
+        let uri = self.export_uri(name);
+        let registry = Arc::new(ObjectStoreRegistry::default());
+        let (store, path) =
+            ObjectStore::from_uri_and_params(registry, &uri, &self.object_store_params())
+                .await
+                .with_context(|| format!("failed to open object store for {uri}"))?;
+        store
+            .put(&path, bytes)
+            .await
+            .with_context(|| format!("failed to write export {uri}"))?;
+        Ok(())
+    }
+
+    /// Read a `pond_sql_query` export artifact back (for the
+    /// `pond-sql-export://` MCP resource).
+    pub(crate) async fn export_read(&self, name: &str) -> Result<Vec<u8>> {
+        let uri = self.export_uri(name);
+        let registry = Arc::new(ObjectStoreRegistry::default());
+        let (store, path) =
+            ObjectStore::from_uri_and_params(registry, &uri, &self.object_store_params())
+                .await
+                .with_context(|| format!("failed to open object store for {uri}"))?;
+        let bytes = store
+            .read_one_all(&path)
+            .await
+            .with_context(|| format!("failed to read export {uri}"))?;
+        Ok(bytes.to_vec())
+    }
+
+    /// Local filesystem path of an export artifact, when the data dir is
+    /// `file://`. The stdio MCP client shares this filesystem, so it can read
+    /// the file directly (e.g. duckdb/polars) instead of pulling base64 via
+    /// `resources/read`. `None` on object-store installs.
+    pub(crate) fn export_local_path(&self, name: &str) -> Option<std::path::PathBuf> {
+        if self.location.scheme() != "file" {
+            return None;
+        }
+        let dir = self.location.to_file_path().ok()?;
+        Some(dir.join("exports").join(name))
+    }
+
     pub async fn row_counts(&self) -> Result<(usize, usize, usize)> {
         Ok((
             self.count_rows(Table::Sessions).await?,
@@ -1024,14 +1094,7 @@ impl Handle {
     /// (spec.md#lance-chokepoints-storage), identical for `file://` and `s3://`.
     pub async fn table_sizes(&self) -> Result<TableSizes> {
         let registry = Arc::new(ObjectStoreRegistry::default());
-        let params = ObjectStoreParams {
-            storage_options_accessor: (!self.storage_options.is_empty()).then(|| {
-                Arc::new(StorageOptionsAccessor::with_static_options(
-                    self.storage_options.clone(),
-                ))
-            }),
-            ..Default::default()
-        };
+        let params = self.object_store_params();
 
         let sessions = self
             .listed_size(

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -3,8 +3,8 @@
 //! per-transport behavior divergence.
 //!
 //! HTTP exposes `POST /v1/search`, `POST /v1/get`, and `POST /v1/ingest`. MCP
-//! exposes only `pond_search` / `pond_get` (the kb-parity surface); ingest
-//! stays HTTP-only and CLI-only.
+//! exposes `pond_search` / `pond_get` (the kb-parity surface) plus
+//! `pond_sql_query` (read-only SQL); ingest stays HTTP-only and CLI-only.
 
 use std::sync::Arc;
 
@@ -167,11 +167,14 @@ pub mod http {
 }
 
 pub mod mcp {
-    //! The rmcp MCP layer: `pond_search` / `pond_get` tools and `schema://pond`
-    //! / `stats://pond` resources, transport-agnostic. Mounted on stdio (via
-    //! `pond mcp`) and on the `/mcp` HTTP route (via `pond serve`).
+    //! The rmcp MCP layer: `pond_search` / `pond_get` / `pond_sql_query` tools
+    //! and `schema://pond` / `schema://pond-sql` / `stats://pond` (plus
+    //! `pond-sql-export://` export artifacts) resources, transport-agnostic.
+    //! Mounted on stdio (via `pond mcp`) and on the `/mcp` HTTP route (via
+    //! `pond serve`).
 
     use anyhow::Context;
+    use base64::{Engine, engine::general_purpose::STANDARD};
     use rmcp::{
         ErrorData, RoleServer, ServerHandler, ServiceExt,
         handler::server::{router::tool::ToolRouter, wrapper::Parameters},
@@ -187,12 +190,15 @@ pub mod mcp {
         transport::stdio,
     };
     use serde::Deserialize;
+    use uuid::Uuid;
 
     use super::AppState;
     use crate::{
         PROTOCOL_VERSION,
         handlers::pond_get as run_get,
         handlers::pond_search as run_search,
+        sql,
+        substrate::Table,
         wire::{
             ErrorCode as WireErrorCode, ErrorEnvelope, GetEnvelope, GetRequest, GetResponse,
             GetResult, MessageView, PartKind, PartSummary, ProjectFilter, ResponseMode,
@@ -237,6 +243,58 @@ at 1000. Bounded by a size budget: when the footer shows `after_id=`, pass it \
 back to page. A whole-session response also lists the session's subagents (each \
 stored as its own session) in a footer; pass a listed id back as session_id to \
 open it. Not for bulk export - use `pond export`.";
+
+    /// Static documentation served as the `schema://pond-sql` resource: the
+    /// table/column schema, dialect, function set, and conventions for
+    /// `pond_sql_query`. Loaded on demand so the tool description stays tight.
+    const SQL_SCHEMA_DOC: &str = "\
+pond_sql_query runs ONE read-only SELECT (DataFusion SQL, PostgreSQL-compatible) \
+over three registered tables. Read-only is hard-enforced: anything other than a \
+single SELECT/WITH query is rejected (no INSERT/UPDATE/DELETE/CREATE/DROP/COPY/\
+EXPLAIN/SET). It complements pond_search (semantic recall) - use it for filtering, \
+joins, and aggregation over metadata; use pond_search for meaning-based search.
+
+Tables and columns:
+- messages(session_id text, id text, timestamp timestamp(us, UTC), role text \
+{user|assistant|system|tool}, source_agent text, project text, content text NULL, \
+search_text text NULL, embedding_model text NULL, options json). The embedding \
+`vector` column exists but is never returned (omitted from results); you may still \
+filter on it, e.g. `vector IS NOT NULL`.
+- sessions(id text, parent_session_id text NULL, parent_message_id text NULL, \
+source_agent text, created_at timestamp(us, UTC), project text, options json).
+- parts(session_id text, message_id text, id text, ordinal int, type text, \
+provenance text {conversational|injected}, variant_data json, options json). The \
+verbatim message body lives here in `variant_data`.
+
+Join keys: messages.session_id = sessions.id; parts.session_id = messages.session_id \
+AND parts.message_id = messages.id. Subagents are sessions whose source_agent \
+matches '%/%' (e.g. 'claude-code/general-purpose').
+
+Indexed (fast) filter columns: messages.project / session_id / timestamp / role / \
+source_agent; parts.session_id / message_id; sessions.id. Prefer equality/range \
+predicates on these.
+
+JSON columns (options, variant_data) are returned as decoded JSON text. To filter \
+inside them use lance's JSON UDFs (filter-only): json_get_string(col,'path'), \
+json_get_int, json_get_bool, json_extract(col,'$.a.b'), json_array_contains.
+
+Full-text (BM25) search in SQL via the fts() table function: SELECT * FROM \
+fts('messages', '{\"match\":{\"column\":\"search_text\",\"terms\":\"...\"}}') - \
+compose with WHERE/JOIN/GROUP BY around it. Vector/semantic search is NOT available \
+in SQL; use pond_search for that.
+
+Functions: standard SQL (GROUP BY/HAVING/ORDER BY/LIMIT/JOIN/UNION/DISTINCT/CTE/\
+subquery/CASE/CAST), aggregates (count, count(distinct), sum, avg, min, max, \
+stddev, median, approx_distinct), date (date_trunc, date_part, date_bin, to_char, \
+now), regex (regexp_like, regexp_match, regexp_replace), and the usual string \
+functions. Quote identifiers with double quotes (e.g. \"timestamp\"); string \
+literals use single quotes.
+
+Output: by default a row-capped rendered table (set `limit`, default 100). For the \
+full result set set output=parquet or output=ndjson - pond writes the file and \
+returns a `pond-sql-export://<id>` resource link; read it via MCP resources/read \
+(on a local/stdio install the response also names the on-disk path so you can open \
+it directly with duckdb/polars).";
 
     /// `pond_search` MCP tool parameters.
     #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -321,6 +379,27 @@ open it. Not for bulk export - use `pond export`.";
         /// `message_id` (session mode) or last `part_id` (message mode).
         #[serde(default)]
         after_id: Option<String>,
+    }
+
+    /// `pond_sql_query` MCP tool parameters.
+    #[derive(Debug, Deserialize, schemars::JsonSchema)]
+    struct McpSqlParams {
+        /// One read-only SQL statement (DataFusion / PostgreSQL-compatible)
+        /// over tables `sessions`, `messages`, `parts`. SELECT/WITH only;
+        /// writes and side-effecting statements are rejected. See the
+        /// `schema://pond-sql` resource for columns, joins, indexed filter
+        /// columns, JSON/FTS functions, and examples.
+        sql: String,
+        /// Output format: "table" (default; rendered, row-capped inline),
+        /// "parquet", or "ndjson". For parquet/ndjson the full result set is
+        /// written to a file and a `pond-sql-export://` resource link is
+        /// returned (no truncation).
+        #[serde(default)]
+        output: Option<String>,
+        /// Inline row cap for "table" output. Default 100, max 1000. Ignored
+        /// for parquet/ndjson exports (which return every row).
+        #[serde(default)]
+        limit: Option<usize>,
     }
 
     fn parse_session_from(value: Option<String>) -> SessionFrom {
@@ -465,6 +544,95 @@ open it. Not for bulk export - use `pond export`.";
                 GetEnvelope::Error(envelope) => Err(to_error_data(&envelope)),
             }
         }
+
+        #[tool(
+            description = "Run ONE read-only SQL query (DataFusion / PostgreSQL-compatible) \
+                           over the stored corpus as three tables: sessions, messages, parts. \
+                           For filtering, joins, and aggregation (counts, group-by, time \
+                           buckets) - the analytic complement to pond_search's semantic \
+                           recall. SELECT/WITH only; writes and side-effecting statements are \
+                           rejected. BM25 search-in-SQL via fts('messages', '{...json...}'); \
+                           JSON columns queryable with json_get_string / json_extract. The \
+                           embedding `vector` column is never returned. Output defaults to a \
+                           row-capped table (set `limit`); set output=parquet|ndjson to write \
+                           the full result to a file returned as a pond-sql-export:// resource. \
+                           Read resource schema://pond-sql for the column list, join keys, \
+                           indexed columns, functions, and examples.",
+            annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+        )]
+        async fn pond_sql_query(
+            &self,
+            Parameters(params): Parameters<McpSqlParams>,
+        ) -> Result<CallToolResult, ErrorData> {
+            let mode = match params.output.as_deref() {
+                None | Some("table") => sql::Mode::Inline,
+                Some("parquet") => sql::Mode::Export(sql::Format::Parquet),
+                Some("ndjson") => sql::Mode::Export(sql::Format::Ndjson),
+                Some(other) => {
+                    return Ok(CallToolResult::error(vec![Content::text(format!(
+                        "unknown output {other:?}; use \"table\", \"parquet\", or \"ndjson\""
+                    ))]));
+                }
+            };
+            let inline_rows = params
+                .limit
+                .unwrap_or(sql::DEFAULT_INLINE_ROWS)
+                .min(sql::MAX_INLINE_ROWS);
+
+            // The three tables are independent (per-table caches/mutexes), so
+            // overlap their freshness/manifest fetches rather than serialize.
+            let store = &self.state.store;
+            let tables = match tokio::try_join!(
+                store.dataset(Table::Sessions),
+                store.dataset(Table::Messages),
+                store.dataset(Table::Parts),
+            ) {
+                Ok((sessions, messages, parts)) => sql::Tables {
+                    sessions,
+                    messages,
+                    parts,
+                },
+                Err(_) => {
+                    return Err(ErrorData::internal_error(
+                        "sql datasets unavailable".to_owned(),
+                        None,
+                    ));
+                }
+            };
+
+            match sql::run(&tables, &params.sql, mode, inline_rows).await {
+                Ok(sql::Outcome::Inline(text)) => Ok(tool_result(text)),
+                Ok(sql::Outcome::Export {
+                    bytes,
+                    format,
+                    rows,
+                    columns,
+                }) => {
+                    let name = format!("{}.{}", Uuid::now_v7(), format.ext());
+                    match store.export_write(&name, &bytes).await {
+                        Ok(_) => Ok(export_result(
+                            store,
+                            &name,
+                            format,
+                            rows,
+                            &columns,
+                            bytes.len(),
+                        )),
+                        Err(error) => Err(ErrorData::internal_error(
+                            format!("export write failed: {error}"),
+                            None,
+                        )),
+                    }
+                }
+                Err(sql::SqlError::Query(message)) => {
+                    Ok(CallToolResult::error(vec![Content::text(message)]))
+                }
+                Err(sql::SqlError::Infra(error)) => Err(ErrorData::internal_error(
+                    format!("sql execution failed: {error}"),
+                    None,
+                )),
+            }
+        }
     }
 
     // `router = self.tool_router` makes the generated `call_tool` / `list_tools`
@@ -494,7 +662,10 @@ open it. Not for bulk export - use `pond export`.";
                  recent topic + project + from_date=today), then pond_get(session_id, \
                  session_from=\"end\") for the recent pre-compaction turns. Deeper \
                  reference on demand: resource schema://pond (all filters + response format), \
-                 stats://pond (corpus + embedding stats).",
+                 stats://pond (corpus + embedding stats). For structured/analytic queries \
+                 (filtering, joins, counts, group-by) use pond_sql_query: read-only SQL \
+                 (SELECT only) over the sessions/messages/parts tables, with optional \
+                 parquet/ndjson export; see resource schema://pond-sql.",
             )
         }
 
@@ -506,6 +677,7 @@ open it. Not for bulk export - use `pond export`.";
             Ok(ListResourcesResult {
                 resources: vec![
                     RawResource::new("schema://pond", "pond search schema").no_annotation(),
+                    RawResource::new("schema://pond-sql", "pond SQL table schema").no_annotation(),
                     RawResource::new("stats://pond", "pond corpus stats").no_annotation(),
                 ],
                 next_cursor: None,
@@ -523,6 +695,36 @@ open it. Not for bulk export - use `pond export`.";
                     SCHEMA_DOC,
                     request.uri,
                 )])),
+                "schema://pond-sql" => Ok(ReadResourceResult::new(vec![ResourceContents::text(
+                    SQL_SCHEMA_DOC,
+                    request.uri,
+                )])),
+                // `pond_sql_query` export artifacts: read the file pond wrote
+                // (parquet -> base64 blob, ndjson -> text). The filename is
+                // validated to a minted `<uuid>.<ext>` so the URI can't traverse.
+                uri if uri.starts_with("pond-sql-export://") => {
+                    let name = uri.trim_start_matches("pond-sql-export://").to_owned();
+                    if !valid_export_name(&name) {
+                        return Err(ErrorData::resource_not_found(
+                            format!("invalid export id: {name}"),
+                            None,
+                        ));
+                    }
+                    let bytes = self.state.store.export_read(&name).await.map_err(|error| {
+                        ErrorData::resource_not_found(format!("export not found: {error}"), None)
+                    })?;
+                    let contents = if name.ends_with(".ndjson") {
+                        ResourceContents::text(
+                            String::from_utf8_lossy(&bytes).into_owned(),
+                            request.uri,
+                        )
+                        .with_mime_type("application/x-ndjson")
+                    } else {
+                        ResourceContents::blob(STANDARD.encode(&bytes), request.uri)
+                            .with_mime_type("application/vnd.apache.parquet")
+                    };
+                    Ok(ReadResourceResult::new(vec![contents]))
+                }
                 "stats://pond" => {
                     let store = &self.state.store;
                     let map_err = |error: anyhow::Error| {
@@ -606,6 +808,7 @@ open it. Not for bulk export - use `pond export`.";
             let chars = match tool.name.as_ref() {
                 "pond_search" => 80_000,
                 "pond_get" => 200_000,
+                "pond_sql_query" => 80_000,
                 _ => continue,
             };
             let mut meta = serde_json::Map::new();
@@ -636,6 +839,56 @@ open it. Not for bulk export - use `pond export`.";
     /// structured wire shape use the HTTP `/v1/*` JSON API instead.
     fn tool_result(transcript: String) -> CallToolResult {
         CallToolResult::success(vec![Content::text(transcript)])
+    }
+
+    /// Build the `pond_sql_query` export result: a text summary plus a
+    /// `resource_link` to the artifact (the spec-canonical way to hand back a
+    /// tool-produced file - the bytes ride `resources/read`, not the tool
+    /// result, so they don't load into context unless the host fetches them).
+    /// On a `file://` install the summary also names the on-disk path so a
+    /// co-located agent can read it directly.
+    fn export_result(
+        store: &crate::sessions::Store,
+        name: &str,
+        format: sql::Format,
+        rows: usize,
+        columns: &[String],
+        bytes: usize,
+    ) -> CallToolResult {
+        let uri = format!("pond-sql-export://{name}");
+        let column_list = if columns.is_empty() {
+            "(none)".to_owned()
+        } else {
+            columns.join(", ")
+        };
+        let mut summary = format!(
+            "Exported {rows} row(s), {bytes} bytes ({}). Columns: {column_list}.\n\
+             Fetch via MCP resources/read on {uri}.",
+            format.ext()
+        );
+        if let Some(path) = store.export_local_path(name) {
+            summary.push_str(&format!(
+                "\nLocal file: {} - on this (stdio) install you can read it directly \
+                 (e.g. duckdb, polars).",
+                path.display()
+            ));
+        }
+        let link = RawResource::new(uri, name.to_owned())
+            .with_description(format!("pond SQL export ({}, {rows} rows)", format.ext()))
+            .with_mime_type(format.mime().to_owned())
+            .with_size(u32::try_from(bytes).unwrap_or(u32::MAX));
+        CallToolResult::success(vec![Content::text(summary), Content::resource_link(link)])
+    }
+
+    /// Accept only the export filenames pond mints (`<uuid>.parquet|ndjson`),
+    /// guarding the `pond-sql-export://` resource against path traversal.
+    fn valid_export_name(name: &str) -> bool {
+        let Some((stem, ext)) = name.rsplit_once('.') else {
+            return false;
+        };
+        matches!(ext, "parquet" | "ndjson")
+            && !stem.is_empty()
+            && stem.bytes().all(|b| b.is_ascii_hexdigit() || b == b'-')
     }
 
     /// Footer for a `pond_get` session response listing the session's spawn-only

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -245,21 +245,24 @@ stored as its own session) in a footer; pass a listed id back as session_id to \
 open it. Not for bulk export - use `pond export`.";
 
     /// Static documentation served as the `schema://pond-sql` resource: the
-    /// table/column schema, dialect, function set, and conventions for
-    /// `pond_sql_query`. Loaded on demand so the tool description stays tight.
+    /// table/column schema, dialect, function set, output modes, pagination
+    /// pattern, drilling pattern, and worked examples for `pond_sql_query`.
+    /// Loaded on demand so the tool description stays tight.
     const SQL_SCHEMA_DOC: &str = "\
 pond_sql_query runs ONE read-only SELECT (DataFusion SQL, PostgreSQL-compatible) \
 over three registered tables. Read-only is hard-enforced: anything other than a \
-single SELECT/WITH query is rejected (no INSERT/UPDATE/DELETE/CREATE/DROP/COPY/\
-EXPLAIN/SET). It complements pond_search (semantic recall) - use it for filtering, \
-joins, and aggregation over metadata; use pond_search for meaning-based search.
+single SELECT/WITH (or EXPLAIN of one) is rejected (no INSERT/UPDATE/DELETE/\
+CREATE/DROP/COPY/SET). It complements pond_search (semantic recall) - use it for \
+filtering, joins, and aggregation over metadata; use pond_search for meaning-based \
+search.
 
 Tables and columns:
 - messages(session_id text, id text, timestamp timestamp(us, UTC), role text \
 {user|assistant|system|tool}, source_agent text, project text, content text NULL, \
 search_text text NULL, embedding_model text NULL, options json). The embedding \
-`vector` column exists but is never returned (omitted from results); you may still \
-filter on it, e.g. `vector IS NOT NULL`.
+`vector` column exists but is never returned (omitted from results) and explicit \
+projection of it is rejected; you may still filter on it in WHERE, e.g. `vector \
+IS NOT NULL`. For semantic search, use pond_search.
 - sessions(id text, parent_session_id text NULL, parent_message_id text NULL, \
 source_agent text, created_at timestamp(us, UTC), project text, options json).
 - parts(session_id text, message_id text, id text, ordinal int, type text, \
@@ -283,18 +286,117 @@ fts('messages', '{\"match\":{\"column\":\"search_text\",\"terms\":\"...\"}}') - 
 compose with WHERE/JOIN/GROUP BY around it. Vector/semantic search is NOT available \
 in SQL; use pond_search for that.
 
-Functions: standard SQL (GROUP BY/HAVING/ORDER BY/LIMIT/JOIN/UNION/DISTINCT/CTE/\
-subquery/CASE/CAST), aggregates (count, count(distinct), sum, avg, min, max, \
-stddev, median, approx_distinct), date (date_trunc, date_part, date_bin, to_char, \
-now), regex (regexp_like, regexp_match, regexp_replace), and the usual string \
-functions. Quote identifiers with double quotes (e.g. \"timestamp\"); string \
-literals use single quotes.
+Function quick-reference (exact DataFusion names so the model doesn't have to \
+guess):
+- aggregates: count, count(distinct ...), sum, avg, min, max, stddev, median, \
+approx_distinct, approx_percentile_cont, array_agg, string_agg
+- date/time: now(), date_trunc('day'|'hour'|'minute'|..., ts), date_part('year'|..., \
+ts), date_bin(interval, ts, origin), to_char(ts, fmt), to_timestamp(text), \
+extract(field FROM ts), age(t1, t2)
+- intervals: `INTERVAL '7 days'`, `INTERVAL '1 hour'` (single-quoted, postgres-style)
+- string: length, lower, upper, substr, position, split_part, regexp_like, \
+regexp_match, regexp_replace, like, ilike, starts_with, ends_with, concat, \
+concat_ws
+- numeric: round, floor, ceil, abs, sign, log, exp, power, sqrt
+- conditional: CASE WHEN ... THEN ... ELSE ..., coalesce, nullif, greatest, least
+- cast: CAST(x AS TYPE) or x::TYPE (e.g. variant_data::text)
+Quote identifiers with double quotes when they collide with keywords (e.g. \
+\"timestamp\"); string literals use single quotes.
 
-Output: by default a row-capped rendered table (set `limit`, default 100). For the \
-full result set set output=parquet or output=ndjson - pond writes the file and \
-returns a `pond-sql-export://<id>` resource link; read it via MCP resources/read \
-(on a local/stdio install the response also names the on-disk path so you can open \
-it directly with duckdb/polars).";
+EXPLAIN is allowed: `EXPLAIN <query>` or `EXPLAIN ANALYZE <query>` returns the \
+DataFusion plan (and per-operator timings for ANALYZE) so you can self-diagnose \
+slow queries without leaving SQL.
+
+Output modes (the `output` arg):
+- table (default): a row-capped rendered ASCII table with a header showing \
+`{total_rows} in {elapsed_ms} ms; showing {shown}` and, on truncation, a \
+keyset-pagination hint.
+- json: same row-capped payload as `table` but delivered as a JSON object \
+{total_rows, shown_rows, truncated, elapsed_ms, columns, rows: [{col: val, ...}]}. \
+Spec-compliant dual delivery: the structured JSON rides MCP's `structuredContent` \
+field; clients that don't surface that channel get the same JSON as a text block. \
+Empirically validated on Claude Code 2.1.165 - the agent reads the structured form.
+- parquet | ndjson: write the FULL result set to a file and return a \
+`pond-sql-export://<id>` resource link; read it via MCP resources/read. On a \
+local/stdio install the response also names the on-disk path so you can open it \
+directly with duckdb/polars.
+
+Pagination - keyset (preferred):
+Use ORDER BY on indexed columns plus a composite seek key for stable tie-breaking. \
+The agent owns the cursor (the last sort value it saw); no server-side state.
+
+  -- page 1: most recent 100 messages in pond
+  SELECT id, timestamp, role, project
+  FROM messages
+  WHERE project LIKE '%pond%'
+  ORDER BY timestamp DESC, id DESC
+  LIMIT 100;
+
+  -- page 2: pass back the last (timestamp, id) the agent saw
+  SELECT id, timestamp, role, project
+  FROM messages
+  WHERE project LIKE '%pond%'
+    AND (timestamp, id) < (TIMESTAMP '2026-06-05T08:14:22.123456Z', 'last-id')
+  ORDER BY timestamp DESC, id DESC
+  LIMIT 100;
+
+Keyset stays stable across concurrent ingest (older rows don't shift) and uses \
+the btree on `timestamp`/`id` directly. For known-bounded full results, skip \
+pagination entirely: output=parquet writes everything in one call. OFFSET works \
+but scans-and-discards prior rows and shifts pages under writes - prefer keyset.
+
+Drilling from aggregates to content (instead of N round-trips of pond_get):
+JOIN to messages/parts directly. Example - top 10 longest sessions with first \
+user message:
+
+  WITH top_sessions AS (
+    SELECT session_id, COUNT(*) AS msgs
+    FROM messages
+    GROUP BY session_id
+    ORDER BY msgs DESC
+    LIMIT 10
+  )
+  SELECT ts.session_id, ts.msgs, s.project, s.source_agent,
+         m.content AS first_user_msg
+  FROM top_sessions ts
+  JOIN sessions s ON s.id = ts.session_id
+  LEFT JOIN messages m
+    ON m.session_id = ts.session_id
+   AND m.role = 'user'
+   AND m.timestamp = (
+     SELECT MIN(timestamp) FROM messages
+     WHERE session_id = ts.session_id AND role = 'user'
+   );
+
+One call, agent picks exactly which columns to hydrate. When you want the \
+pond_get-style rendered transcript (tool-call lines, subagent footer), call \
+pond_get with the session_id - that's its job.
+
+Examples (3 patterns the agent should recognize):
+
+  -- 1. Activity by project this week
+  SELECT project, COUNT(*) AS msgs, COUNT(DISTINCT session_id) AS sessions
+  FROM messages
+  WHERE timestamp >= now() - INTERVAL '7 days'
+  GROUP BY project
+  ORDER BY msgs DESC
+  LIMIT 20;
+
+  -- 2. Subagent breakdown
+  SELECT source_agent, COUNT(*) AS n
+  FROM sessions
+  WHERE source_agent LIKE '%/%'
+  GROUP BY source_agent
+  ORDER BY n DESC;
+
+  -- 3. BM25 search in SQL, joined with metadata
+  SELECT m.session_id, m.timestamp, m.project, m.content
+  FROM fts('messages', \
+'{\"match\":{\"column\":\"search_text\",\"terms\":\"race condition\"}}') f
+  JOIN messages m ON m.id = f.id
+  WHERE m.project LIKE '%pond%'
+  ORDER BY m.timestamp DESC
+  LIMIT 50;";
 
     /// `pond_search` MCP tool parameters.
     #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -385,19 +487,21 @@ it directly with duckdb/polars).";
     #[derive(Debug, Deserialize, schemars::JsonSchema)]
     struct McpSqlParams {
         /// One read-only SQL statement (DataFusion / PostgreSQL-compatible)
-        /// over tables `sessions`, `messages`, `parts`. SELECT/WITH only;
-        /// writes and side-effecting statements are rejected. See the
-        /// `schema://pond-sql` resource for columns, joins, indexed filter
-        /// columns, JSON/FTS functions, and examples.
+        /// over tables `sessions`, `messages`, `parts`. SELECT/WITH only
+        /// (or EXPLAIN of one); writes and side-effecting statements are
+        /// rejected. See the `schema://pond-sql` resource for columns, joins,
+        /// indexed filter columns, JSON/FTS functions, the function quick-
+        /// reference, pagination + drilling patterns, and examples.
         sql: String,
-        /// Output format: "table" (default; rendered, row-capped inline),
-        /// "parquet", or "ndjson". For parquet/ndjson the full result set is
-        /// written to a file and a `pond-sql-export://` resource link is
-        /// returned (no truncation).
+        /// Output format: "table" (default; rendered ASCII table with metrics
+        /// footer), "json" (same row-capped data as a structured JSON object,
+        /// delivered via MCP structuredContent), "parquet", or "ndjson". For
+        /// parquet/ndjson the full result set is written to a file and a
+        /// `pond-sql-export://` resource link is returned (no truncation).
         #[serde(default)]
         output: Option<String>,
-        /// Inline row cap for "table" output. Default 100, max 1000. Ignored
-        /// for parquet/ndjson exports (which return every row).
+        /// Inline row cap for "table" / "json" output. Default 100, max 1000.
+        /// Ignored for parquet/ndjson exports (which return every row).
         #[serde(default)]
         limit: Option<usize>,
     }
@@ -550,14 +654,23 @@ it directly with duckdb/polars).";
                            over the stored corpus as three tables: sessions, messages, parts. \
                            For filtering, joins, and aggregation (counts, group-by, time \
                            buckets) - the analytic complement to pond_search's semantic \
-                           recall. SELECT/WITH only; writes and side-effecting statements are \
-                           rejected. BM25 search-in-SQL via fts('messages', '{...json...}'); \
-                           JSON columns queryable with json_get_string / json_extract. The \
-                           embedding `vector` column is never returned. Output defaults to a \
-                           row-capped table (set `limit`); set output=parquet|ndjson to write \
-                           the full result to a file returned as a pond-sql-export:// resource. \
-                           Read resource schema://pond-sql for the column list, join keys, \
-                           indexed columns, functions, and examples.",
+                           recall. SELECT/WITH only (or EXPLAIN of one); writes and side- \
+                           effecting statements are rejected. BM25 search-in-SQL via \
+                           fts('messages', '{...json...}'); JSON columns queryable with \
+                           json_get_string / json_extract. The embedding `vector` column is \
+                           never returned (explicit projection is rejected; filtering in \
+                           WHERE is fine). Output defaults to a row-capped rendered table; \
+                           set output=json for a structured JSON payload (delivered via MCP \
+                           structuredContent), or output=parquet|ndjson to write the full \
+                           result to a file returned as a pond-sql-export:// resource. Three \
+                           starter patterns: (a) GROUP BY for activity counts - SELECT \
+                           project, COUNT(*) FROM messages WHERE timestamp >= now() - \
+                           INTERVAL '7 days' GROUP BY project; (b) keyset pagination - ORDER \
+                           BY timestamp DESC, id DESC then WHERE (timestamp, id) < (...) for \
+                           the next page; (c) JOIN messages/sessions/parts to hydrate \
+                           aggregates instead of N pond_get calls. Read resource \
+                           schema://pond-sql for the full column list, indexed columns, \
+                           function quick-reference, pagination + drilling examples.",
             annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
         )]
         async fn pond_sql_query(
@@ -566,11 +679,13 @@ it directly with duckdb/polars).";
         ) -> Result<CallToolResult, ErrorData> {
             let mode = match params.output.as_deref() {
                 None | Some("table") => sql::Mode::Inline,
+                Some("json") => sql::Mode::InlineJson,
                 Some("parquet") => sql::Mode::Export(sql::Format::Parquet),
                 Some("ndjson") => sql::Mode::Export(sql::Format::Ndjson),
                 Some(other) => {
                     return Ok(CallToolResult::error(vec![Content::text(format!(
-                        "unknown output {other:?}; use \"table\", \"parquet\", or \"ndjson\""
+                        "unknown output {other:?}; use \"table\", \"json\", \"parquet\", \
+                         or \"ndjson\""
                     ))]));
                 }
             };
@@ -602,6 +717,7 @@ it directly with duckdb/polars).";
 
             match sql::run(&tables, &params.sql, mode, inline_rows).await {
                 Ok(sql::Outcome::Inline(text)) => Ok(tool_result(text)),
+                Ok(sql::Outcome::InlineJson(value)) => Ok(CallToolResult::structured(value)),
                 Ok(sql::Outcome::Export {
                     bytes,
                     format,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -23,6 +23,8 @@ mod s3_backend;
 mod search;
 #[path = "integration/session_scoped_pk.rs"]
 mod session_scoped_pk;
+#[path = "integration/sql.rs"]
+mod sql;
 #[path = "integration/store_concurrency.rs"]
 mod store_concurrency;
 #[path = "integration/transport_http.rs"]

--- a/tests/integration/sql.rs
+++ b/tests/integration/sql.rs
@@ -1,0 +1,299 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+//! `pond_sql_query` over the stdio-MCP transport (spec.md#protocol): an
+//! in-process rmcp client drives read-only SQL against a synthetic corpus.
+//! Asserts inline aggregation, the hard read-only gate (DROP/INSERT rejected as
+//! tool errors), `vector`-column omission, the `fts()` UDTF, and the
+//! parquet/ndjson export round-trip through the `pond-sql-export://` resource.
+
+use chrono::Utc;
+use pond::{
+    PROTOCOL_VERSION,
+    embed::{EmbedWorker, Embedder},
+    handlers::{IngestEvent, pond_ingest},
+    sessions::{Store, embedding_dim},
+    transport::{AppState, mcp::PondMcp},
+    wire::{IngestEnvelope, IngestRequest, Message, Part, PartKind, Provenance, Session},
+};
+use rmcp::{
+    ClientHandler, ServiceExt,
+    model::{CallToolRequestParams, CallToolResult, ReadResourceRequestParams, ResourceContents},
+};
+use serde_json::json;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+const SESSION_ID: &str = "sql-test-session";
+const PROJECT: &str = "pond-sql-test";
+
+fn s(value: &str) -> Option<pond::adapter::Extracted<String>> {
+    pond::adapter::extract_str(&serde_json::json!({ "x": value }), "x")
+}
+
+/// Deterministic, content-dependent vectors - no model weights needed.
+struct FakeBackend;
+
+impl Embedder for FakeBackend {
+    fn device(&self) -> &str {
+        "fake"
+    }
+
+    fn embed(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {
+        Ok(texts
+            .iter()
+            .map(|text| {
+                let bytes = text.as_bytes();
+                (0..embedding_dim())
+                    .map(|i| {
+                        let byte = bytes.get(i % bytes.len().max(1)).copied().unwrap_or(0);
+                        f32::from(byte) / 255.0
+                    })
+                    .collect()
+            })
+            .collect())
+    }
+}
+
+#[derive(Clone, Default)]
+struct TestClient;
+
+impl ClientHandler for TestClient {}
+
+/// One session with a user message and an assistant message, each carrying a
+/// text part, so `GROUP BY role` yields two rows and `parts` is populated.
+async fn synthetic_state(temp: &TempDir) -> anyhow::Result<AppState> {
+    let store = Store::open_local(temp.path()).await?;
+
+    let session = Session {
+        id: SESSION_ID.to_owned(),
+        parent_session_id: None,
+        parent_message_id: None,
+        source_agent: "claude-code".to_owned(),
+        created_at: Utc::now(),
+        project: s(PROJECT).unwrap(),
+        options: Default::default(),
+    };
+    let user = Message::User {
+        id: "m-user".to_owned(),
+        session_id: SESSION_ID.to_owned(),
+        timestamp: Utc::now(),
+        options: Default::default(),
+    };
+    let assistant = Message::Assistant {
+        id: "m-asst".to_owned(),
+        session_id: SESSION_ID.to_owned(),
+        timestamp: Utc::now(),
+        options: Default::default(),
+    };
+    let user_text = Part {
+        session_id: SESSION_ID.to_owned(),
+        id: "p-user".to_owned(),
+        message_id: "m-user".to_owned(),
+        ordinal: 0,
+        provenance: Provenance::Conversational,
+        options: Default::default(),
+        kind: PartKind::Text {
+            text: s("what is the answer"),
+        },
+    };
+    let asst_text = Part {
+        session_id: SESSION_ID.to_owned(),
+        id: "p-asst".to_owned(),
+        message_id: "m-asst".to_owned(),
+        ordinal: 0,
+        provenance: Provenance::Conversational,
+        options: Default::default(),
+        kind: PartKind::Text {
+            text: s("the answer is forty-two"),
+        },
+    };
+
+    let envelope = pond_ingest(
+        &store,
+        IngestRequest {
+            protocol_version: PROTOCOL_VERSION,
+            namespace: Some("local".to_owned()),
+            events: vec![
+                IngestEvent::Session(session),
+                IngestEvent::Message(user),
+                IngestEvent::Message(assistant),
+                IngestEvent::Part(user_text),
+                IngestEvent::Part(asst_text),
+            ],
+        },
+    )
+    .await;
+    assert!(
+        matches!(envelope, IngestEnvelope::Success(_)),
+        "synthetic ingest should succeed: {envelope:?}",
+    );
+    let backend = FakeBackend;
+    EmbedWorker::new(&store, &backend).run().await?;
+    store.optimize_indices(None, None).await?.into_result()?;
+
+    Ok(AppState {
+        store: Arc::new(store),
+        embedder: Arc::new(pond::embed::LazyEmbedder::from_loaded(Arc::new(backend))),
+        search: pond::config::SearchConfig::default(),
+    })
+}
+
+fn first_text(result: &CallToolResult) -> Option<&str> {
+    result
+        .content
+        .iter()
+        .find_map(|content| content.raw.as_text().map(|text| text.text.as_str()))
+}
+
+fn resource_link_uri(result: &CallToolResult) -> Option<String> {
+    result
+        .content
+        .iter()
+        .find_map(|content| content.raw.as_resource_link().map(|link| link.uri.clone()))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn pond_sql_query_over_mcp() -> anyhow::Result<()> {
+    let temp = TempDir::new()?;
+    let state = synthetic_state(&temp).await?;
+
+    let (server_transport, client_transport) = tokio::io::duplex(1 << 16);
+    let server = PondMcp::new(state);
+    let server_handle = tokio::spawn(async move {
+        server.serve(server_transport).await?.waiting().await?;
+        anyhow::Ok(())
+    });
+    let client = TestClient.serve(client_transport).await?;
+
+    let call = async |args: serde_json::Value| {
+        client
+            .call_tool(
+                CallToolRequestParams::new("pond_sql_query")
+                    .with_arguments(args.as_object().unwrap().clone()),
+            )
+            .await
+    };
+
+    // The new tool advertises its result-size cap alongside the others.
+    let tools = client.list_all_tools().await?;
+    let cap = tools
+        .iter()
+        .find(|tool| tool.name == "pond_sql_query")
+        .and_then(|tool| tool.meta.as_ref())
+        .and_then(|meta| meta.0.get("anthropic/maxResultSizeChars"))
+        .and_then(serde_json::Value::as_i64);
+    assert_eq!(cap, Some(80_000), "pond_sql_query carries a size cap");
+
+    // 1. Inline aggregation: GROUP BY over the role column.
+    let result = call(json!({
+        "sql": "SELECT role, count(*) AS n FROM messages GROUP BY role ORDER BY role"
+    }))
+    .await?;
+    assert_ne!(result.is_error, Some(true), "aggregation should succeed");
+    let text = first_text(&result).expect("inline result is text");
+    assert!(text.contains("assistant"), "groups assistant: {text}");
+    assert!(text.contains("user"), "groups user: {text}");
+    assert!(text.contains("2 row(s)"), "two role groups: {text}");
+
+    // 2. Read-only is hard-enforced: writes / DDL come back as tool errors.
+    for write in [
+        "DROP TABLE messages",
+        "INSERT INTO messages (id) VALUES ('x')",
+        "COPY (SELECT 1) TO '/tmp/x.parquet'",
+        "SELECT 1; SELECT 2",
+    ] {
+        let result = call(json!({ "sql": write })).await?;
+        assert_eq!(
+            result.is_error,
+            Some(true),
+            "non-SELECT must be a tool error: {write}"
+        );
+    }
+
+    // 3. SELECT * works and the embedding `vector` column is omitted.
+    let result = call(json!({ "sql": "SELECT * FROM messages" })).await?;
+    assert_ne!(result.is_error, Some(true), "select * should succeed");
+    let text = first_text(&result).expect("inline result is text");
+    assert!(
+        text.contains("session_id"),
+        "shows canonical columns: {text}"
+    );
+    assert!(
+        text.contains("embedding_model"),
+        "keeps text columns: {text}"
+    );
+    assert!(!text.contains("vector"), "omits the vector column: {text}");
+
+    // 4. BM25 search-in-SQL via the fts() table function executes and composes
+    // with ordinary SQL (projection / LIMIT) around it.
+    let result = call(json!({
+        "sql": "SELECT id FROM fts('messages', \
+                '{\"match\":{\"column\":\"search_text\",\"terms\":\"answer\"}}') LIMIT 5"
+    }))
+    .await?;
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "fts() should execute: {result:?}"
+    );
+
+    // 5. ndjson export round-trips through the pond-sql-export:// resource.
+    let result = call(json!({
+        "sql": "SELECT role, project FROM messages ORDER BY role",
+        "output": "ndjson"
+    }))
+    .await?;
+    assert_ne!(result.is_error, Some(true), "ndjson export should succeed");
+    assert!(
+        first_text(&result).is_some_and(|text| text.contains("Exported")),
+        "export carries a text summary"
+    );
+    let uri = resource_link_uri(&result).expect("export returns a resource_link");
+    assert!(
+        uri.starts_with("pond-sql-export://"),
+        "custom scheme: {uri}"
+    );
+    assert!(uri.ends_with(".ndjson"), "ndjson extension: {uri}");
+    let read = client
+        .read_resource(ReadResourceRequestParams::new(uri))
+        .await?;
+    match read.contents.first().expect("resource has contents") {
+        ResourceContents::TextResourceContents { text, .. } => {
+            assert!(text.contains("assistant"), "ndjson holds the rows: {text}");
+            assert!(text.contains(PROJECT), "ndjson holds the project: {text}");
+        }
+        other => panic!("ndjson export should read back as text, got {other:?}"),
+    }
+
+    // 6. parquet export round-trips as a base64 blob with the PAR1 magic.
+    let result = call(json!({
+        "sql": "SELECT role FROM messages",
+        "output": "parquet"
+    }))
+    .await?;
+    assert_ne!(result.is_error, Some(true), "parquet export should succeed");
+    let uri = resource_link_uri(&result).expect("export returns a resource_link");
+    assert!(uri.ends_with(".parquet"), "parquet extension: {uri}");
+    let read = client
+        .read_resource(ReadResourceRequestParams::new(uri))
+        .await?;
+    match read.contents.first().expect("resource has contents") {
+        ResourceContents::BlobResourceContents { blob, .. } => {
+            // base64 of bytes starting with the parquet magic "PAR1" begins "UEFS".
+            assert!(blob.starts_with("UEFS"), "parquet blob has PAR1 magic");
+        }
+        other => panic!("parquet export should read back as a blob, got {other:?}"),
+    }
+
+    // An unknown export id is a clean not-found, not a traversal.
+    let missing = client
+        .read_resource(ReadResourceRequestParams::new(
+            "pond-sql-export://../etc/passwd",
+        ))
+        .await;
+    assert!(missing.is_err(), "invalid export id is rejected");
+
+    client.cancel().await?;
+    let _ = server_handle.await;
+    Ok(())
+}

--- a/tests/integration/sql.rs
+++ b/tests/integration/sql.rs
@@ -12,6 +12,7 @@ use pond::{
     embed::{EmbedWorker, Embedder},
     handlers::{IngestEvent, pond_ingest},
     sessions::{Store, embedding_dim},
+    substrate::MaintenancePolicy,
     transport::{AppState, mcp::PondMcp},
     wire::{IngestEnvelope, IngestRequest, Message, Part, PartKind, Provenance, Session},
 };
@@ -129,7 +130,10 @@ async fn synthetic_state(temp: &TempDir) -> anyhow::Result<AppState> {
     );
     let backend = FakeBackend;
     EmbedWorker::new(&store, &backend).run().await?;
-    store.optimize_indices(None, None).await?.into_result()?;
+    store
+        .optimize_indices(None, &MaintenancePolicy::always_compact())
+        .await?
+        .into_result()?;
 
     Ok(AppState {
         store: Arc::new(store),

--- a/tests/integration/sql.rs
+++ b/tests/integration/sql.rs
@@ -297,6 +297,110 @@ async fn pond_sql_query_over_mcp() -> anyhow::Result<()> {
         .await;
     assert!(missing.is_err(), "invalid export id is rejected");
 
+    // 7. output=json: spec-compliant dual delivery - text fallback (stringified
+    // JSON) AND structuredContent carrying the typed payload. The metrics
+    // footer fields (total_rows, shown_rows, elapsed_ms, columns, rows) are
+    // present.
+    let result = call(json!({
+        "sql": "SELECT role, count(*) AS n FROM messages GROUP BY role ORDER BY role",
+        "output": "json"
+    }))
+    .await?;
+    assert_ne!(result.is_error, Some(true), "json output should succeed");
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("output=json sets structured_content");
+    assert_eq!(
+        structured.get("total_rows").and_then(|v| v.as_u64()),
+        Some(2)
+    );
+    assert_eq!(
+        structured.get("shown_rows").and_then(|v| v.as_u64()),
+        Some(2)
+    );
+    assert_eq!(
+        structured.get("truncated").and_then(|v| v.as_bool()),
+        Some(false)
+    );
+    assert!(
+        structured
+            .get("elapsed_ms")
+            .and_then(|v| v.as_u64())
+            .is_some(),
+        "elapsed_ms present: {structured:?}"
+    );
+    let columns = structured
+        .get("columns")
+        .and_then(|v| v.as_array())
+        .expect("columns array");
+    assert!(columns.iter().any(|c| c == "role"));
+    assert!(columns.iter().any(|c| c == "n"));
+    let rows = structured
+        .get("rows")
+        .and_then(|v| v.as_array())
+        .expect("rows array");
+    assert_eq!(rows.len(), 2);
+    // The spec-compliant text fallback is the stringified structured payload
+    // (per `CallToolResult::structured`) - clients that don't render the
+    // structured channel still see the data.
+    let text = first_text(&result).expect("text fallback present");
+    let parsed: serde_json::Value =
+        serde_json::from_str(text).expect("text fallback is the same JSON");
+    assert_eq!(&parsed, structured, "text fallback matches structured");
+
+    // 8. EXPLAIN passes the read-only gate and returns a plan.
+    let result = call(json!({ "sql": "EXPLAIN SELECT role FROM messages" })).await?;
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "EXPLAIN should succeed: {result:?}"
+    );
+    let text = first_text(&result).expect("EXPLAIN renders inline");
+    assert!(
+        text.to_ascii_lowercase().contains("plan"),
+        "EXPLAIN output mentions a plan: {text}"
+    );
+
+    // 9. Explicit projection of the `vector` column is a loud tool error,
+    // not the prior silent-empty result.
+    let result = call(json!({ "sql": "SELECT vector FROM messages" })).await?;
+    assert_eq!(
+        result.is_error,
+        Some(true),
+        "SELECT vector must be an isError tool result"
+    );
+    let text = first_text(&result).expect("error carries a message");
+    assert!(
+        text.contains("pond_search"),
+        "error redirects to pond_search: {text}"
+    );
+
+    // 10. Inline truncation now points the agent at keyset pagination.
+    // Force truncation with a 1-row limit on a 4-row corpus.
+    let result = call(json!({
+        "sql": "SELECT id, timestamp FROM messages ORDER BY timestamp",
+        "limit": 1
+    }))
+    .await?;
+    let text = first_text(&result).expect("inline result");
+    assert!(
+        text.contains("keyset"),
+        "truncation hint mentions keyset pagination: {text}"
+    );
+    assert!(
+        text.contains("schema://pond-sql"),
+        "truncation hint points at the schema doc: {text}"
+    );
+
+    // 11. Inline metrics footer reports elapsed time.
+    let result = call(json!({ "sql": "SELECT 1" })).await?;
+    let text = first_text(&result).expect("inline result");
+    assert!(
+        text.contains(" ms"),
+        "metrics footer carries elapsed ms: {text}"
+    );
+
     client.cancel().await?;
     let _ = server_handle.await;
     Ok(())


### PR DESCRIPTION
## Summary

Adds **`pond_sql_query`**, a third MCP tool exposing **read-only DataFusion SQL** over pond's three Lance tables (`sessions` / `messages` / `parts`) for filtering, joins, and aggregation - the analytic complement to `pond_search`'s semantic recall. The tables register as `LanceTableProvider`s (so `WHERE`/projection/`LIMIT` push into Lance's indexed scan) on a fresh per-call `SessionContext`. Also ships a matching **`pond sql`** CLI.

## Read-only is hard-enforced (two layers)

1. **Pre-parse gate** (`parse_and_gate`): `DFParser` must yield exactly one top-level `Query` or `EXPLAIN <Query>`. Rejects multi-statement input and `EXPLAIN`/`ANALYZE`/`DESCRIBE`/`SET` over non-`Query` inputs. `EXPLAIN INSERT/COPY/DROP` is rejected.
2. **Plan gate**: `sql_with_options(allow_ddl=false, allow_dml=false, allow_statements=<true only when EXPLAIN>)` - `verify_plan` walks subqueries and rejects `Ddl`/`Dml`/`Copy`/`Statement`, so `INSERT`/`UPDATE`/`DELETE`/`MERGE`/`CREATE`/`DROP`/`COPY TO`/`CREATE EXTERNAL TABLE`/`SET` can never execute (filesystem-escape statements included).

## Agent-facing surface

- Tables, columns, join keys, indexed filter columns, dialect, and functions are documented in the **`schema://pond-sql`** resource (expanded to ~6.8 KB): function quick-reference with exact DataFusion names, `EXPLAIN` section, `output=json` semantics, **keyset pagination** with worked SQL examples, aggregate-to-content **drilling via JOIN/CTE**, and three starter patterns (this-week activity, subagent breakdown, `fts()` composed with `JOIN`).
- Registers the **`fts()` BM25 UDTF** (search-in-SQL) and Lance's **JSON UDFs** (`json_get_string`/`json_extract`/...).
- **`EXPLAIN [ANALYZE]`** passes the gate so the agent can see the physical plan (including which scalar index was hit) without leaving SQL.
- **Inline metrics footer** on every rendered result: `{N} row(s) in {M} ms; showing {S}`; `output=json` carries an `elapsed_ms` field.
- **Truncation hint** dictates the exact keyset-pagination SQL shape (`ORDER BY <col>, then WHERE (col, id) < (<last_col>, <last_id>)`), so the agent pages without a server-side cursor.

## Output modes

- **`table`** (default): row-capped ASCII table, byte-budgeted (~80 KB).
- **`json`** (new): same row-capped payload delivered through MCP's `structuredContent` channel, with a spec-compliant text fallback via `CallToolResult::structured(...)`. Empirically validated on **Claude Code 2.1.165** - the agent reads the structured form; non-supporting clients see the same JSON in the text block.
- **`parquet`** / **`ndjson`** (export): the full result is written to `<data-dir>/exports/<uuidv7>.<ext>` - a prefix invisible to the manifest-driven Directory namespace, never `register_table`'d - and returned as a **`pond-sql-export://` `resource_link`** fetched via `resources/read` (parquet as base64 blob, ndjson as text). Strict `valid_export_name` blocks path traversal. On local stdio the summary also reports the on-disk path so the agent can read it directly (duckdb/polars). No presigned/public URLs.

Guardrails across modes: per-query 512 MiB memory pool + 30 s wall-clock timeout (covering parse + plan + execute) + output byte caps.

## Breaking: `SELECT vector` now errors

`SELECT vector` / `array_length(vector)` etc. in the projection now return an `isError` tool result that redirects to `pond_search`. `WHERE vector IS NOT NULL` and other reference forms stay legal. Previously the column was silently dropped, which wasted agent tokens on diagnosis. Hence the `feat(sql)!:` marker on the squash subject (release-plz `0.X.0` bump).

## `pond sql` CLI

`pond sql "<query>"` with `--output {table,json,ndjson,parquet}` / `--limit` / `--output-file` / `--data-dir` / `--config`. Same SQL surface as the MCP tool. Parquet requires `--output-file`; ndjson and json go to stdout by default.

## Dependencies

- New compiled crate: **`parquet`** (lance reads its own format, not parquet) - the only genuinely new build cost.
- `arrow-json` and `lance-datafusion` were already in the tree (manifest lines only).

## Testing

- `tests/integration/sql.rs` (407 LoC) drives the tool over the in-process MCP transport: inline aggregation, the read-only gate (DROP/INSERT/COPY/multi-statement/EXPLAIN-INSERT rejected as tool errors), `vector`-column projection rejection, `fts()` UDTF, parquet+ndjson export round-trip through `resources/read` (incl. a path-traversal rejection), and the new `output=json` byte-equality between `content[0].text` and `JSON.stringify(structuredContent)`.
- Unit tests in `src/sql.rs` cover SELECT-only / EXPLAIN / vector-projection guards and the truncation hint shape.
- Full suite green: 122 unit + 31 integration; `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
- Live-corpus A/B probe against `~/.local/share/pond` (1.83 M messages, 1.27 M parts, 10.3 K sessions) confirmed every prior friction point measurably improved with no regressions.

## Notes

- Read-only over the **corpus** is the invariant; exports write derived artifacts to a pond-owned prefix via the same `storage_options` (private bucket stays private).
- The keyset-pagination + drilling docs replace what was scoped as server-side cursor pagination and server-side hydration; SQL already exposes the primitives, so docs + examples are the right shape.
- Semantic/ANN vector search is intentionally **not** in SQL - that stays in `pond_search`.
- Also fixes a pre-existing `GetRequest { session_from }` omission in `benches/serve_mem_bench.rs` and a stale `optimize_indices` signature in `benches/backend_bench.rs` (both broken on `main`).
