### PR TITLE
chore: release v0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.12.2](https://github.com/tenequm/pond/compare/v0.12.1...v0.12.2) - 2026-07-07
+
+### <!-- 1 -->🎉 New Features
+- **deps:** upgrade lance 7.0.0 -> 8.0.0 ([56e968e](https://github.com/tenequm/pond/commit/56e968ed355581eb7464ad0cd2c19236b81b9e67))
+
+**Full Changelog**: https://github.com/tenequm/pond/compare/v0.12.1...v0.12.2
+
 ## [0.12.1](https://github.com/tenequm/pond/compare/v0.12.0...v0.12.1) - 2026-07-06
 
 Sync status now reports genuine work only, and forked subagent transcripts are no longer silently dropped. Verified end to end against the full real corpus (11k+ sessions / 1.8M messages) on both a local store and the S3 backend: ingestion is byte-identical to v0.12.0 except for the recovered data.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6639,7 +6639,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pond-db"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 # crate). The library and binary stay `pond` via [lib]/[[bin]] below, so the
 # command and `use pond::...` are unchanged - only `cargo install pond-db` differs.
 name = "pond-db"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2024"
 # MSRV pinned to the toolchain we build and test with (rust-toolchain.toml).
 rust-version = "1.95"


### PR DESCRIPTION



## 🤖 New release

* `pond-db`: 0.12.1 -> 0.12.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.2](https://github.com/tenequm/pond/compare/v0.12.1...v0.12.2) - 2026-07-07

### <!-- 1 -->🎉 New Features
- **deps:** upgrade lance 7.0.0 -> 8.0.0 ([56e968e](https://github.com/tenequm/pond/commit/56e968ed355581eb7464ad0cd2c19236b81b9e67))

**Full Changelog**: https://github.com/tenequm/pond/compare/v0.12.1...v0.12.2
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).