### PR TITLE
chore: release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 # Changelog
+## [0.11.1](https://github.com/tenequm/pond/compare/v0.11.0...v0.11.1) - 2026-07-01
+
+### <!-- 3 -->🚀 Performance
+- **sync:** cut remote sync from ~80-520s to ~44s
+- **sync:** eliminate compaction churn + batch scalar folds + live progress
+
+### <!-- 4 -->🚜 Refactor
+- **bench:** rename copy_bench -> write_bench, add write-path profiler
+
+### <!-- 5 -->📚 Documentation
+- add logo to README
+
+**Full Changelog**: https://github.com/tenequm/pond/compare/v0.11.0...v0.11.1
 
 ## [0.11.0](https://github.com/tenequm/pond/compare/v0.10.2...v0.11.0) - 2026-07-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6463,7 +6463,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pond-db"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 # crate). The library and binary stay `pond` via [lib]/[[bin]] below, so the
 # command and `use pond::...` are unchanged - only `cargo install pond-db` differs.
 name = "pond-db"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 # MSRV pinned to the toolchain we build and test with (rust-toolchain.toml).
 rust-version = "1.95"


### PR DESCRIPTION



## 🤖 New release

* `pond-db`: 0.11.0 -> 0.11.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.1](https://github.com/tenequm/pond/compare/v0.11.0...v0.11.1) - 2026-07-01

### <!-- 3 -->🚀 Performance
- **sync:** cut remote sync from ~80-520s to ~44s
- **sync:** eliminate compaction churn + batch scalar folds + live progress

### <!-- 4 -->🚜 Refactor
- **bench:** rename copy_bench -> write_bench, add write-path profiler

### <!-- 5 -->📚 Documentation
- add logo to README

**Full Changelog**: https://github.com/tenequm/pond/compare/v0.11.0...v0.11.1
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).