### PR TITLE
refactor(maintenance)!: gate compaction, drop unsafe vacuum, carve out [maintenance] config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -205,13 +205,27 @@ pub const DEFAULT_CONFIG_TOML: &str = "\
 # Search tuning. Leave unset for Lance defaults; set when tuning IVF_PQ recall
 # against a corpus.
 #
-# `index_lag_threshold` is the minimum unindexed-fragment count before a
-# per-intent append/rebuild runs in `pond index optimize`; the brute-force
-# fallback keeps queries correct while fragments accumulate. Defaults to 4.
-#
 # [search]
 # nprobes = 16
 # refine_factor = 2
+
+# Storage maintenance. Tunes the compaction + cleanup pass that runs inside
+# `pond sync` and `pond index optimize`.
+#
+# - `compaction_fragment_cap` is the sub-target fragment count past which the
+#   compaction phase runs (it also runs once those fragments hold a whole target
+#   fragment's worth of rows). Default 64 stops the automated sync re-compacting
+#   the trailing fragment every pass; 0 compacts every pass.
+# - `cleanup_older_than` is the manifest-retention window for the safe cleanup
+#   pass. Accepts `Ns` / `Nm` / `Nh` / `Nd` (default `1d`). Versions older than
+#   this are reclaimed by Lance's OCC-coordinated GC.
+# - `index_lag_threshold` is the minimum unindexed-fragment count before a
+#   per-intent append/rebuild runs in `pond index optimize`; the brute-force
+#   fallback keeps queries correct while fragments accumulate. Default 4.
+#
+# [maintenance]
+# compaction_fragment_cap = 64
+# cleanup_older_than = \"1d\"
 # index_lag_threshold = 4
 
 # Long-running process caps. Both accept either a plain byte count or a
