### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.9.0](https://github.com/tenequm/pond/compare/v0.8.1...v0.9.0) - 2026-06-12
+
+### <!-- 0 -->🛠 Breaking Changes
+- **init:** [**breaking**] redesign storage onboarding and add 5m sync cadence
+
+**Full Changelog**: https://github.com/tenequm/pond/compare/v0.8.1...v0.9.0
 ## [0.8.1](https://github.com/tenequm/pond/compare/v0.8.0...v0.8.1) - 2026-06-12
 
 ### <!-- 2 -->🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6441,7 +6441,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pond-db"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 # crate). The library and binary stay `pond` via [lib]/[[bin]] below, so the
 # command and `use pond::...` are unchanged - only `cargo install pond-db` differs.
 name = "pond-db"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 # MSRV pinned to the toolchain we build and test with (rust-toolchain.toml).
 rust-version = "1.95"


### PR DESCRIPTION



## 🤖 New release

* `pond-db`: 0.8.1 -> 0.9.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.0](https://github.com/tenequm/pond/compare/v0.8.1...v0.9.0) - 2026-06-12

### <!-- 0 -->🛠 Breaking Changes
- **init:** [**breaking**] redesign storage onboarding and add 5m sync cadence

**Full Changelog**: https://github.com/tenequm/pond/compare/v0.8.1...v0.9.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).