### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
 # Changelog
+## [0.11.0](https://github.com/tenequm/pond/compare/v0.10.2...v0.11.0) - 2026-07-01
+
+### <!-- 0 -->🛠 Breaking Changes
+- [**breaking**] append-only write path - incremental indexes, grown-session copy append, inline embed at ingest
+
+### <!-- 3 -->🚀 Performance
+- **search:** warm remote search ~8s -> sub-second; fix #75 date filters
+
+### <!-- 5 -->📚 Documentation
+- add remote read-path cold-start plan and drop stale prewarm comment figures
+
+### <!-- 6 -->🧹 Chores
+- bench batch/commit sweeps, append-only write-path plan, AIMD hands-off rule
+- enforce changelog header taxonomy (pre-commit + moon + CI); backfill 0.10.1/0.10.2
+
+**Full Changelog**: https://github.com/tenequm/pond/compare/v0.10.2...v0.11.0
 
 ## [0.10.2](https://github.com/tenequm/pond/compare/v0.10.1...v0.10.2) - 2026-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
+
 ## [0.11.0](https://github.com/tenequm/pond/compare/v0.10.2...v0.11.0) - 2026-07-01
 
+The write path becomes append-only - incremental index folds, inline embed at ingest, and delta-only copy - and remote `pond_search` drops from ~8s to sub-second.
+
 ### <!-- 0 -->🛠 Breaking Changes
-- [**breaking**] append-only write path - incremental indexes, grown-session copy append, inline embed at ingest
+- **Append-only write path.** `pond sync` now embeds each message inline in its ingest commit, and both sync and copy fold the scalar indexes incrementally (`optimize_indices(append)`) instead of a full `create_index(replace=true)` rebuild - so the whole-source-column index rebuild that dominated each sync/copy tail (~520s on the real corpus) is gone. `pond copy` carries only absent-or-grown sessions and appends a grown session's delta rows through the shared ingest write path (append, not merge-insert), keeping remote copies bandwidth-bound rather than commit-latency-bound.
 
 ### <!-- 3 -->🚀 Performance
-- **search:** warm remote search ~8s -> sub-second; fix #75 date filters
+- **search:** warm remote `pond_search` drops from **~7.9s to sub-second** (best 224ms) on the full S3 corpus (11,788 sessions / 2.14M messages). Two stages did work the query never needed. `has_embeddings` answered "does this store have embeddings?" with an `IsNotNull(vector)` scan of the entire vector column (**6.8-11.7s per query**); it now reads the manifest (index presence, ~0ms) and only falls back to a `LIMIT 1` probe when no index exists. Per-hit part summaries fetched file blobs from S3 and scanned `parts` once per session sequentially; they now skip the blob (the label rides `variant_data` metadata) and run concurrently. The real retrieval - embed + IVF probe + hydrate - is ~0.1s.
+- **search (#75):** `from_date`/`to_date` returned empty on remote stores because the `messages_timestamp_zonemap` mis-prunes the tz-aware `timestamp` column (`ScalarValue::partial_cmp` across the tz mismatch prunes every zone). The index is dropped and date bounds run as a refine over the candidate set. Stores that already built it: run `pond optimize --drop-index messages_timestamp_zonemap` once, or date filters stay empty there.
 
 ### <!-- 5 -->📚 Documentation
 - add remote read-path cold-start plan and drop stale prewarm comment figures

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6463,7 +6463,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pond-db"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 # crate). The library and binary stay `pond` via [lib]/[[bin]] below, so the
 # command and `use pond::...` are unchanged - only `cargo install pond-db` differs.
 name = "pond-db"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2024"
 # MSRV pinned to the toolchain we build and test with (rust-toolchain.toml).
 rust-version = "1.95"


### PR DESCRIPTION



## 🤖 New release

* `pond-db`: 0.10.2 -> 0.11.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.0](https://github.com/tenequm/pond/compare/v0.10.2...v0.11.0) - 2026-07-01

### <!-- 0 -->🛠 Breaking Changes
- [**breaking**] append-only write path - incremental indexes, grown-session copy append, inline embed at ingest

### <!-- 3 -->🚀 Performance
- **search:** warm remote search ~8s -> sub-second; fix #75 date filters

### <!-- 5 -->📚 Documentation
- add remote read-path cold-start plan and drop stale prewarm comment figures

### <!-- 6 -->🧹 Chores
- bench batch/commit sweeps, append-only write-path plan, AIMD hands-off rule
- enforce changelog header taxonomy (pre-commit + moon + CI); backfill 0.10.1/0.10.2

**Full Changelog**: https://github.com/tenequm/pond/compare/v0.10.2...v0.11.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).