@@ -257,6 +271,8 @@ pub struct Config {
     #[serde(default)]
     pub search: SearchConfig,
     #[serde(default)]
+    pub maintenance: MaintenanceConfig,
+    #[serde(default)]
     pub runtime: RuntimeConfig,
     /// `[sources.<adapter>]` map: per-adapter config blobs the matching
     /// factory deserializes inside its `open()`. The shape is adapter-defined
@@ -299,6 +315,27 @@ pub struct SearchConfig {
     pub nprobes: Option<usize>,
     #[serde(default)]
     pub refine_factor: Option<u32>,
+}
+
+/// `[maintenance]`: storage-maintenance knobs shared by `pond sync` and
+/// `pond index optimize`. All optional - omit and pond falls back to the
+/// in-process defaults in `pond::substrate` (`DEFAULT_COMPACTION_FRAGMENT_CAP`,
+/// `default_cleanup_older_than`, and the `index_lag_threshold` initializer).
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MaintenanceConfig {
+    /// Sub-target fragment count past which the compaction phase runs (it also
+    /// runs once those fragments hold a whole target fragment's worth of rows).
+    /// Default 64 stops the automated sync re-compacting the trailing fragment
+    /// every pass; 0 compacts every pass.
+    #[serde(default)]
+    pub compaction_fragment_cap: Option<usize>,
+    /// Manifest-retention window for the safe cleanup pass. Accepts
+    /// `Ns`/`Nm`/`Nh`/`Nd` (default `1d`). Versions older than this are
+    /// reclaimed by Lance's OCC-coordinated GC (`delete_unverified=false`),
+    /// which never races a concurrent writer on any backend.
+    #[serde(default)]
+    pub cleanup_older_than: Option<String>,
     /// Minimum unindexed-fragment count below which `optimize_table_indices`
     /// skips the per-intent append/rebuild path; the brute-force fallback
     /// keeps queries correct while fragments accumulate. Default 4 trades a
@@ -306,12 +343,6 @@ pub struct SearchConfig {
     /// commits during high-rate ingest.
     #[serde(default)]
     pub index_lag_threshold: Option<usize>,
-    /// Sub-target fragment count past which the compaction phase runs (it also
-    /// runs once those fragments hold a whole target fragment's worth of rows).
-    /// Default 64 stops the automated sync re-compacting the trailing fragment
-    /// every pass; 0 compacts every pass.
-    #[serde(default)]
-    pub compaction_fragment_cap: Option<usize>,
 }
 
 /// `[embeddings]`: model selector and vector dimension. There is no master
@@ -398,7 +429,7 @@ impl Config {
         };
         config.embeddings.validate()?;
         config.embeddings.install_runtime();
-        if let Some(threshold) = config.search.index_lag_threshold {
+        if let Some(threshold) = config.maintenance.index_lag_threshold {
             crate::substrate::init_index_lag_threshold(threshold);
         }
         // Tilde expansion is per-adapter (inside each factory's `open()`):

--- a/src/config.rs
+++ b/src/config.rs
@@ -306,6 +306,12 @@ pub struct SearchConfig {
     /// commits during high-rate ingest.
     #[serde(default)]
     pub index_lag_threshold: Option<usize>,
+    /// Sub-target fragment count past which the compaction phase runs (it also
+    /// runs once those fragments hold a whole target fragment's worth of rows).
+    /// Default 64 stops the automated sync re-compacting the trailing fragment
+    /// every pass; 0 compacts every pass.
+    #[serde(default)]
+    pub compaction_fragment_cap: Option<usize>,
 }
 
 /// `[embeddings]`: model selector and vector dimension. There is no master

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,8 @@ use pond::{
         Store,
     },
     substrate::{
-        IndexStatus, OptimizeEvent, OptimizeProgressFn, PhaseOutcome, TableSizes,
-        index_lag_threshold,
+        IndexStatus, MaintenancePolicy, OptimizeEvent, OptimizeProgressFn, PhaseOutcome,
+        TableSizes, default_cleanup_older_than, index_lag_threshold,
     },
     transport::{self, AppState},
     wire::{
@@ -396,10 +396,41 @@ enum IndexCommand {
     Optimize {
         #[arg(long)]
         wait: bool,
+        /// Override the manifest-retention window for this run. Accepts
+        /// `Ns`/`Nm`/`Nh`/`Nd` (default: the configured `[maintenance]
+        /// .cleanup_older_than`, or `1d`). The cleanup pass stays safe
+        /// (`delete_unverified=false`), so this is OCC-coordinated and
+        /// safe to run while the cron is active; `0s` reclaims every
+        /// verified dead version up to the latest committed manifest.
+        #[arg(long, value_parser = parse_retention)]
+        cleanup_older_than: Option<chrono::Duration>,
     },
     Rebuild {
         intent: Option<String>,
     },
+}
+
+fn parse_retention(raw: &str) -> Result<chrono::Duration, String> {
+    let trimmed = raw.trim();
+    let split = trimmed
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(trimmed.len());
+    let (number, unit) = trimmed.split_at(split);
+    let amount: i64 = number
+        .parse()
+        .map_err(|_| format!("retention {raw:?}: leading number is not an integer"))?;
+    if amount < 0 {
+        return Err(format!("retention {raw:?} must be non-negative"));
+    }
+    match unit {
+        "s" => Ok(chrono::Duration::seconds(amount)),
+        "m" => Ok(chrono::Duration::minutes(amount)),
+        "h" => Ok(chrono::Duration::hours(amount)),
+        "d" => Ok(chrono::Duration::days(amount)),
+        other => Err(format!(
+            "retention {raw:?}: unit {other:?} not recognized (use s/m/h/d)"
+        )),
+    }
 }
 
 /// Parse `--project <value>` into a `ProjectFilter`. `re:<pattern>` selects
@@ -531,7 +562,8 @@ async fn main() -> anyhow::Result<()> {
                 run_embed_stage(&store, force_embed).await?;
             }
             if stages.update_indexes {
-                run_update_indexes_stage(&store, configured_compaction_cap(&loaded)).await?;
+                let policy = configured_maintenance_policy(&loaded, None)?;
+                run_update_indexes_stage(&store, &policy).await?;
             }
             render_sync_summary(&store, &summary).await?;
         }
@@ -548,8 +580,8 @@ async fn main() -> anyhow::Result<()> {
                     .await?;
             let summary = run_embed_stage_with_limit(&store, force, limit, "--force").await?;
             if !summary.cancelled && summary.messages > 0 {
-                let outcome =
-                    run_update_indexes_stage(&store, configured_compaction_cap(&config)).await?;
+                let policy = configured_maintenance_policy(&config, None)?;
+                let outcome = run_update_indexes_stage(&store, &policy).await?;
                 if outcome.any_indices_failed() {
                     std::process::exit(1);
                 }
@@ -671,11 +703,13 @@ async fn main() -> anyhow::Result<()> {
                     let statuses = store.index_status().await?;
                     render_index_status(&statuses)?;
                 }
-                IndexCommand::Optimize { wait } => {
+                IndexCommand::Optimize {
+                    wait,
+                    cleanup_older_than,
+                } => {
+                    let policy = configured_maintenance_policy(&loaded, cleanup_older_than)?;
                     let (progress, bar) = optimize_progress_bar();
-                    let outcome = store
-                        .optimize_indices(Some(progress), configured_compaction_cap(&loaded))
-                        .await?;
+                    let outcome = store.optimize_indices(Some(progress), &policy).await?;
                     bar.finish_and_clear();
                     render_optimize_outcome(&outcome)?;
                     if wait {
@@ -1202,22 +1236,39 @@ async fn run_embed_stage_with_limit(
     Ok(summary)
 }
 
-/// Compaction fragment cap from `[search].compaction_fragment_cap`, or the default.
-fn configured_compaction_cap(config: &Config) -> usize {
-    config
-        .search
+/// Resolve the `MaintenancePolicy` for one optimize/sync invocation: start
+/// from `[maintenance]` (or the in-process defaults), then apply the CLI
+/// `--cleanup-older-than` override when present.
+fn configured_maintenance_policy(
+    config: &Config,
+    cleanup_override: Option<chrono::Duration>,
+) -> anyhow::Result<MaintenancePolicy> {
+    let compaction_fragment_cap = config
+        .maintenance
         .compaction_fragment_cap
-        .unwrap_or(pond::substrate::DEFAULT_COMPACTION_FRAGMENT_CAP)
+        .unwrap_or(pond::substrate::DEFAULT_COMPACTION_FRAGMENT_CAP);
+    let configured_cleanup = config
+        .maintenance
+        .cleanup_older_than
+        .as_deref()
+        .map(parse_retention)
+        .transpose()
+        .map_err(|err| anyhow::anyhow!("invalid [maintenance].cleanup_older_than: {err}"))?;
+    let cleanup_older_than = cleanup_override
+        .or(configured_cleanup)
+        .unwrap_or_else(default_cleanup_older_than);
+    Ok(MaintenancePolicy {
+        compaction_fragment_cap,
+        cleanup_older_than,
+    })
 }
 
 async fn run_update_indexes_stage(
     store: &Store,
-    compaction_cap: usize,
+    policy: &MaintenancePolicy,
 ) -> anyhow::Result<OptimizeOutcome> {
     let (progress, bar) = optimize_progress_bar();
-    let outcome = store
-        .optimize_indices(Some(progress), compaction_cap)
-        .await?;
+    let outcome = store.optimize_indices(Some(progress), policy).await?;
     bar.finish_and_clear();
     // No `index:` recap line: the `render_sync_summary` (or `pond status`)
     // `indexes  text + semantic ready` line is the single source of truth

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,9 +21,9 @@ use pond::{
     embed::{BatchProgress, CandleEmbedder, EmbedSummary, EmbedWorker, Embedder, LazyEmbedder},
     handlers::{self, IngestSummary, SessionOutcome, SyncEvent, SyncStatus},
     sessions::{
-        AdapterStats, CleanupConfig, CorpusStats, EmbeddingProgress, LanceArchiveCounts,
-        LanceArchiveExport, LanceArchiveImport, MESSAGES_FTS_INDEX, MESSAGES_VECTOR_INDEX,
-        OptimizeOutcome, RowTotals, Store,
+        AdapterStats, CorpusStats, EmbeddingProgress, LanceArchiveCounts, LanceArchiveExport,
+        LanceArchiveImport, MESSAGES_FTS_INDEX, MESSAGES_VECTOR_INDEX, OptimizeOutcome, RowTotals,
+        Store,
     },
     substrate::{
         IndexStatus, OptimizeEvent, OptimizeProgressFn, PhaseOutcome, TableSizes,
@@ -396,114 +396,10 @@ enum IndexCommand {
     Optimize {
         #[arg(long)]
         wait: bool,
-        /// Override the manifest-retention window for this run.
-        /// Accepts Ns/Nm/Nh/Nd (default: 1d). Implies aggressive deletion
-        /// (delete_unverified=true): reclaims files Lance's 7-day in-progress
-        /// guard would otherwise protect. Unsafe under concurrent writers;
-        /// see --vacuum for a one-shot full reclaim.
-        #[arg(long, value_parser = parse_retention_arg)]
-        cleanup_older_than: Option<chrono::Duration>,
-        /// Reclaim every orphan immediately. Sugar for
-        /// `--cleanup-older-than 0s`. Same safety caveat applies.
-        #[arg(long, conflicts_with = "cleanup_older_than")]
-        vacuum: bool,
-        /// Skip the confirmation prompt when aggressive cleanup is enabled.
-        /// Required for non-interactive use of --vacuum / --cleanup-older-than.
-        #[arg(long, short = 'y')]
-        yes: bool,
     },
     Rebuild {
         intent: Option<String>,
     },
-}
-
-/// `clap` value-parser for `--cleanup-older-than`. Accepts `Ns`/`Nm`/`Nh`/`Nd`
-/// (or bare `N` interpreted as seconds). Mirrors LanceDB's docs without taking
-/// a humantime dependency.
-fn parse_retention_arg(input: &str) -> Result<chrono::Duration, String> {
-    let trimmed = input.trim();
-    let split_at = trimmed
-        .find(|c: char| !c.is_ascii_digit())
-        .unwrap_or(trimmed.len());
-    let (num, unit) = trimmed.split_at(split_at);
-    let n: i64 = num
-        .parse()
-        .map_err(|_| format!("invalid duration {input:?} (expected like `1h`, `30m`, `0s`)"))?;
-    match unit {
-        "s" | "" => Ok(chrono::Duration::seconds(n)),
-        "m" => Ok(chrono::Duration::minutes(n)),
-        "h" => Ok(chrono::Duration::hours(n)),
-        "d" => Ok(chrono::Duration::days(n)),
-        _ => Err(format!(
-            "unknown duration unit {unit:?} in {input:?} (use s/m/h/d)"
-        )),
-    }
-}
-
-fn format_retention(d: chrono::Duration) -> String {
-    let s = d.num_seconds();
-    if s == 0 {
-        return "0s".into();
-    }
-    if s.rem_euclid(86_400) == 0 {
-        return format!("{}d", s / 86_400);
-    }
-    if s.rem_euclid(3_600) == 0 {
-        return format!("{}h", s / 3_600);
-    }
-    if s.rem_euclid(60) == 0 {
-        return format!("{}m", s / 60);
-    }
-    format!("{s}s")
-}
-
-/// Resolve `--cleanup-older-than` / `--vacuum` / `--yes` into a `CleanupConfig`
-/// override (or `None` to use pond's safe default). Any explicit retention flag
-/// implies `delete_unverified=true` to bypass Lance's 7-day in-progress guard;
-/// that bypass is unsafe under concurrent writers, so a confirmation prompt
-/// fires unless `--yes` is set (non-interactive callers must pass `--yes`).
-fn resolve_cleanup_config(
-    cleanup_older_than: Option<chrono::Duration>,
-    vacuum: bool,
-    yes: bool,
-) -> anyhow::Result<Option<CleanupConfig>> {
-    let aggressive = vacuum || cleanup_older_than.is_some();
-    if !aggressive {
-        return Ok(None);
-    }
-    let older_than = if vacuum {
-        chrono::Duration::zero()
-    } else {
-        cleanup_older_than.unwrap_or_else(chrono::Duration::zero)
-    };
-    let cfg = CleanupConfig {
-        older_than,
-        delete_unverified: true,
-    };
-    let warning = format!(
-        "warning: cleanup_older_than={} with delete_unverified=true.\n\
-         warning: this deletes orphan files newer than Lance's 7-day in-progress guard.\n\
-         warning: ensure no other pond writer (serve, sync, embed) is active on this data dir.",
-        format_retention(cfg.older_than),
-    );
-    eprintln!("{}", pond::output::paint(&warning, pond::output::yellow()));
-    if yes {
-        return Ok(Some(cfg));
-    }
-    if !io::stdin().is_terminal() {
-        anyhow::bail!(
-            "refusing to run aggressive cleanup non-interactively; pass --yes to confirm"
-        );
-    }
-    let proceed = dialoguer::Confirm::new()
-        .with_prompt("Continue?")
-        .default(false)
-        .interact()
-        .context("failed to read confirmation")?;
-    if !proceed {
-        anyhow::bail!("aborted by operator");
-    }
-    Ok(Some(cfg))
 }
 
 /// Parse `--project <value>` into a `ProjectFilter`. `re:<pattern>` selects
@@ -635,7 +531,7 @@ async fn main() -> anyhow::Result<()> {
                 run_embed_stage(&store, force_embed).await?;
             }
             if stages.update_indexes {
-                run_update_indexes_stage(&store).await?;
+                run_update_indexes_stage(&store, configured_compaction_cap(&loaded)).await?;
             }
             render_sync_summary(&store, &summary).await?;
         }
@@ -652,7 +548,8 @@ async fn main() -> anyhow::Result<()> {
                     .await?;
             let summary = run_embed_stage_with_limit(&store, force, limit, "--force").await?;
             if !summary.cancelled && summary.messages > 0 {
-                let outcome = run_update_indexes_stage(&store).await?;
+                let outcome =
+                    run_update_indexes_stage(&store, configured_compaction_cap(&config)).await?;
                 if outcome.any_indices_failed() {
                     std::process::exit(1);
                 }
@@ -774,27 +671,11 @@ async fn main() -> anyhow::Result<()> {
                     let statuses = store.index_status().await?;
                     render_index_status(&statuses)?;
                 }
-                IndexCommand::Optimize {
-                    wait,
-                    cleanup_older_than,
-                    vacuum,
-                    yes,
-                } => {
-                    let cleanup = resolve_cleanup_config(cleanup_older_than, vacuum, yes)?;
-                    if let Some(c) = cleanup {
-                        output(&format!(
-                            "{}  cleanup_older_than={}{}",
-                            pond::output::paint("optimize:", pond::output::dim()),
-                            format_retention(c.older_than),
-                            if c.delete_unverified {
-                                " (aggressive)"
-                            } else {
-                                ""
-                            },
-                        ))?;
-                    }
+                IndexCommand::Optimize { wait } => {
                     let (progress, bar) = optimize_progress_bar();
-                    let outcome = store.optimize_indices(Some(progress), cleanup).await?;
+                    let outcome = store
+                        .optimize_indices(Some(progress), configured_compaction_cap(&loaded))
+                        .await?;
                     bar.finish_and_clear();
                     render_optimize_outcome(&outcome)?;
                     if wait {
@@ -1321,9 +1202,22 @@ async fn run_embed_stage_with_limit(
     Ok(summary)
 }
 
-async fn run_update_indexes_stage(store: &Store) -> anyhow::Result<OptimizeOutcome> {
+/// Compaction fragment cap from `[search].compaction_fragment_cap`, or the default.
+fn configured_compaction_cap(config: &Config) -> usize {
+    config
+        .search
+        .compaction_fragment_cap
+        .unwrap_or(pond::substrate::DEFAULT_COMPACTION_FRAGMENT_CAP)
+}
+
+async fn run_update_indexes_stage(
+    store: &Store,
+    compaction_cap: usize,
+) -> anyhow::Result<OptimizeOutcome> {
     let (progress, bar) = optimize_progress_bar();
-    let outcome = store.optimize_indices(Some(progress), None).await?;
+    let outcome = store
+        .optimize_indices(Some(progress), compaction_cap)
+        .await?;
     bar.finish_and_clear();
     // No `index:` recap line: the `render_sync_summary` (or `pond status`)
     // `indexes  text + semantic ready` line is the single source of truth

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -174,25 +174,6 @@ pub fn default_cleanup_older_than() -> chrono::Duration {
     chrono::Duration::days(1)
 }
 
-/// Cleanup parameters for the compaction phase of `pond index optimize`.
-/// `delete_unverified=true` overrides Lance's 7-day in-progress safety
-/// guard - required to reclaim files younger than 7 days, unsafe under
-/// concurrent writers.
-#[derive(Debug, Clone, Copy)]
-pub struct CleanupConfig {
-    pub older_than: chrono::Duration,
-    pub delete_unverified: bool,
-}
-
-impl Default for CleanupConfig {
-    fn default() -> Self {
-        Self {
-            older_than: default_cleanup_older_than(),
-            delete_unverified: false,
-        }
-    }
-}
-
 /// What `pond status` reports: where the data lives, total rows per table,
 /// and a per-(adapter, project) breakdown built from one `messages` scan.
 #[derive(Debug, Clone)]
@@ -1599,15 +1580,14 @@ impl Store {
     pub async fn optimize_indices(
         &self,
         progress: Option<OptimizeProgressFn>,
-        cleanup: Option<CleanupConfig>,
+        compaction_cap: usize,
     ) -> Result<OptimizeOutcome> {
-        let cleanup = cleanup.unwrap_or_default();
         let policy = pond_index_intents();
         let mut tables = Vec::with_capacity(3);
         for (table, intents) in policy.all() {
             let outcome = self
                 .handle
-                .optimize_table(table, intents, progress.as_ref(), cleanup)
+                .optimize_table(table, intents, progress.as_ref(), compaction_cap)
                 .await;
             tables.push(outcome);
         }
@@ -1644,14 +1624,10 @@ impl Store {
         &self,
         vector_threshold: usize,
     ) -> Result<OptimizeOutcome> {
-        let cleanup = CleanupConfig::default();
         let policy = pond_index_intents_with_vector_threshold(vector_threshold);
         let mut tables = Vec::with_capacity(3);
         for (table, intents) in policy.all() {
-            let outcome = self
-                .handle
-                .optimize_table(table, intents, None, cleanup)
-                .await;
+            let outcome = self.handle.optimize_table(table, intents, None, 0).await;
             tables.push(outcome);
         }
         Ok(OptimizeOutcome { tables })
@@ -4250,7 +4226,7 @@ mod tests {
         ];
         store.upsert_parts(&batch_b).await?;
 
-        store.optimize_indices(None, None).await?.into_result()?;
+        store.optimize_indices(None, 0).await?.into_result()?;
 
         Ok(())
     }
@@ -4641,7 +4617,7 @@ mod tests {
         // emits `ScalarIndexQuery` whenever the index exists.
         let (store, keys) = store_with_messages(&temp, 4).await?;
         store.write_embeddings(&embedded(&keys)).await?;
-        store.optimize_indices(None, None).await?.into_result()?;
+        store.optimize_indices(None, 0).await?.into_result()?;
 
         let query = vec![0.01_f32; embedding_dim()];
         let plan = store

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -24,9 +24,9 @@ use tokio_stream::{Stream, StreamExt};
 use crate::{
     config, embed,
     substrate::{
-        Handle, IndexIntent, IndexParamsKind, IndexStatus, IndexTrigger, OptimizeProgressFn,
-        PhaseOutcome, Predicate, ScalarValue, ScanOpts, Table, TableOptimizeOutcome, TableSizes,
-        VECTOR_INDEX_ACTIVATION_ROWS,
+        Handle, IndexIntent, IndexParamsKind, IndexStatus, IndexTrigger, MaintenancePolicy,
+        OptimizeProgressFn, PhaseOutcome, Predicate, ScalarValue, ScanOpts, Table,
+        TableOptimizeOutcome, TableSizes, VECTOR_INDEX_ACTIVATION_ROWS,
     },
     wire::{
         FileData, Message, Part, PartKind, ResponseMode, Role, SUMMARY_PART_TYPES, Session,
@@ -162,16 +162,6 @@ impl OptimizeOutcome {
         }
         Ok(self)
     }
-}
-
-/// Default manifest-retention window for `pond index optimize`'s explicit
-/// cleanup pass. Matches LanceDB's recommended OSS-operator practice
-/// (lancedb docs: performance.mdx, tables/update.mdx). Note: with
-/// `delete_unverified=false` (default), Lance protects files newer than
-/// 7 days regardless of this value (`UNVERIFIED_THRESHOLD_DAYS` in
-/// lance/dataset/cleanup.rs).
-pub fn default_cleanup_older_than() -> chrono::Duration {
-    chrono::Duration::days(1)
 }
 
 /// What `pond status` reports: where the data lives, total rows per table,
@@ -1580,14 +1570,14 @@ impl Store {
     pub async fn optimize_indices(
         &self,
         progress: Option<OptimizeProgressFn>,
-        compaction_cap: usize,
+        maintenance: &MaintenancePolicy,
     ) -> Result<OptimizeOutcome> {
-        let policy = pond_index_intents();
+        let intents = pond_index_intents();
         let mut tables = Vec::with_capacity(3);
-        for (table, intents) in policy.all() {
+        for (table, intents) in intents.all() {
             let outcome = self
                 .handle
-                .optimize_table(table, intents, progress.as_ref(), compaction_cap)
+                .optimize_table(table, intents, progress.as_ref(), maintenance)
                 .await;
             tables.push(outcome);
         }
@@ -1624,10 +1614,14 @@ impl Store {
         &self,
         vector_threshold: usize,
     ) -> Result<OptimizeOutcome> {
-        let policy = pond_index_intents_with_vector_threshold(vector_threshold);
+        let intents = pond_index_intents_with_vector_threshold(vector_threshold);
+        let policy = MaintenancePolicy::always_compact();
         let mut tables = Vec::with_capacity(3);
-        for (table, intents) in policy.all() {
-            let outcome = self.handle.optimize_table(table, intents, None, 0).await;
+        for (table, intents) in intents.all() {
+            let outcome = self
+                .handle
+                .optimize_table(table, intents, None, &policy)
+                .await;
             tables.push(outcome);
         }
         Ok(OptimizeOutcome { tables })
@@ -4226,7 +4220,10 @@ mod tests {
         ];
         store.upsert_parts(&batch_b).await?;
 
-        store.optimize_indices(None, 0).await?.into_result()?;
+        store
+            .optimize_indices(None, &MaintenancePolicy::always_compact())
+            .await?
+            .into_result()?;
 
         Ok(())
     }
@@ -4617,7 +4614,10 @@ mod tests {
         // emits `ScalarIndexQuery` whenever the index exists.
         let (store, keys) = store_with_messages(&temp, 4).await?;
         store.write_embeddings(&embedded(&keys)).await?;
-        store.optimize_indices(None, 0).await?.into_result()?;
+        store
+            .optimize_indices(None, &MaintenancePolicy::always_compact())
+            .await?
+            .into_result()?;
 
         let query = vec![0.01_f32; embedding_dim()];
         let plan = store

--- a/src/substrate.rs
+++ b/src/substrate.rs
@@ -49,7 +49,7 @@ pub const DEFAULT_INDEX_LAG_THRESHOLD: usize = 4;
 
 static INDEX_LAG_THRESHOLD_RUNTIME: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 
-/// Seed the process-wide index-lag threshold from `[search].index_lag_threshold`.
+/// Seed the process-wide index-lag threshold from `[maintenance].index_lag_threshold`.
 /// First call wins (mirrors `embed::init_model_id` / `sessions::init_embedding_dim`).
 pub fn init_index_lag_threshold(value: usize) {
     INDEX_LAG_THRESHOLD_RUNTIME.get_or_init(|| value);
@@ -66,6 +66,39 @@ pub fn index_lag_threshold() -> usize {
 /// stops re-Rewriting the trailing fragment every pass (spec.md#lance-index-maintenance).
 /// 0 disables the gate.
 pub const DEFAULT_COMPACTION_FRAGMENT_CAP: usize = 64;
+
+/// Default manifest-retention window for the safe cleanup pass. Matches
+/// LanceDB's recommended OSS-operator practice (lancedb docs: performance.mdx,
+/// tables/update.mdx). With `delete_unverified=false`, Lance's 7-day
+/// in-progress guard still protects unverified files regardless of this value
+/// (`UNVERIFIED_THRESHOLD_DAYS` in lance/dataset/cleanup.rs).
+pub fn default_cleanup_older_than() -> chrono::Duration {
+    chrono::Duration::days(1)
+}
+
+/// Resolved per-call inputs to the storage-maintenance pass. Built from
+/// `[maintenance]` (and any per-invocation CLI override) at the entry point;
+/// threaded down to `optimize_table_compact` so the substrate never re-reads
+/// `Config` itself.
+#[derive(Debug, Clone, Copy)]
+pub struct MaintenancePolicy {
+    /// Compaction gate: see [`DEFAULT_COMPACTION_FRAGMENT_CAP`]. `0` always
+    /// compacts (preserves the pre-gate test behavior).
+    pub compaction_fragment_cap: usize,
+    /// Manifest-retention window handed to `cleanup_old_versions`.
+    pub cleanup_older_than: chrono::Duration,
+}
+
+impl MaintenancePolicy {
+    /// Preserves the pre-gate compaction-always behavior that the existing
+    /// optimize tests assume.
+    pub fn always_compact() -> Self {
+        Self {
+            compaction_fragment_cap: 0,
+            cleanup_older_than: default_cleanup_older_than(),
+        }
+    }
+}
 
 /// Compact when the largest mergeable run of sub-target fragments can fill a
 /// whole target fragment (consolidation that freezes a fragment) or the
@@ -851,10 +884,10 @@ impl Handle {
         table: Table,
         intents: &[IndexIntent],
         progress: Option<&OptimizeProgressFn>,
-        compaction_cap: usize,
+        policy: &MaintenancePolicy,
     ) -> TableOptimizeOutcome {
         let compaction = self
-            .run_optimize_compact_phase(table, progress, compaction_cap)
+            .run_optimize_compact_phase(table, progress, policy)
             .await;
         let indices = self
             .run_optimize_indices_phase(table, intents, progress)
@@ -910,13 +943,13 @@ impl Handle {
         &self,
         table: Table,
         progress: Option<&OptimizeProgressFn>,
-        compaction_cap: usize,
+        policy: &MaintenancePolicy,
     ) -> PhaseOutcome {
         let result = self
             .retry_lance(table.label(), || async {
                 let mut guard = self.cached(table).await?.lock().await;
                 let mut dataset = guard.latest().await?;
-                optimize_table_compact(&mut dataset, table, progress, compaction_cap).await?;
+                optimize_table_compact(&mut dataset, table, progress, policy).await?;
                 guard.replace(dataset);
                 Ok::<_, anyhow::Error>(())
             })
@@ -1231,7 +1264,7 @@ async fn optimize_table_compact(
     dataset: &mut Dataset,
     table: Table,
     progress: Option<&OptimizeProgressFn>,
-    compaction_cap: usize,
+    policy: &MaintenancePolicy,
 ) -> Result<()> {
     let compaction = CompactionOptions {
         defer_index_remap: false,
@@ -1248,7 +1281,12 @@ async fn optimize_table_compact(
             .map(|fragment| fragment.metadata().physical_rows.unwrap_or(0)),
         target,
     );
-    if should_compact(mergeable_run_rows, candidate_count, target, compaction_cap) {
+    if should_compact(
+        mergeable_run_rows,
+        candidate_count,
+        target,
+        policy.compaction_fragment_cap,
+    ) {
         emit(
             progress,
             OptimizeEvent::PhaseStart {
@@ -1273,7 +1311,7 @@ async fn optimize_table_compact(
             table = table.as_str(),
             mergeable_run_rows,
             candidate_count,
-            cap = compaction_cap,
+            cap = policy.compaction_fragment_cap,
             "compaction skipped: sub-target fragments under threshold",
         );
     }
@@ -1291,11 +1329,7 @@ async fn optimize_table_compact(
     );
     let started = Instant::now();
     dataset
-        .cleanup_old_versions(
-            crate::sessions::default_cleanup_older_than(),
-            Some(false),
-            Some(false),
-        )
+        .cleanup_old_versions(policy.cleanup_older_than, Some(false), Some(false))
         .await
         .context("cleanup_old_versions failed during index optimize")?;
     emit(
@@ -1376,7 +1410,7 @@ async fn optimize_table_indices(
         }
         // Lag guard: let fragments accumulate behind the brute-force fallback
         // rather than firing a commit per tiny append. Threshold is operator-
-        // tunable via `[search].index_lag_threshold`.
+        // tunable via `[maintenance].index_lag_threshold`.
         if unindexed.len() < index_lag_threshold() {
             continue;
         }

--- a/src/substrate.rs
+++ b/src/substrate.rs
@@ -62,6 +62,46 @@ pub fn index_lag_threshold() -> usize {
         .unwrap_or(DEFAULT_INDEX_LAG_THRESHOLD)
 }
 
+/// Compaction runs only past this many sub-target fragments, so the 5-min sync
+/// stops re-Rewriting the trailing fragment every pass (spec.md#lance-index-maintenance).
+/// 0 disables the gate.
+pub const DEFAULT_COMPACTION_FRAGMENT_CAP: usize = 64;
+
+/// Compact when the largest mergeable run of sub-target fragments can fill a
+/// whole target fragment (consolidation that freezes a fragment) or the
+/// sub-target count has piled past `cap`. `cap == 0` always compacts.
+fn should_compact(
+    mergeable_run_rows: usize,
+    candidate_count: usize,
+    target_rows: usize,
+    cap: usize,
+) -> bool {
+    mergeable_run_rows >= target_rows || candidate_count >= cap
+}
+
+/// Largest contiguous below-target run (rows) and total below-target count over
+/// fragments in dataset order. The run approximates Lance's biggest mergeable
+/// bin, so a fragment stranded between at-target fragments (which Lance won't
+/// merge) never inflates the total and never triggers perpetual re-compaction.
+fn compaction_candidates(
+    physical_rows: impl IntoIterator<Item = usize>,
+    target: usize,
+) -> (usize, usize) {
+    let mut count = 0;
+    let mut run = 0;
+    let mut max_run = 0;
+    for rows in physical_rows {
+        if rows < target {
+            count += 1;
+            run += rows;
+            max_run = max_run.max(run);
+        } else {
+            run = 0;
+        }
+    }
+    (max_run, count)
+}
+
 /// Declarative description of one index pond keeps on a table. Created when
 /// its trigger fires; folded forward by `pond index optimize`.
 #[derive(Debug, Clone)]
@@ -811,10 +851,10 @@ impl Handle {
         table: Table,
         intents: &[IndexIntent],
         progress: Option<&OptimizeProgressFn>,
-        cleanup: crate::sessions::CleanupConfig,
+        compaction_cap: usize,
     ) -> TableOptimizeOutcome {
         let compaction = self
-            .run_optimize_compact_phase(table, progress, cleanup)
+            .run_optimize_compact_phase(table, progress, compaction_cap)
             .await;
         let indices = self
             .run_optimize_indices_phase(table, intents, progress)
@@ -870,13 +910,13 @@ impl Handle {
         &self,
         table: Table,
         progress: Option<&OptimizeProgressFn>,
-        cleanup: crate::sessions::CleanupConfig,
+        compaction_cap: usize,
     ) -> PhaseOutcome {
         let result = self
             .retry_lance(table.label(), || async {
                 let mut guard = self.cached(table).await?.lock().await;
                 let mut dataset = guard.latest().await?;
-                optimize_table_compact(&mut dataset, table, progress, cleanup).await?;
+                optimize_table_compact(&mut dataset, table, progress, compaction_cap).await?;
                 guard.replace(dataset);
                 Ok::<_, anyhow::Error>(())
             })
@@ -1191,32 +1231,56 @@ async fn optimize_table_compact(
     dataset: &mut Dataset,
     table: Table,
     progress: Option<&OptimizeProgressFn>,
-    cleanup: crate::sessions::CleanupConfig,
+    compaction_cap: usize,
 ) -> Result<()> {
     let compaction = CompactionOptions {
         defer_index_remap: false,
         ..CompactionOptions::default()
     };
 
-    emit(
-        progress,
-        OptimizeEvent::PhaseStart {
-            table,
-            phase: OptimizePhase::Compact,
-            detail: None,
-        },
+    // Candidacy mirrors Lance's planner: a fragment is compactable iff it holds
+    // fewer than target_rows_per_fragment rows (optimize.rs).
+    let target = compaction.target_rows_per_fragment;
+    let fragments = dataset.get_fragments();
+    let (mergeable_run_rows, candidate_count) = compaction_candidates(
+        fragments
+            .iter()
+            .map(|fragment| fragment.metadata().physical_rows.unwrap_or(0)),
+        target,
     );
-    let started = Instant::now();
-    compact_files(dataset, compaction, None).await?;
-    emit(
-        progress,
-        OptimizeEvent::PhaseDone {
-            table,
-            phase: OptimizePhase::Compact,
-            elapsed_ms: started.elapsed().as_millis() as u64,
-        },
-    );
+    if should_compact(mergeable_run_rows, candidate_count, target, compaction_cap) {
+        emit(
+            progress,
+            OptimizeEvent::PhaseStart {
+                table,
+                phase: OptimizePhase::Compact,
+                detail: None,
+            },
+        );
+        let started = Instant::now();
+        compact_files(dataset, compaction, None).await?;
+        emit(
+            progress,
+            OptimizeEvent::PhaseDone {
+                table,
+                phase: OptimizePhase::Compact,
+                elapsed_ms: started.elapsed().as_millis() as u64,
+            },
+        );
+    } else {
+        tracing::debug!(
+            target: "pond::perf",
+            table = table.as_str(),
+            mergeable_run_rows,
+            candidate_count,
+            cap = compaction_cap,
+            "compaction skipped: sub-target fragments under threshold",
+        );
+    }
 
+    // Safe GC only. delete_unverified=false keeps Lance's 7-day in-progress
+    // guard, so this never races a concurrent writer (spec.md#concurrency); GC
+    // runs outside OCC, so the guard is what makes it safe on any backend.
     emit(
         progress,
         OptimizeEvent::PhaseStart {
@@ -1226,14 +1290,10 @@ async fn optimize_table_compact(
         },
     );
     let started = Instant::now();
-    // delete_unverified=true is the operator opt-in via `--cleanup-older-than`
-    // / `--vacuum` that bypasses Lance's 7-day in-progress safety guard
-    // (UNVERIFIED_THRESHOLD_DAYS in lance/dataset/cleanup.rs). Required to
-    // reclaim files younger than 7 days; unsafe under concurrent writers.
     dataset
         .cleanup_old_versions(
-            cleanup.older_than,
-            Some(cleanup.delete_unverified),
+            crate::sessions::default_cleanup_older_than(),
+            Some(false),
             Some(false),
         )
         .await
@@ -1684,6 +1744,33 @@ fn like_contains(value: &str) -> String {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn compaction_gate_skips_subtarget_trickle_compacts_on_progress() {
+        let target = 1_048_576;
+        // Bloat case: a large trailing fragment plus a tiny new one - under a
+        // full target fragment and under the cap -> skip (don't re-Rewrite).
+        assert!(!should_compact(510_000 + 30, 2, target, 64));
+        // A run that fills a whole target fragment -> compact (and freeze it).
+        assert!(should_compact(target, 3, target, 64));
+        // Many tiny fragments past the cap -> compact to bound fragment count.
+        assert!(should_compact(5_000, 64, target, 64));
+        // cap == 0 always compacts (preserves pre-gate behavior for tests).
+        assert!(should_compact(0, 0, target, 0));
+    }
+
+    #[test]
+    fn compaction_candidates_strands_isolated_subtarget_fragment() {
+        let target = 1_048_576;
+        // [at-target, isolated 256K, at-target, tail 510K, tiny 30]: the only
+        // mergeable run is tail+tiny; the 256K between at-target frags is stranded,
+        // so even though sub-target rows total 766K it never re-fires the gate.
+        let (run, count) =
+            compaction_candidates([1_048_576, 256_000, 1_048_576, 510_000, 30], target);
+        assert_eq!(count, 3);
+        assert_eq!(run, 510_030);
+        assert!(!should_compact(run, count, target, 64));
+    }
 
     #[test]
     fn namespace_error_code_walks_wrapped_chain() {

--- a/tests/integration/optimize_under_contention.rs
+++ b/tests/integration/optimize_under_contention.rs
@@ -18,7 +18,7 @@ use pond::{
     config::parse_data_dir,
     handlers::ingest_events,
     sessions::{IngestEvent, MessageWrite, OptimizeOutcome, Store},
-    substrate::PhaseOutcome,
+    substrate::{MaintenancePolicy, PhaseOutcome},
     wire::{Message, Part, PartKind, Provenance, ProviderOptions, Session},
 };
 
@@ -112,7 +112,9 @@ async fn optimize_returns_per_table_outcome_on_quiet_store() -> anyhow::Result<(
     }
     ingest_events(&store, events).await?;
 
-    let outcome = store.optimize_indices(None, 0).await?;
+    let outcome = store
+        .optimize_indices(None, &MaintenancePolicy::always_compact())
+        .await?;
     assert_eq!(outcome.tables.len(), 3);
     for table in &outcome.tables {
         assert!(
@@ -202,7 +204,9 @@ async fn optimize_under_contention_surfaces_skipped_not_err() -> anyhow::Result<
     // commit lane is actively contended.
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
-    let outcome: OptimizeOutcome = optimizer.optimize_indices(None, 0).await?;
+    let outcome: OptimizeOutcome = optimizer
+        .optimize_indices(None, &MaintenancePolicy::always_compact())
+        .await?;
     stop.store(true, std::sync::atomic::Ordering::Relaxed);
     let _ = writer_task.await;
 

--- a/tests/integration/optimize_under_contention.rs
+++ b/tests/integration/optimize_under_contention.rs
@@ -17,7 +17,7 @@ use chrono::Utc;
 use pond::{
     config::parse_data_dir,
     handlers::ingest_events,
-    sessions::{CleanupConfig, IngestEvent, MessageWrite, OptimizeOutcome, Store},
+    sessions::{IngestEvent, MessageWrite, OptimizeOutcome, Store},
     substrate::PhaseOutcome,
     wire::{Message, Part, PartKind, Provenance, ProviderOptions, Session},
 };
@@ -112,7 +112,7 @@ async fn optimize_returns_per_table_outcome_on_quiet_store() -> anyhow::Result<(
     }
     ingest_events(&store, events).await?;
 
-    let outcome = store.optimize_indices(None, None).await?;
+    let outcome = store.optimize_indices(None, 0).await?;
     assert_eq!(outcome.tables.len(), 3);
     for table in &outcome.tables {
         assert!(
@@ -151,43 +151,6 @@ async fn build_indices_only_leaves_compaction_unattempted() -> anyhow::Result<()
         assert!(
             matches!(table.compaction, PhaseOutcome::NotAttempted),
             "compaction on {} must be NotAttempted under build_indices_only, got {:?}",
-            table.table.as_str(),
-            table.compaction,
-        );
-    }
-    Ok(())
-}
-
-/// `Store::optimize_indices` with `--vacuum`-equivalent config
-/// (`older_than=0s`, `delete_unverified=true`) doesn't error on a quiet store.
-/// Proves the aggressive-reclaim path is wired and doesn't trip the cleanup
-/// primitive at our pinned Lance version.
-#[tokio::test(flavor = "multi_thread")]
-async fn optimize_with_vacuum_config_runs_clean() -> anyhow::Result<()> {
-    let url = parse_data_dir("shared-memory://pond-test-optimize-vacuum/")?;
-    let store = Store::open(&url).await?;
-    let session = make_session("01HXYVACUUM00001");
-    let mut events = vec![IngestEvent::Session(session.clone())];
-    for idx in 0..16 {
-        events.push(IngestEvent::Message(make_message(&session.id, idx)));
-        events.push(IngestEvent::Part(make_part(
-            &session.id,
-            idx,
-            "vacuum body",
-        )));
-    }
-    ingest_events(&store, events).await?;
-
-    let cleanup = CleanupConfig {
-        older_than: chrono::Duration::zero(),
-        delete_unverified: true,
-    };
-    let outcome = store.optimize_indices(None, Some(cleanup)).await?;
-    assert_eq!(outcome.tables.len(), 3);
-    for table in &outcome.tables {
-        assert!(
-            !matches!(table.compaction, PhaseOutcome::Failed(_)),
-            "vacuum cleanup must not fail on {}: {:?}",
             table.table.as_str(),
             table.compaction,
         );
@@ -239,7 +202,7 @@ async fn optimize_under_contention_surfaces_skipped_not_err() -> anyhow::Result<
     // commit lane is actively contended.
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
-    let outcome: OptimizeOutcome = optimizer.optimize_indices(None, None).await?;
+    let outcome: OptimizeOutcome = optimizer.optimize_indices(None, 0).await?;
     stop.store(true, std::sync::atomic::Ordering::Relaxed);
     let _ = writer_task.await;
 

--- a/tests/integration/search.rs
+++ b/tests/integration/search.rs
@@ -14,6 +14,7 @@ use pond::{
     handlers::pond_get,
     handlers::pond_search,
     sessions::{Store, embedding_dim},
+    substrate::MaintenancePolicy,
     wire::PartKind,
     wire::{
         GetEnvelope, GetRequest, GetResult, ProjectFilter, ResponseMode, Role, SearchEnvelope,
@@ -67,7 +68,10 @@ async fn searchable_corpus(temp: &TempDir) -> anyhow::Result<(Store, LazyEmbedde
 
     let backend = FakeBackend;
     EmbedWorker::new(&store, &backend).run().await?;
-    store.optimize_indices(None, 0).await?.into_result()?;
+    store
+        .optimize_indices(None, &MaintenancePolicy::always_compact())
+        .await?
+        .into_result()?;
     let embedder = LazyEmbedder::from_loaded(Arc::new(backend) as Arc<dyn Embedder>);
     Ok((store, embedder))
 }

--- a/tests/integration/search.rs
+++ b/tests/integration/search.rs
@@ -67,7 +67,7 @@ async fn searchable_corpus(temp: &TempDir) -> anyhow::Result<(Store, LazyEmbedde
 
     let backend = FakeBackend;
     EmbedWorker::new(&store, &backend).run().await?;
-    store.optimize_indices(None, None).await?.into_result()?;
+    store.optimize_indices(None, 0).await?.into_result()?;
     let embedder = LazyEmbedder::from_loaded(Arc::new(backend) as Arc<dyn Embedder>);
     Ok((store, embedder))
 }

--- a/tests/integration/transport_http.rs
+++ b/tests/integration/transport_http.rs
@@ -18,6 +18,7 @@ use pond::{
     embed::{EmbedWorker, Embedder},
     handlers::ingest_adapter,
     sessions::{Store, embedding_dim},
+    substrate::MaintenancePolicy,
     transport::{AppState, http},
     wire::{ErrorCode, GetEnvelope, SearchEnvelope},
 };
@@ -65,7 +66,10 @@ async fn router() -> anyhow::Result<(TempDir, Arc<Store>, Router)> {
 
     let backend = FakeBackend;
     EmbedWorker::new(&store, &backend).run().await?;
-    store.optimize_indices(None, 0).await?.into_result()?;
+    store
+        .optimize_indices(None, &MaintenancePolicy::always_compact())
+        .await?
+        .into_result()?;
 
     let store = Arc::new(store);
     let state = AppState {

--- a/tests/integration/transport_http.rs
+++ b/tests/integration/transport_http.rs
@@ -65,7 +65,7 @@ async fn router() -> anyhow::Result<(TempDir, Arc<Store>, Router)> {
 
     let backend = FakeBackend;
     EmbedWorker::new(&store, &backend).run().await?;
-    store.optimize_indices(None, None).await?.into_result()?;
+    store.optimize_indices(None, 0).await?.into_result()?;
 
     let store = Arc::new(store);
     let state = AppState {

--- a/tests/integration/transport_mcp.rs
+++ b/tests/integration/transport_mcp.rs
@@ -11,6 +11,7 @@ use pond::{
     embed::{EmbedWorker, Embedder},
     handlers::{IngestEvent, pond_ingest},
     sessions::{Store, embedding_dim},
+    substrate::MaintenancePolicy,
     transport::{AppState, mcp::PondMcp},
     wire::{IngestEnvelope, IngestRequest},
     wire::{Message, Part, PartKind, Provenance, Session},
@@ -144,7 +145,10 @@ async fn synthetic_state(temp: &TempDir) -> anyhow::Result<AppState> {
     );
     let backend = FakeBackend;
     EmbedWorker::new(&store, &backend).run().await?;
-    store.optimize_indices(None, 0).await?.into_result()?;
+    store
+        .optimize_indices(None, &MaintenancePolicy::always_compact())
+        .await?
+        .into_result()?;
 
     Ok(AppState {
         store: Arc::new(store),

--- a/tests/integration/transport_mcp.rs
+++ b/tests/integration/transport_mcp.rs
@@ -144,7 +144,7 @@ async fn synthetic_state(temp: &TempDir) -> anyhow::Result<AppState> {
     );
     let backend = FakeBackend;
     EmbedWorker::new(&store, &backend).run().await?;
-    store.optimize_indices(None, None).await?.into_result()?;
+    store.optimize_indices(None, 0).await?.into_result()?;
 
     Ok(AppState {
         store: Arc::new(store),


### PR DESCRIPTION
## Problem

A ~6 GiB personal corpus had grown to **~98 GiB on disk** - ~93 GiB of it dead, un-GC'd Lance versions (measured with pylance 7: messages 3.6 GiB live / 57.8 GiB dead; parts 2.1 GiB live / 35.0 GiB dead).

Root cause (proven, not inferred): the `pond sync` cron runs every 5 minutes and `optimize_table_compact` called `compact_files` **unconditionally on every pass**. With slow ingest the trailing fragment never reaches `target_rows_per_fragment` (~1.05M), so Lance re-Rewrites it into a fresh ~1 GiB file each pass (the tail fragment id walks 594->597->600->603 across versions while the at-target fragment 168 stays frozen). The paired `cleanup_old_versions` runs with the safe `delete_unverified=false`, so Lance's 7-day in-progress guard forbids reclaiming any of it -> ~12 GiB/h of orphans that can't be freed for a week.

The only reclaim tool was `pond index optimize --vacuum` (`delete_unverified=true`), which deletes files **outside** Lance's OCC commit protocol and can drop a file a concurrent writer just committed - i.e. a maintenance command that can corrupt data during a normal cron run.

`spec.md#lance-index-maintenance` calls for periodic, operator-triggered maintenance; nothing requires compacting every sync.

## Fix

**Gate the compaction phase** (`src/substrate.rs`): compact only when the **largest contiguous run of below-target fragments** can fill a whole target fragment (a merge that freezes an at-target fragment), or when the sub-target fragment count exceeds `[maintenance].compaction_fragment_cap` (default 64). Using the largest *mergeable* run - not the global sub-target sum - keeps a fragment stranded between at-target fragments (Lance can't merge it) from re-firing the gate forever. Orphan production drops to roughly ingest volume, which the safe 7-day GC keeps bounded on its own.

**Remove the `delete_unverified=true` footgun** (`--vacuum` / `--yes`, `CleanupConfig`, and the resolve/format/parse helpers). The reachable cleanup path always passes Lance's safe `delete_unverified=false`, which is OCC-coordinated and behaves identically on local FS and object stores. No pond command can corrupt data under the cron, on any backend - safe by construction, no external lock, no filesystem side-channel.

**Carve out `[maintenance]` config + `MaintenancePolicy`**: the storage knobs (`compaction_fragment_cap`, `cleanup_older_than`, `index_lag_threshold`) move out of `[search]` (which `spec.md` defines as query-tuning: `nprobes`, `refine_factor`) into a dedicated `[maintenance]` section. A small `MaintenancePolicy { compaction_fragment_cap, cleanup_older_than }` value struct threads through `optimize_indices` -> `optimize_table_compact`; it has no `delete_unverified` field, so the safety floor is structurally enforced - the literal `Some(false)` at the only call site cannot be overridden by any caller.

**Restore a safe `--cleanup-older-than <dur>`** on `pond index optimize`: a per-invocation retention override (`Ns`/`Nm`/`Nh`/`Nd`) that still forces `delete_unverified=false`. Safe to run while the cron is active; `0s` reclaims every verified dead version up to the latest committed manifest. The retention parser is shared by the CLI flag and the `[maintenance].cleanup_older_than` config loader.

The existing ~93 GiB drains automatically as files age past the 7-day guard (the safe GC runs every sync); no manual step.

## Notes

- Net **-22 lines** across two commits, zero new dependencies, zero new files.
- `Store::optimize_indices` takes `&MaintenancePolicy`; tests use `MaintenancePolicy::always_compact()` (cap=0) to preserve the prior unconditional-compact behavior.
- **Breaking** (`!:`):
  - removes `pond index optimize --vacuum` / `--yes` flags and the public `CleanupConfig` type
  - changes `Store::optimize_indices` signature (now takes `&MaintenancePolicy`)
  - moves `index_lag_threshold` from `[search]` to `[maintenance]`

## Validation

- `cargo fmt`, `cargo clippy --lib --bins --tests -- -D warnings` clean (toolchain 1.95.0).
- `cargo test --lib --bins --tests`: 108 unit + 30 integration pass, 0 failures - including new `should_compact` / `compaction_candidates` gate tests.
- Did not run compaction against the live store; the gate decision and candidate-run logic are unit-tested with synthetic fragment sizes.
