### PR TITLE
chore: release v0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## [0.10.3](https://github.com/tenequm/pond/compare/v0.10.2...v0.10.3) - 2026-06-29
+
+### <!-- 6 -->🧹 Chores
+- enforce changelog header taxonomy (pre-commit + moon + CI); backfill 0.10.1/0.10.2
+
+**Full Changelog**: https://github.com/tenequm/pond/compare/v0.10.2...v0.10.3
 
 ## [0.10.2](https://github.com/tenequm/pond/compare/v0.10.1...v0.10.2) - 2026-06-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6463,7 +6463,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pond-db"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 # crate). The library and binary stay `pond` via [lib]/[[bin]] below, so the
 # command and `use pond::...` are unchanged - only `cargo install pond-db` differs.
 name = "pond-db"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2024"
 # MSRV pinned to the toolchain we build and test with (rust-toolchain.toml).
 rust-version = "1.95"


### PR DESCRIPTION



## 🤖 New release

* `pond-db`: 0.10.2 -> 0.10.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.3](https://github.com/tenequm/pond/compare/v0.10.2...v0.10.3) - 2026-06-29

### <!-- 6 -->🧹 Chores
- enforce changelog header taxonomy (pre-commit + moon + CI); backfill 0.10.1/0.10.2

**Full Changelog**: https://github.com/tenequm/pond/compare/v0.10.2...v0.10.3
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).