### PR TITLE
fix: harden the FTS index path against Lance 7.0.0 merge defects; 7x faster freshness peek

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -27,4 +27,7 @@ call time, don't guess.
 `brew install tenequm/tap/pond` (or `cargo binstall pond-db`, or `nix profile
 install github:tenequm/pond-nix#pond`), then `pond init`, then `claude mcp add -s
 user pond -- pond mcp`. Keep current with `pond sync`; `pond --help` for the rest.
+Claude.ai chats are not synced automatically - request a data export
+(claude.ai Settings -> Privacy -> Export data, arrives as an emailed `.zip`),
+then `pond sync claude-ai-export --path <export.zip>`.
 Docs: https://pond.locker/

--- a/benches/ingest_bench.rs
+++ b/benches/ingest_bench.rs
@@ -70,6 +70,13 @@ struct Args {
     /// breakdown on pass 2 is the number the delta-write optimization targets.
     #[arg(long, default_value_t = 1)]
     passes: usize,
+    /// Skip oracle for pass 2+. `noop` (default) re-decodes every body -
+    /// the matched-heavy re-merge measurement above. `rowmap` builds the same
+    /// freshness oracle `pond sync` uses (ensure_rowmap + RowmapOracle), so
+    /// pass 2 measures the pure fresh-skip path - peek everything, ingest
+    /// nothing - the number the escalating peek window moves.
+    #[arg(long, value_enum, default_value_t = OracleKind::Noop)]
+    oracle: OracleKind,
     /// Print the top reasons sessions get skipped or validator-rejected. Used
     /// to diagnose "why is my rejection rate so high?" without grepping the
     /// bar output (which indicatif suppresses on non-tty stderr).
@@ -79,6 +86,12 @@ struct Args {
     /// target; without this flag clap would reject it as unknown.
     #[arg(long, hide = true)]
     bench: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+enum OracleKind {
+    Noop,
+    Rowmap,
 }
 
 #[tokio::main]
@@ -120,6 +133,7 @@ async fn main() -> Result<()> {
         // not targeting a remote store.
         let (store, _temp) = open_store(args.url.as_deref(), config.as_ref()).await?;
         let adapter = ClaudeCodeAdapter::new(&corpus);
+        let rowmap_cache = TempDir::new()?;
 
         for pass in 1..=passes {
             capture.reset();
@@ -130,10 +144,21 @@ async fn main() -> Result<()> {
             // chars) so near-duplicate messages collapse onto one row.
             let mut skip_reasons: HashMap<String, u64> = HashMap::new();
             let mut error_reasons: HashMap<String, u64> = HashMap::new();
+            // Mirrors run_import_stage's oracle wiring: rowmap on pass 2+
+            // exercises the fresh-skip path (peek everything, ingest nothing).
+            let rowmap_oracle;
+            let oracle: &dyn pond::adapter::SkipOracle =
+                if args.oracle == OracleKind::Rowmap && pass > 1 {
+                    store.ensure_rowmap(rowmap_cache.path()).await?;
+                    rowmap_oracle = pond::sessions::RowmapOracle(store.rowmap_snapshot());
+                    &rowmap_oracle
+                } else {
+                    &pond::adapter::NoopOracle
+                };
             let started = Instant::now();
             let mut sync_partial = 0u64;
             let mut sync_partial_drops = 0u64;
-            let summary = ingest_adapter(&store, &adapter, &pond::adapter::NoopOracle, |event| {
+            let summary = ingest_adapter(&store, &adapter, oracle, |event| {
                 if let SyncEvent::SessionDone(outcome) = event {
                     match &outcome.status {
                         SyncStatus::Skipped { reason } => {

--- a/docs/site/src/pages/guides/import-claude-ai.mdx
+++ b/docs/site/src/pages/guides/import-claude-ai.mdx
@@ -1,9 +1,12 @@
 # Import a Claude.ai export
 
-The `claude-ai-export` adapter ingests a Claude.ai data export. It's a manual download, so it isn't auto-discovered:
+Claude.ai conversations have no local session files, so they arrive via the official data export instead of `pond sync`'s auto-discovery:
+
+1. On claude.ai, open Settings -> Privacy -> Export data. The export arrives by email as a `.zip` link.
+2. Download it and run:
 
 ```sh
-pond sync claude-ai-export --path <path-to-export>
+pond sync claude-ai-export --path <path-to-export.zip>
 ```
 
-`--path` is a one-off override that bypasses config and writes nothing.
+`--path` accepts the `.zip` directly, an extracted directory, or a bare `conversations.json`; it is a one-off override that bypasses config and writes nothing. The import is idempotent - re-running with a newer export adds only what is new.

--- a/src/adapter/codex_cli.rs
+++ b/src/adapter/codex_cli.rs
@@ -31,7 +31,7 @@ use super::{
     empty_options,
     extract::{Extracted, extract_compact_repr, extract_raw_record, extract_self_str, extract_str},
     extracted_text,
-    jsonl::{BoundedRow, JsonlTree, TAIL_CAP, jsonl_tree_discover, jsonl_tree_events, read_tail},
+    jsonl::{BoundedRow, JsonlTree, jsonl_tree_discover, jsonl_tree_events, peek_last_mapped},
     jsonl_bytes, part_id, part_ordinal, raw_record,
 };
 
@@ -277,21 +277,18 @@ impl JsonlTree for CodexCliAdapter {
         // Pond stores the envelope `timestamp` only for `response_item` rows
         // (`event_msg`/`turn_context` get the session-start default), so the
         // session's max stored timestamp is its last response_item's. Scan a
-        // bounded tail backward for it - never the whole file.
-        let tail = read_tail(path, TAIL_CAP)?;
-        tail.split(|&byte| byte == b'\n')
-            .rev()
-            .filter_map(|line| serde_json::from_slice::<Value>(line).ok())
-            .find(|row| row.get("type").and_then(Value::as_str) == Some("response_item"))
-            .and_then(|row| {
+        // bounded tail backward for it - never the whole file. The nested
+        // `Option` keeps the walk stopping at the newest response_item even
+        // when its timestamp fails to parse, exactly like the pre-seam walk.
+        peek_last_mapped(path, |line| {
+            let row: Value = serde_json::from_str(line).ok()?;
+            (row.get("type").and_then(Value::as_str) == Some("response_item")).then(|| {
                 let text = row.get("timestamp").and_then(Value::as_str)?;
-                Some(
-                    DateTime::parse_from_rfc3339(text)
-                        .ok()?
-                        .with_timezone(&Utc)
-                        .timestamp_micros(),
-                )
+                DateTime::parse_from_rfc3339(text)
+                    .ok()
+                    .map(|ts| ts.with_timezone(&Utc).timestamp_micros())
             })
+        })?
     }
 
     fn session(&self, path: &Path, rows: &[BoundedRow]) -> Result<Session, AdapterError> {

--- a/src/adapter/jsonl.rs
+++ b/src/adapter/jsonl.rs
@@ -205,27 +205,62 @@ fn collect_heads<D: JsonlTree>(
     let name = driver.name();
     let files = collect_jsonl_files(driver.root())
         .map_err(|io| AdapterError::io(name, io.path, io.source))?;
-    let mut heads = Vec::with_capacity(files.len());
-    for path in files {
-        // The freshness peek (first line -> session id, file tail -> latest
-        // timestamp) costs bounded reads + JSON decodes per file. On a first-time
-        // ingest (`NoopOracle` or an empty map) there is nothing to compare
-        // against, so skip the peek entirely.
-        let (session_id, last_ts) = if oracle_is_empty {
-            (None, None)
-        } else {
-            let first_line = peek_first_line(&path).unwrap_or_default();
-            let session_id = driver.peek_session_id(&path, &first_line);
-            let last_ts = session_id.as_ref().and_then(|_| driver.peek_last_ts(&path));
-            (session_id, last_ts)
-        };
-        heads.push(FileHead {
-            path,
-            session_id,
-            last_ts,
-        });
+    // The freshness peek (first line -> session id, file tail -> latest
+    // timestamp) costs bounded reads + JSON decodes per file. On a first-time
+    // ingest (`NoopOracle` or an empty map) there is nothing to compare
+    // against, so skip the peek entirely.
+    if oracle_is_empty {
+        return Ok(files
+            .into_iter()
+            .map(|path| FileHead {
+                path,
+                session_id: None,
+                last_ts: None,
+            })
+            .collect());
     }
+    // Peeks are independent per-file io; fan them out over contiguous chunks
+    // of the already-sorted file list and stitch results back in chunk order,
+    // so head order (and therefore ingest order) is byte-identical to the
+    // sequential walk. Already inside `spawn_blocking`, so scoped OS threads
+    // are the right tool - no async machinery.
+    let workers = std::thread::available_parallelism()
+        .map(std::num::NonZeroUsize::get)
+        .unwrap_or(1)
+        .min(8);
+    let chunk_size = files.len().div_ceil(workers).max(1);
+    let mut heads = Vec::with_capacity(files.len());
+    std::thread::scope(|scope| {
+        let handles: Vec<_> = files
+            .chunks(chunk_size)
+            .map(|chunk| {
+                scope.spawn(move || {
+                    chunk
+                        .iter()
+                        .map(|path| peek_head(driver, path))
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect();
+        for handle in handles {
+            let chunk_heads = handle
+                .join()
+                .unwrap_or_else(|panic| std::panic::resume_unwind(panic));
+            heads.extend(chunk_heads);
+        }
+    });
     Ok(heads)
+}
+
+fn peek_head<D: JsonlTree>(driver: &D, path: &Path) -> FileHead {
+    let first_line = peek_first_line(path).unwrap_or_default();
+    let session_id = driver.peek_session_id(path, &first_line);
+    let last_ts = session_id.as_ref().and_then(|_| driver.peek_last_ts(path));
+    FileHead {
+        path: path.to_owned(),
+        session_id,
+        last_ts,
+    }
 }
 
 /// First non-empty line of `path`, read bounded so a pathological first line
@@ -267,19 +302,46 @@ pub(crate) fn read_tail(path: &Path, cap: u64) -> Option<Vec<u8>> {
     Some(buf)
 }
 
-/// Default tail window for the freshness peek. Big enough that the last record is
+/// Escalation ceiling for the freshness peek. Big enough that the last record is
 /// whole on any realistic transcript; a single record larger than this yields a
 /// `None` peek and a safe re-read.
 pub(crate) const TAIL_CAP: u64 = 32 * 1024 * 1024;
 
+/// First-pass tail window for the freshness peek. The watermark line sits within
+/// the last few KB on virtually every real transcript; escalating to [`TAIL_CAP`]
+/// only on a miss cut the per-sync peek read from 6.63GB to 0.59GB on the real
+/// corpus with identical coverage.
+pub(crate) const PEEK_TAIL_CAP: u64 = 64 * 1024;
+
+/// Tail window restricted to whole lines: the raw `read_tail` buffer plus the
+/// offset of its first complete line - 0 when the window provably covers the
+/// whole file, else one past the first newline, discarding the possibly
+/// mid-record first chunk. This is the escalation's correctness guard: the
+/// small pass never judges a truncated line. `None` when the window holds no
+/// whole line at all (single line larger than `cap`), which escalates.
+fn tail_whole_lines(path: &Path, cap: u64) -> Option<(Vec<u8>, usize)> {
+    let buf = read_tail(path, cap)?;
+    let start = if (buf.len() as u64) < cap {
+        0
+    } else {
+        buf.iter().position(|&byte| byte == b'\n')? + 1
+    };
+    Some((buf, start))
+}
+
+/// Last-to-first walk over the non-empty lines of `buf`, returning the first
+/// that `pick` maps to `Some`.
+fn pick_lines_rev<T>(buf: &[u8], pick: &impl Fn(&str) -> Option<T>) -> Option<T> {
+    buf.split(|&byte| byte == b'\n')
+        .rev()
+        .filter(|line| !line.iter().all(u8::is_ascii_whitespace))
+        .find_map(|line| pick(&String::from_utf8_lossy(line)))
+}
+
 /// Last non-empty line of `path` from a bounded tail window. A record larger than
 /// the window, or any io error, yields `None` - the file then re-reads (safe).
 pub(crate) fn peek_last_line(path: &Path) -> Option<String> {
-    let buf = read_tail(path, TAIL_CAP)?;
-    buf.split(|&byte| byte == b'\n')
-        .rev()
-        .find(|line| !line.iter().all(u8::is_ascii_whitespace))
-        .map(|line| String::from_utf8_lossy(line).into_owned())
+    peek_last_mapped(path, |line| Some(line.to_owned()))
 }
 
 /// Walk non-empty lines of the tail window from last to first, returning the first
@@ -289,12 +351,28 @@ pub(crate) fn peek_last_line(path: &Path) -> Option<String> {
 /// conversation, so the literal last line is rarely the watermark. Short-circuits
 /// at the first match (the newest message sits just behind that trailing metadata),
 /// so it stays as cheap as a single-line peek in practice.
+///
+/// Two passes: a [`PEEK_TAIL_CAP`] window over whole lines only, then - if that
+/// found nothing - the full [`TAIL_CAP`] window with the historical semantics.
+/// Every outcome is therefore either an exact match from a complete line or
+/// exactly what the single big window would have returned.
 pub(crate) fn peek_last_mapped<T>(path: &Path, pick: impl Fn(&str) -> Option<T>) -> Option<T> {
-    let buf = read_tail(path, TAIL_CAP)?;
-    buf.split(|&byte| byte == b'\n')
-        .rev()
-        .filter(|line| !line.iter().all(u8::is_ascii_whitespace))
-        .find_map(|line| pick(&String::from_utf8_lossy(line)))
+    peek_last_mapped_with_caps(path, PEEK_TAIL_CAP, TAIL_CAP, pick)
+}
+
+fn peek_last_mapped_with_caps<T>(
+    path: &Path,
+    small_cap: u64,
+    full_cap: u64,
+    pick: impl Fn(&str) -> Option<T>,
+) -> Option<T> {
+    if let Some((buf, start)) = tail_whole_lines(path, small_cap)
+        && let Some(found) = pick_lines_rev(&buf[start..], &pick)
+    {
+        return Some(found);
+    }
+    let buf = read_tail(path, full_cap)?;
+    pick_lines_rev(&buf, &pick)
 }
 
 fn read_files<D: JsonlTree>(
@@ -646,5 +724,116 @@ mod tests {
             _ => panic!("expected second record"),
         };
         assert_eq!(second["b"], "next");
+    }
+
+    fn pick_ts(line: &str) -> Option<i64> {
+        serde_json::from_str::<Value>(line).ok()?["ts"].as_i64()
+    }
+
+    fn write_peek_file(dir: &tempfile::TempDir, name: &str, content: &str) -> PathBuf {
+        let path = dir.path().join(name);
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn peek_escalates_when_the_small_window_misses_the_watermark() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // Watermark line, then enough timestamp-less metadata to push it out
+        // of a 64-byte first pass entirely.
+        let content = format!("{{\"ts\":7}}\n{}", "{\"m\":1}\n".repeat(10));
+        let path = write_peek_file(&dir, "escalate.jsonl", &content);
+        assert_eq!(
+            peek_last_mapped_with_caps(&path, 64, TAIL_CAP, pick_ts),
+            Some(7),
+            "the escalated pass must find what the small window cannot",
+        );
+    }
+
+    #[test]
+    fn peek_never_matches_a_truncated_first_chunk() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // Line B is garbage whose final 10 bytes parse as `{"ts":999}` on
+        // their own. Trailing metadata is sized so the 64-byte window starts
+        // exactly at that fragment: an unguarded walk would return 999; the
+        // whole-lines pass discards the fragment, escalates, and finds the
+        // real watermark on line A.
+        let line_a = "{\"ts\":111}\n";
+        let line_b = format!("{}{{\"ts\":999}}\n", "X".repeat(30));
+        let meta = format!("{{\"pad\":\"{}\"}}\n", "y".repeat(42));
+        assert_eq!(meta.len(), 53, "fragment(10) + newline(1) + meta = 64");
+        let path = write_peek_file(&dir, "cut.jsonl", &format!("{line_a}{line_b}{meta}"));
+        assert_eq!(
+            peek_last_mapped_with_caps(&path, 64, TAIL_CAP, pick_ts),
+            Some(111),
+            "a mid-line fragment must never satisfy the peek",
+        );
+    }
+
+    #[test]
+    fn peek_small_window_covers_a_small_file_from_its_first_line() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = write_peek_file(&dir, "small.jsonl", "{\"ts\":42}\n{\"m\":1}\n");
+        assert_eq!(
+            peek_last_mapped_with_caps(&path, 64, TAIL_CAP, pick_ts),
+            Some(42),
+            "a window covering the whole file must consider its first line",
+        );
+    }
+
+    #[derive(Clone)]
+    struct PeekTree {
+        root: PathBuf,
+    }
+
+    impl JsonlTree for PeekTree {
+        type State = ();
+
+        fn name(&self) -> &'static str {
+            "peek-test"
+        }
+        fn root(&self) -> &Path {
+            &self.root
+        }
+        fn peek_session_id(&self, path: &Path, _first_line: &str) -> Option<String> {
+            Some(path.file_stem()?.to_str()?.to_owned())
+        }
+        fn peek_last_ts(&self, _path: &Path) -> Option<i64> {
+            Some(1)
+        }
+        fn session(&self, _path: &Path, _rows: &[BoundedRow]) -> Result<Session, AdapterError> {
+            unreachable!("collect_heads never builds sessions")
+        }
+        fn events_from_row(
+            &self,
+            _session: &Session,
+            _row: &BoundedRow,
+            _state: &mut Self::State,
+        ) -> Result<Vec<IngestEvent>, String> {
+            unreachable!("collect_heads never reads rows")
+        }
+    }
+
+    #[test]
+    fn parallel_peek_keeps_heads_in_sorted_path_order() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // More files than the worker cap, created out of name order.
+        for i in [7, 3, 19, 0, 12, 5, 16, 1, 9, 14, 2, 18, 4, 11, 6] {
+            write_peek_file(&dir, &format!("s{i:02}.jsonl"), "{\"ts\":1}\n");
+        }
+        let tree = PeekTree {
+            root: dir.path().to_owned(),
+        };
+        let heads = collect_heads(&tree, false).unwrap();
+        let paths: Vec<_> = heads.iter().map(|head| head.path.clone()).collect();
+        let mut sorted = paths.clone();
+        sorted.sort();
+        assert_eq!(paths, sorted, "head order must stay deterministic");
+        assert!(
+            heads
+                .iter()
+                .all(|head| head.session_id.is_some() && head.last_ts == Some(1)),
+            "the peeked fields must survive the parallel fan-out",
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1187,15 +1187,15 @@ async fn main() -> anyhow::Result<()> {
                     .with_context(|| format!("drop_index({name}) failed"))?;
                 output(&format!("optimize: dropped index {name}"))?;
             } else if rebuild {
-                // Migration path: bring the store to the regular-optimize end
-                // state (embed + fold + compaction + cleanup), then rebuild
+                // Recovery/migration path: fill the embed backlog, rebuild
                 // every index from scratch so it adopts current params, then
-                // reclaim the segments the rebuild superseded.
+                // reclaim the segments the rebuild superseded. The incremental
+                // fold is deliberately not run first: the rebuild discards its
+                // output, and a structurally broken index - the fault
+                // --rebuild exists to repair - fails the fold, which would
+                // make the recovery path unreachable.
                 let policy = configured_maintenance_policy(&loaded, None)?;
-                let outcome = finalize_indexes(&store, &policy, force_embed).await?;
-                if outcome.any_indices_failed() {
-                    std::process::exit(1);
-                }
+                run_embed_stage(&store, force_embed).await?;
                 let (progress, bar) = optimize_progress_bar();
                 let result = store.rebuild_indices(None, Some(progress)).await;
                 bar.finish_and_clear();
@@ -4055,6 +4055,12 @@ fn render_optimize_hints(outcome: &OptimizeOutcome) -> anyhow::Result<()> {
                 &format!("error  indices on {}: {error:#}", entry.table.as_str()),
                 red(),
             ))?;
+            if pond::substrate::is_index_error(error) {
+                output(&format!(
+                    "{}  structural index fault; recover with `pond optimize --rebuild`",
+                    paint("hint", dim()),
+                ))?;
+            }
         }
         if let PhaseOutcome::Failed(error) = &entry.compaction {
             output(&paint(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1056,7 +1056,7 @@ async fn main() -> anyhow::Result<()> {
                     store.table_sizes(),
                     store.row_counts(),
                     store.adapter_names(include_subagents),
-                    store.index_status(),
+                    store.index_status_indexable(),
                     embedding_fut,
                 )?;
                 let totals = RowTotals {

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1160,9 +1160,19 @@ impl Store {
             return Ok((outcomes, counts));
         }
 
+        // The sessions merge is insert-only (`WhenMatched::DoNothing`), so a
+        // row already present would be probed and left untouched while still
+        // paying a commit - Lance 7 writes a new empty manifest version even
+        // when every row matches. Filter to the genuinely absent rows and skip
+        // the merge outright when none are new: the steady-state flush (grown
+        // sessions, no new ones) then commits 2 tables, not 3. Absent rows
+        // keep merge (not append): two writers can race the same new session
+        // id, and merge makes the loser's row a no-op instead of a duplicate.
         let sessions_owned: Vec<Session> = writeable
             .iter()
-            .map(|substream| substream.session.clone())
+            .map(|substream| &substream.session)
+            .filter(|session| !existing_sessions.contains_key(&session.id))
+            .cloned()
             .collect();
         // Drop only in-batch duplicates here (spec.md#adapter-integrity-dedup);
         // `append_filtered` drops the rows already present on the destination.
@@ -1210,7 +1220,6 @@ impl Store {
             .embed_message_rows(&message_rows, &existing_message_pks)
             .await?;
 
-        let session_batches = sessions_batches(&sessions_owned)?;
         let message_stream = tokio_stream::iter(
             messages_batches(&message_rows, &message_vectors)?
                 .into_iter()
@@ -1233,8 +1242,10 @@ impl Store {
                 Self::part_keep(existing_part_pks.clone()),
             ),
         )?;
-        let _sessions_inserted =
+        if !sessions_owned.is_empty() {
+            let session_batches = sessions_batches(&sessions_owned)?;
             merge_insert_chunks(&self.handle, Table::Sessions, session_batches).await?;
+        }
 
         for substream in &writeable {
             outcomes.extend(success_outcomes_for_substream(
@@ -6833,6 +6844,35 @@ mod tests {
             0,
             "a threshold-0 fold must consolidate the deferred tail",
         );
+        Ok(())
+    }
+
+    /// A flush whose every session row already exists must not commit the
+    /// sessions table at all: the merge is insert-only, so the commit would
+    /// be an empty manifest version paid on every steady-state sync.
+    #[tokio::test]
+    async fn grown_session_flush_skips_the_sessions_merge() -> anyhow::Result<()> {
+        let temp = TempDir::new()?;
+        let store = Store::open_local(temp.path()).await?;
+        ingest_events(&store, conversational_events("session-grow", 1)).await?;
+        let sessions_before = store.handle.dataset(Table::Sessions).await?.version_id();
+        let messages_before = store.handle.dataset(Table::Messages).await?.version_id();
+
+        ingest_events(&store, conversational_events("session-grow", 2)).await?;
+        assert_eq!(
+            store.handle.dataset(Table::Sessions).await?.version_id(),
+            sessions_before,
+            "an all-present sessions batch must skip the merge commit",
+        );
+        assert!(
+            store.handle.dataset(Table::Messages).await?.version_id() > messages_before,
+            "the grown message rows must still commit",
+        );
+        let session = store
+            .get_session("session-grow")
+            .await?
+            .expect("session row must survive the skipped merge");
+        assert_eq!(session.messages.len(), 2);
         Ok(())
     }
 

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -3051,10 +3051,26 @@ impl Store {
     }
 
     pub async fn index_status(&self) -> Result<Vec<IndexStatus>> {
+        self.index_status_with(false).await
+    }
+
+    /// Like [`Self::index_status`], but content indexes (FTS, IVF) report only
+    /// the non-null - actually indexable - rows of their unindexed tail. The
+    /// honest number for `pond status`; costs a tail-bounded scan, so the
+    /// per-sync summary stays on the cheap manifest-only variant.
+    pub async fn index_status_indexable(&self) -> Result<Vec<IndexStatus>> {
+        self.index_status_with(true).await
+    }
+
+    async fn index_status_with(&self, indexable_only: bool) -> Result<Vec<IndexStatus>> {
         let policy = pond_index_intents();
         let mut statuses = Vec::new();
         for (table, intents) in policy.all() {
-            statuses.extend(self.handle.index_status(table, intents).await?);
+            statuses.extend(
+                self.handle
+                    .index_status(table, intents, indexable_only)
+                    .await?,
+            );
         }
         Ok(statuses)
     }
@@ -6816,6 +6832,97 @@ mod tests {
                 .await?,
             0,
             "a threshold-0 fold must consolidate the deferred tail",
+        );
+        Ok(())
+    }
+
+    /// A tail whose every row has a null `search_text` (tool-call-only
+    /// messages) must not fold into the FTS index: Lance 7.0.0 writes an
+    /// empty delta segment for it and reads that segment back with a
+    /// mismatched posting-tail codec, deterministically failing every later
+    /// merge. The guard skips the fold; the rows stay in the flat-scanned
+    /// tail and get carried into the next fold that has real text.
+    #[tokio::test]
+    async fn fts_fold_skips_a_tail_with_no_indexable_text() -> anyhow::Result<()> {
+        let temp = TempDir::new()?;
+        let (store, _keys) = store_with_messages(&temp, 300).await?;
+        store
+            .optimize_indices_with_scalar_fold_threshold(0)
+            .await?
+            .into_result()?;
+
+        let tool_only_message = |i: usize| {
+            let message_id = format!("tool-msg-{i}");
+            [
+                IngestEvent::Message(Message::Assistant {
+                    id: message_id.clone(),
+                    session_id: "session-toolonly".to_owned(),
+                    timestamp: Utc::now(),
+                    options: ProviderOptions::new(),
+                }),
+                IngestEvent::Part(Part {
+                    session_id: "session-toolonly".to_owned(),
+                    id: format!("{message_id}-part"),
+                    message_id,
+                    ordinal: 0,
+                    provenance: crate::wire::Provenance::Conversational,
+                    options: ProviderOptions::new(),
+                    kind: PartKind::ToolCall {
+                        call_id: Some(Extracted::from_test_value(format!("call-{i}"))),
+                        name: Some(Extracted::from_test_value("Bash".to_owned())),
+                        params: serde_json::json!({"command": "ls"}),
+                        provider_executed: false,
+                    },
+                }),
+            ]
+        };
+        let mut events = vec![IngestEvent::Session(synthetic_session("session-toolonly"))];
+        events.extend((0..3).flat_map(tool_only_message));
+        ingest_events(&store, events).await?;
+
+        store
+            .optimize_indices_with_scalar_fold_threshold(0)
+            .await?
+            .into_result()?;
+        assert_eq!(
+            store
+                .handle
+                .unindexed_row_count(Table::Messages, MESSAGES_FTS_INDEX)
+                .await?,
+            3,
+            "an all-null tail must not fold into the FTS index",
+        );
+        let fts_status = |statuses: Vec<crate::substrate::IndexStatus>| {
+            statuses
+                .into_iter()
+                .find(|status| status.intent_name == MESSAGES_FTS_INDEX)
+                .expect("FTS status present")
+        };
+        assert_eq!(
+            fts_status(store.index_status().await?).unindexed_rows,
+            3,
+            "the raw view counts uncovered rows",
+        );
+        assert_eq!(
+            fts_status(store.index_status_indexable().await?).unindexed_rows,
+            0,
+            "the indexable view treats an all-null tail as nothing pending",
+        );
+
+        // One real text row lands: the next fold indexes the whole tail,
+        // carrying the previously skipped rows - none are stranded.
+        ingest_events(&store, conversational_events("session-toolonly", 1)).await?;
+        store
+            .optimize_indices_with_scalar_fold_threshold(0)
+            .await?
+            .into_result()?;
+        assert_eq!(
+            store
+                .handle
+                .unindexed_row_count(Table::Messages, MESSAGES_FTS_INDEX)
+                .await?,
+            0,
+            "a fold with real text must consolidate the skipped rows too",
         );
         Ok(())
     }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -6847,6 +6847,62 @@ mod tests {
         Ok(())
     }
 
+    /// At the delta-merge threshold the FTS index must REBUILD, never merge:
+    /// Lance 7.0.0's inverted merge fails two ways on real segments (posting
+    /// tail codec mismatch on empty segments; index-out-of-bounds panic in
+    /// `InnerBuilder::merge_from`), so consolidation routes FTS to the
+    /// from-scratch rebuild path. This drives real grow -> fold cycles past
+    /// the threshold and asserts an IndexRebuild phase fired, the segment
+    /// chain collapsed to one, and the rebuilt index covers everything.
+    #[tokio::test]
+    async fn fts_consolidation_rebuilds_instead_of_merging() -> anyhow::Result<()> {
+        use crate::substrate::{OptimizeEvent, OptimizePhase};
+
+        type PhaseLog = std::sync::Arc<std::sync::Mutex<Vec<(OptimizePhase, Option<String>)>>>;
+        let temp = TempDir::new()?;
+        let (store, _keys) = store_with_messages(&temp, 300).await?;
+        let phases: PhaseLog = std::sync::Arc::default();
+        let sink = phases.clone();
+        let progress: crate::substrate::OptimizeProgressFn = std::sync::Arc::new(move |event| {
+            if let OptimizeEvent::PhaseStart { phase, detail, .. } = event {
+                sink.lock().unwrap().push((phase, detail));
+            }
+        });
+
+        for round in 0..=crate::substrate::DELTA_MERGE_THRESHOLD {
+            ingest_events(&store, conversational_events(&format!("grow-{round}"), 2)).await?;
+            store
+                .optimize_indices(Some(progress.clone()), &MaintenancePolicy::always_compact())
+                .await?
+                .into_result()?;
+        }
+
+        assert!(
+            phases.lock().unwrap().iter().any(|(phase, detail)| {
+                matches!(phase, OptimizePhase::IndexRebuild)
+                    && detail.as_deref() == Some(MESSAGES_FTS_INDEX)
+            }),
+            "crossing the threshold must rebuild the FTS index, not merge it",
+        );
+        let fts_segments = store
+            .handle
+            .messages_index_names()
+            .await?
+            .into_iter()
+            .filter(|name| name == MESSAGES_FTS_INDEX)
+            .count();
+        assert_eq!(fts_segments, 1, "the rebuild collapses the segment chain");
+        assert_eq!(
+            store
+                .handle
+                .unindexed_row_count(Table::Messages, MESSAGES_FTS_INDEX)
+                .await?,
+            0,
+            "the rebuilt index covers every fragment",
+        );
+        Ok(())
+    }
+
     /// A flush whose every session row already exists must not commit the
     /// sessions table at all: the merge is insert-only, so the commit would
     /// be an empty manifest version paid on every steady-state sync.

--- a/src/substrate.rs
+++ b/src/substrate.rs
@@ -1429,6 +1429,15 @@ fn is_conflict_exhausted(error: &anyhow::Error) -> bool {
     error.chain().any(|cause| cause.is::<ConflictExhausted>())
 }
 
+/// True when the chain root is Lance's `Index` error class - a structural
+/// index fault (e.g. delta segments with mismatched posting tail codecs) that
+/// retry cannot clear and only a from-scratch rebuild repairs.
+pub fn is_index_error(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<lance::Error>()
+        .is_some_and(|err| matches!(err, lance::Error::Index { .. }))
+}
+
 /// On-disk byte totals for the three session datasets, plus everything else
 /// under the data-dir root. Sized by listing through Lance's object-store
 /// layer (spec.md#lance-chokepoints-storage) so `file://` and `s3://` behave alike.
@@ -3885,6 +3894,18 @@ mod tests {
 
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn is_index_error_matches_lance_index_class_through_context() {
+        let index_fault = anyhow::Error::from(lance::Error::index(
+            "cannot merge inverted index segments with different posting tail codecs",
+        ))
+        .context("optimize_indices(merge) failed during index optimize");
+        assert!(is_index_error(&index_fault));
+
+        let io_fault = anyhow::anyhow!("connection reset").context("optimize_indices failed");
+        assert!(!is_index_error(&io_fault));
+    }
 
     #[test]
     fn prune_keeps_live_uuid_dirs_and_drops_dead_ones() {

--- a/src/substrate.rs
+++ b/src/substrate.rs
@@ -2458,9 +2458,10 @@ impl Handle {
         &self,
         table: Table,
         intents: &[IndexIntent],
+        indexable_only: bool,
     ) -> Result<Vec<IndexStatus>> {
         let dataset = self.dataset(table).await?;
-        index_status(table, &dataset, intents).await
+        index_status(table, &dataset, intents, indexable_only).await
     }
 
     pub(crate) async fn dataset(&self, table: Table) -> Result<Dataset> {
@@ -3175,6 +3176,24 @@ async fn optimize_table_indices(
             );
             continue;
         }
+        // FTS-only guard: folding a tail with zero non-null values writes an
+        // empty delta segment, which Lance 7.0.0 reads back with the wrong
+        // posting-tail codec (`Default` = VarintDelta vs the metadata-absent
+        // default Fixed32), deterministically failing every later merge. The
+        // probe is bounded: it reads only the tail fragments the fold itself
+        // would read, stops at the first non-null value, and runs only after
+        // the fold threshold already passed.
+        if matches!(intent.params, IndexParamsKind::InvertedFtsWord)
+            && !column_has_values(dataset, intent.column, &unindexed).await?
+        {
+            tracing::debug!(
+                target: "pond::perf",
+                index = intent.name,
+                tail_rows,
+                "skipping FTS fold (tail has no indexable values)",
+            );
+            continue;
+        }
         // Every family folds incrementally via `optimize_indices` (the
         // append/merge batch below) - no full rebuild. BTree rewrites its index
         // file by merging the existing sorted pages with only the new fragments'
@@ -3242,6 +3261,52 @@ async fn optimize_table_indices(
     Ok(did_work)
 }
 
+/// Fragment-scoped scanner over the non-null rows of `column` - the shared
+/// base of the existence probe and the indexable count below.
+fn non_null_scanner(
+    dataset: &Dataset,
+    column: &'static str,
+    fragments: &[lance::table::format::Fragment],
+) -> Result<lance::dataset::scanner::Scanner> {
+    let mut scanner = dataset.scan();
+    scanner.with_fragments(fragments.to_vec());
+    scanner.filter(&Predicate::IsNotNull(column).to_lance())?;
+    Ok(scanner)
+}
+
+/// True when any row in `fragments` holds a non-null value for `column`.
+/// Existence probe for the FTS fold guard: scans only the given fragments,
+/// stops at the first hit (`limit 1`), so its read is a subset of what the
+/// fold it gates would read.
+async fn column_has_values(
+    dataset: &Dataset,
+    column: &'static str,
+    fragments: &[lance::table::format::Fragment],
+) -> Result<bool> {
+    let mut scanner = non_null_scanner(dataset, column, fragments)?;
+    scanner.project(&[column])?;
+    scanner.limit(Some(1), None)?;
+    let batch = scanner
+        .try_into_batch()
+        .await
+        .with_context(|| format!("non-null probe on {column} failed"))?;
+    Ok(batch.num_rows() > 0)
+}
+
+/// Count of rows in `fragments` holding a non-null value for `column`. Serves
+/// the indexable status view; fragment-scoped, so bounded by the tail.
+async fn column_value_count(
+    dataset: &Dataset,
+    column: &'static str,
+    fragments: &[lance::table::format::Fragment],
+) -> Result<usize> {
+    let count = non_null_scanner(dataset, column, fragments)?
+        .count_rows()
+        .await
+        .with_context(|| format!("non-null count on {column} failed"))?;
+    Ok(count as usize)
+}
+
 async fn rebuild_index(
     dataset: &mut Dataset,
     intent: &IndexIntent,
@@ -3270,6 +3335,7 @@ async fn index_status(
     table: Table,
     dataset: &Dataset,
     intents: &[IndexIntent],
+    indexable_only: bool,
 ) -> Result<Vec<IndexStatus>> {
     let existing = dataset.load_indices().await?;
     let existing_names: std::collections::HashSet<String> =
@@ -3295,10 +3361,26 @@ async fn index_status(
             .await
             .with_context(|| format!("unindexed_fragments failed for {}", table.label()))?;
         let unindexed_fragments = unindexed.len();
-        let unindexed_rows = unindexed
+        let mut unindexed_rows: usize = unindexed
             .iter()
             .map(|fragment| fragment.num_rows().unwrap_or(0))
             .sum();
+        // Content indexes (FTS, IVF) take in only non-null rows - most message
+        // rows carry a null `search_text`/`vector` (tool/system roles), so the
+        // raw fragment row count vastly overstates the actionable backlog and
+        // an all-null tail (which the FTS fold guard skips) would read as
+        // stuck. The indexable view counts what a fold could actually index;
+        // opt-in because the count scans the tail, which the per-sync summary
+        // must not pay.
+        if indexable_only
+            && unindexed_rows > 0
+            && matches!(
+                intent.params,
+                IndexParamsKind::InvertedFtsWord | IndexParamsKind::IvfSqCosine { .. }
+            )
+        {
+            unindexed_rows = column_value_count(dataset, intent.column, &unindexed).await?;
+        }
         statuses.push(IndexStatus {
             table,
             intent_name: intent.name.to_owned(),

--- a/src/substrate.rs
+++ b/src/substrate.rs
@@ -3214,10 +3214,29 @@ async fn optimize_table_indices(
                 .filter(|index| index.name.as_str() == name)
                 .count()
         };
-        let (to_merge, to_append): (Vec<String>, Vec<String>) = append_indices
+        let (consolidate, to_append): (Vec<String>, Vec<String>) = append_indices
             .iter()
             .cloned()
             .partition(|name| segment_count(name) >= DELTA_MERGE_THRESHOLD);
+        // FTS delta segments are never merged: Lance 7.0.0's inverted merge
+        // has two reproducible defects on real segments - "different posting
+        // tail codecs" (a partitionless segment reports the derive-default
+        // codec) and an index-out-of-bounds panic in InnerBuilder::merge_from
+        // (token ids past the resized posting table; crashed the 5-min cron
+        // sync in a loop). At the same threshold a merge would fire, the FTS
+        // index instead rebuilds from scratch - the one consolidation path
+        // Lance executes correctly. Scalar and vector merges are unaffected.
+        let mut fts_rebuilds: Vec<&IndexIntent> = Vec::new();
+        let mut to_merge: Vec<String> = Vec::new();
+        for name in consolidate {
+            let fts_intent = intents.iter().find(|intent| {
+                intent.name == name && matches!(intent.params, IndexParamsKind::InvertedFtsWord)
+            });
+            match fts_intent {
+                Some(intent) => fts_rebuilds.push(intent),
+                None => to_merge.push(name),
+            }
+        }
 
         emit(
             progress,
@@ -3250,9 +3269,30 @@ async fn optimize_table_indices(
                 elapsed_ms: started.elapsed().as_millis() as u64,
             },
         );
+        for intent in &fts_rebuilds {
+            emit(
+                progress,
+                OptimizeEvent::PhaseStart {
+                    table,
+                    phase: OptimizePhase::IndexRebuild,
+                    detail: Some(intent.name.to_owned()),
+                },
+            );
+            let rebuild_started = Instant::now();
+            rebuild_index(dataset, intent, progress, table).await?;
+            emit(
+                progress,
+                OptimizeEvent::PhaseDone {
+                    table,
+                    phase: OptimizePhase::IndexRebuild,
+                    elapsed_ms: rebuild_started.elapsed().as_millis() as u64,
+                },
+            );
+        }
         tracing::debug!(
             target: "pond::perf",
             indices = ?append_indices,
+            rebuilt = ?fts_rebuilds,
             "folded trailing fragments into indices",
         );
         did_work = true;


### PR DESCRIPTION
## What

Four commits, cherry-picked off `ci/arc-runners` so they land with their own conventional-commit types instead of being squash-collapsed under a `ci:` title (release-plz derives version + changelog from these).

1. **fix(optimize):** `--rebuild` no longer runs (and dies on) the incremental fold it exists to supersede; Lance Index-class fold failures print the recovery command. Also documents the claude.ai export import.
2. **fix(index):** FTS folds skip all-null tails - Lance 7.0.0 writes an empty delta segment for them and reads it back with a mismatched posting-tail codec, deterministically poisoning every later merge. `pond status` content-index pending counts now report only indexable (non-null) rows.
3. **perf(sync):** escalating freshness-peek window (64KB whole-lines first pass -> 32MB on miss), parallel peek, skip the no-op sessions merge. Measured on the real 10,469-file corpus: fresh-skip pass **11.07s -> 1.59s (7x)**; steady-state no-op sync **0.53s**.
4. **fix(index):** FTS delta consolidation rebuilds instead of merging - Lance's inverted merge also panics (`InnerBuilder::merge_from` index-out-of-bounds), which crash-looped the 5-min cron sync on a real store. Measured on a full-scale prod clone over S3: 4m24s-4m55s per consolidation, ~once weekly; scalar/vector merges untouched.

## Validation

- fmt / clippy `-D warnings` / full test suite green per commit and at tip (257 tests, 7 new).
- A/B benched: ingest fresh-skip path, S3 finalize profile (16 fold rounds), timed local + remote syncs, remote search recall smoke.
- Full CLI command sweep on local + remote stores (every verb; findings: `pond erase` is spec'd but unimplemented - pre-existing, not addressed here).

## Note for ci/arc-runners (#84)

That branch contains these same changes (some swept into its CI commits). Once this PR merges, #84's squash diff against main shrinks to CI-only changes - merge this first.