### PR TITLE
chore: release v0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.11.2](https://github.com/tenequm/pond/compare/v0.11.1...v0.11.2) - 2026-07-03
+
+### <!-- 2 -->🐛 Bug Fixes
+- **index:** consolidate FTS delta segments by rebuild, never merge ([3a46cea](https://github.com/tenequm/pond/commit/3a46cea98403dd4983d52b9ed4195ac357f85981))
+- **index:** guard FTS folds against all-null tails; honest pending counts ([a7a82f9](https://github.com/tenequm/pond/commit/a7a82f987ed7ab2ff83541852636ba42d3078ec8))
+- **optimize:** make --rebuild reachable when the fold is broken; document claude.ai import ([7695f3f](https://github.com/tenequm/pond/commit/7695f3f8a27bbeef904cd7c6c6a86d4bad14e041))
+
+### <!-- 3 -->🚀 Performance
+- **sync:** escalating peek window, parallel peek, skip no-op sessions merge ([11d1037](https://github.com/tenequm/pond/commit/11d1037ea9c1753fc101bb09543cc33029908886))
+
+### <!-- 6 -->🧹 Chores
+- **repo:** move gitleaks/release-plz configs + git hooks under .github/, moon-manage hook setup ([2323744](https://github.com/tenequm/pond/commit/23237441d92ec569792d8b252aa966431fca48c4))
+
+**Full Changelog**: https://github.com/tenequm/pond/compare/v0.11.1...v0.11.2
+
 ## [0.11.1](https://github.com/tenequm/pond/compare/v0.11.0...v0.11.1) - 2026-07-01
 
 ### <!-- 3 -->🚀 Performance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6463,7 +6463,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pond-db"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 # crate). The library and binary stay `pond` via [lib]/[[bin]] below, so the
 # command and `use pond::...` are unchanged - only `cargo install pond-db` differs.
 name = "pond-db"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 # MSRV pinned to the toolchain we build and test with (rust-toolchain.toml).
 rust-version = "1.95"


### PR DESCRIPTION



## 🤖 New release

* `pond-db`: 0.11.1 -> 0.11.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.2](https://github.com/tenequm/pond/compare/v0.11.1...v0.11.2) - 2026-07-03

### <!-- 2 -->🐛 Bug Fixes
- **index:** consolidate FTS delta segments by rebuild, never merge ([3a46cea](https://github.com/tenequm/pond/commit/3a46cea98403dd4983d52b9ed4195ac357f85981))
- **index:** guard FTS folds against all-null tails; honest pending counts ([a7a82f9](https://github.com/tenequm/pond/commit/a7a82f987ed7ab2ff83541852636ba42d3078ec8))
- **optimize:** make --rebuild reachable when the fold is broken; document claude.ai import ([7695f3f](https://github.com/tenequm/pond/commit/7695f3f8a27bbeef904cd7c6c6a86d4bad14e041))

### <!-- 3 -->🚀 Performance
- **sync:** escalating peek window, parallel peek, skip no-op sessions merge ([11d1037](https://github.com/tenequm/pond/commit/11d1037ea9c1753fc101bb09543cc33029908886))

### <!-- 6 -->🧹 Chores
- **repo:** move gitleaks/release-plz configs + git hooks under .github/, moon-manage hook setup ([2323744](https://github.com/tenequm/pond/commit/23237441d92ec569792d8b252aa966431fca48c4))

**Full Changelog**: https://github.com/tenequm/pond/compare/v0.11.1...v0.11.2
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).