### PR TITLE
feat(parts)!: materialize tool columns + in-place schema migration; per-query SQL timeout

### DIFF
--- a/benches/serve_mem_bench.rs
+++ b/benches/serve_mem_bench.rs
@@ -662,7 +662,7 @@ async fn run_sql_phase(
             messages: Some(store.dataset(Table::Messages).await?),
             parts: Some(store.dataset(Table::Parts).await?),
         };
-        match sql::run(&tables, q, Mode::Inline, sql::DEFAULT_INLINE_ROWS).await {
+        match sql::run(&tables, q, Mode::Inline, sql::DEFAULT_INLINE_ROWS, None).await {
             Ok(_) => {}
             Err(error) => anyhow::bail!("{name}: sql {q:?} failed: {error:?}"),
         }

--- a/benches/sync_oracle_bench.rs
+++ b/benches/sync_oracle_bench.rs
@@ -128,12 +128,18 @@ async fn fetch_tables(store: &Store) -> Result<Tables> {
 /// uses. Returns the row count from the result; the inline rendering cost is
 /// kept tiny by passing `inline_rows = 0`.
 async fn run_sql(tables: &Tables, sql: &str) -> Result<usize> {
-    let outcome = pond::sql::run(tables, sql, Mode::Export(pond::sql::Format::Ndjson), 0)
-        .await
-        .map_err(|err| match err {
-            pond::sql::SqlError::Query(msg) => anyhow::anyhow!("query: {msg}"),
-            pond::sql::SqlError::Infra(err) => err,
-        })?;
+    let outcome = pond::sql::run(
+        tables,
+        sql,
+        Mode::Export(pond::sql::Format::Ndjson),
+        0,
+        None,
+    )
+    .await
+    .map_err(|err| match err {
+        pond::sql::SqlError::Query(msg) => anyhow::anyhow!("query: {msg}"),
+        pond::sql::SqlError::Infra(err) => err,
+    })?;
     let count = match outcome {
         Outcome::Inline(_) => 0,
         Outcome::Export { rows, .. } => rows,

--- a/benches/tokenizer_quality_bench.rs
+++ b/benches/tokenizer_quality_bench.rs
@@ -309,7 +309,7 @@ async fn resolve_anchors(store: &Store, queries: &mut [Query]) -> Result<()> {
             let escaped = anchor.replace('\'', "''");
             let sql =
                 format!("SELECT message_id FROM messages WHERE search_text LIKE '%{escaped}%'");
-            match sql::run(&tables, &sql, Mode::Export(sql::Format::Ndjson), 0).await {
+            match sql::run(&tables, &sql, Mode::Export(sql::Format::Ndjson), 0, None).await {
                 Ok(sql::Outcome::Export { bytes, .. }) => {
                     for line in String::from_utf8_lossy(&bytes).lines() {
                         if line.is_empty() {

--- a/docs/site/src/pages/guides/several-machines.mdx
+++ b/docs/site/src/pages/guides/several-machines.mdx
@@ -5,3 +5,7 @@ Point each machine's `config.toml` (or `POND_*` env) at the same URL and credent
 Concurrent writers are safe: Lance serializes commits through the object store's conditional writes (optimistic concurrency), so two syncs at once cannot corrupt the dataset.
 
 Within one machine, sync is single-flight: a second `pond sync` against the same store waits for the first (naming the holder), and the scheduled run passes `--no-wait` so ticks skip cleanly instead of queueing. `pond status --hosts` shows which machines feed the store - sessions and latest activity per ingest host.
+
+## Mixed versions
+
+A release that changes the store schema (0.13.0 added materialized tool columns) migrates the store in place the first time the new binary opens it - a one-time backfill with a stderr notice - after which older binaries fail at open with a schema-mismatch error. When several machines share one bucket, upgrade pond on all of them together; a machine left on an older version stops syncing until it upgrades.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -362,7 +362,7 @@ This section is how the canonical model of Section 4 persists on the substrate o
 
 ### 5.1 Three datasets
 
-The sessions consumer registers three Lance tables: `sessions`, `messages`, and `parts`. Each is a direct serialization of its canonical type - no projections, no promotions - except that `messages` additionally carries a message's derived embedding (5.5).
+The sessions consumer registers three Lance tables: `sessions`, `messages`, and `parts`. Each is a direct serialization of its canonical type plus a small, named set of derived storage columns with no canonical counterpart: `messages` carries the message's derived embedding (5.5), and `parts` carries the materialized tool-identity columns (5.6). Nothing else is projected or promoted.
 
 `sessions` - one row per Session:
 
@@ -398,6 +398,9 @@ The sessions consumer registers three Lance tables: `sessions`, `messages`, and 
 | `ordinal` | position within the message's content |
 | `type` | the Part discriminator |
 | `provenance` | conversational vs injected (`model-part-provenance`, 4.8); search reads it to exclude injected scaffolding |
+| `tool_name` | derived tool-identity column (5.6); scalar-indexed - tool analytics run on the narrow columns instead of scanning `variant_data` |
+| `call_id` | derived tool-call correlation id (5.6) |
+| `is_failure` | derived ToolResult flag (5.6); non-null only on `tool_result` rows |
 | `variant_data` | JSON (Lance `pa.json_()`, stored as JSONB); the variant-specific fields |
 | `data` | Lance blob; FilePart payload only |
 | `options` | JSON (Lance `pa.json_()`, stored as JSONB) |
@@ -425,6 +428,12 @@ A message's embedding has no canonical-type counterpart - it is produced by pond
 **`session-embed-from-canonical`** {#session-embed-from-canonical} - A message's embedding MUST be derived from its stored `search_text`, never from the source record. Why: `search_text` is durable (`session-durable-copy`) and the source is not - deriving from canonical is what lets pond re-embed under a new or changed model at any later time with no source present, making a model change a re-derivation, not a migration.
 
 Re-embedding rewrites only `vector` and `embedding_model`; no canonical column is touched, and each rewrite lands as a new manifest version, not a row mutation (`lance-append-only`). A model swap is a single conditional `merge_update` keyed on `target.embedding_model != source.embedding_model`: stale rows update, up-to-date rows are left alone, and the vector index is dropped before new vectors arrive (centroids belong to one distance space; the next index stage rebuilds it). A same-dimension swap rewrites `vector` in place; a different-dimension swap adds a new column, backfills from `search_text`, drops the old, and renames - all on `messages`, never a new table. Lance's manifest history retains prior vectors, so a regressed swap rolls back without a re-ingest. Section 8 covers how embeddings are produced and queried.
+
+### 5.6 Derived analytics columns and additive schema migration
+
+`parts` carries three nullable columns materialized at ingest from the tool Part bodies: `tool_name`, `call_id` (also carrying the approval request's `tool_call_id` - the same correlation key), and `is_failure` (non-null only on tool results). NULL means the part is not a tool part or the source did not carry the field (`model-no-synthesis`). They exist because analytics must run on narrow native columns: a JSON getter over `variant_data` reads the whole multi-GB column, which on an object store cannot finish inside the query timeout. `variant_data` remains the verbatim record; the materialized columns are projections of it, never independently writable.
+
+**`session-additive-schema-backfill`** {#session-additive-schema-backfill} - A schema change that adds derived nullable columns MUST upgrade existing data in place, never by re-ingest: on open, a store missing known derivable columns backfills them from data already stored (one `add_columns` commit per table; concurrent openers race benignly under OCC), and a `.pond` archive predating the change restores by deriving the missing cells at the read boundary - an archive is a snapshot and restore never mutates it. Why: re-ingest is not a migration path (`session-durable-copy` - a rotated source cannot supply its rows again), so an additive change that stranded existing stores or archives would violate the durability contract it sits on. The backfill derives only from stored data, preserving `model-no-synthesis`: a cell the stored record cannot justify stays NULL.
 
 ---
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1572,9 +1572,14 @@ fn init_tracing(cli_level: tracing::level_filters::LevelFilter) {
     // the check/probe error. Silencing both keeps the storage probe's spinner
     // (and the init wizard) from being corrupted mid-render; `RUST_LOG`
     // (which replaces this whole filter) still opts back in.
+    //
+    // Lance v8 WARNs on every COUNT over a stable-row-id dataset (all pond
+    // tables) that count_pushdown fell back to a scan - a known, unactionable
+    // consequence of the pin, fixed upstream in v9 (lance PR #7360); drop the
+    // directive at the v9 bump.
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         EnvFilter::new(format!(
-            "{cli_level},lance::index::vector::builder=error,aws_config=error,lance::object_store::throttle=error"
+            "{cli_level},lance::index::vector::builder=error,aws_config=error,lance::object_store::throttle=error,lance::io::exec::count_pushdown=error"
         ))
     });
     // `IndicatifLayer` routes both spans (when they opt-in via `pb_set_*`)

--- a/src/main.rs
+++ b/src/main.rs
@@ -578,6 +578,10 @@ enum Command {
         /// `--format parquet`; optional for ndjson). Ignored for text.
         #[arg(long, short = 'o')]
         output_file: Option<PathBuf>,
+        /// Per-query timeout in seconds. Default 30, max 600 - raise it for a
+        /// genuinely long-running query (e.g. a large remote-store scan).
+        #[arg(long, default_value_t = pond::sql::DEFAULT_QUERY_TIMEOUT_SECS)]
+        timeout: u64,
     },
     /// Run the HTTP API server (or MCP over stdio with --transport stdio).
     ///
@@ -1468,6 +1472,7 @@ async fn main() -> anyhow::Result<()> {
             format,
             limit,
             output_file,
+            timeout,
         } => {
             if matches!(format, CliSqlFormat::Parquet) && output_file.is_none() {
                 bail!(
@@ -1510,7 +1515,7 @@ async fn main() -> anyhow::Result<()> {
                 messages,
                 parts,
             };
-            match pond::sql::run(&tables, &sql, mode, inline_rows).await {
+            match pond::sql::run(&tables, &sql, mode, inline_rows, Some(timeout)).await {
                 Ok(pond::sql::Outcome::Inline(text)) => {
                     output(&text)?;
                 }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -440,13 +440,20 @@ impl Store {
         let messages_dataset =
             open_archive_table(Table::Messages, &source.join("messages.lance")).await?;
         let parts_dataset = open_archive_table(Table::Parts, &source.join("parts.lance")).await?;
+        // Validate every table's schema before importing any: a
+        // mixed-compatibility archive must fail whole, not half-restore.
+        let sessions_upgrade = archive_schema_backfill(&sessions_dataset, Table::Sessions)?;
+        let messages_upgrade = archive_schema_backfill(&messages_dataset, Table::Messages)?;
+        let parts_upgrade = archive_schema_backfill(&parts_dataset, Table::Parts)?;
         let (sessions, sessions_inserted) = self
-            .import_clean_table(Table::Sessions, sessions_dataset)
+            .import_clean_table(Table::Sessions, sessions_dataset, sessions_upgrade)
             .await?;
         let (messages, messages_inserted) = self
-            .import_clean_table(Table::Messages, messages_dataset)
+            .import_clean_table(Table::Messages, messages_dataset, messages_upgrade)
             .await?;
-        let (parts, parts_inserted) = self.import_clean_table(Table::Parts, parts_dataset).await?;
+        let (parts, parts_inserted) = self
+            .import_clean_table(Table::Parts, parts_dataset, parts_upgrade)
+            .await?;
         Ok(LanceArchiveImport {
             rows: LanceArchiveCounts {
                 sessions,
@@ -508,12 +515,21 @@ impl Store {
         Ok((rows, source_version))
     }
 
-    async fn import_clean_table(&self, table: Table, dataset: Dataset) -> Result<(usize, usize)> {
+    /// `upgrade` carries the batch-level backfill for a pre-upgrade archive:
+    /// an archive is a snapshot, so restore MUST NOT mutate it in place - the
+    /// missing cells derive at the read boundary through the same recipe the
+    /// store migration uses.
+    async fn import_clean_table(
+        &self,
+        table: Table,
+        dataset: Dataset,
+        upgrade: Option<ColumnBackfill>,
+    ) -> Result<(usize, usize)> {
         // Force the destination table into existence up front: an empty
         // archive table yields zero batches, so merge_insert alone would
         // leave a lazily-created table (sessions or parts) missing on the destination.
         let _ = self.handle.dataset(table).await?;
-        self.merge_scanner(table, dataset.scan(), "archive import")
+        self.merge_scanner(table, dataset.scan(), "archive import", upgrade)
             .await
     }
 
@@ -527,6 +543,7 @@ impl Store {
         table: Table,
         mut scanner: lance::dataset::scanner::Scanner,
         context: &'static str,
+        upgrade: Option<ColumnBackfill>,
     ) -> Result<(usize, usize)> {
         scanner.blob_handling(lance::datatypes::BlobHandling::AllBinary);
         let mut stream = scanner
@@ -538,6 +555,10 @@ impl Store {
         while let Some(batch) = stream.next().await {
             let batch = batch
                 .with_context(|| format!("failed to read {} {context} batch", table.as_str()))?;
+            let batch = match &upgrade {
+                Some(spec) => upgraded_batch(&batch, spec)?,
+                None => batch,
+            };
             let row_count = batch.num_rows();
             rows += row_count;
             let stats = self
@@ -4534,7 +4555,10 @@ const MESSAGE_SCALAR_INDICES: &[(&str, BuiltinIndexType, &str)] = &[
 ];
 
 /// Scalar indexes on `parts`: `(session_id, message_id)` is the hot-path lookup key for
-/// `parts_for_messages` (hydration on every `get` and grouped search).
+/// `parts_for_messages` (hydration on every `get` and grouped search). `tool_name`
+/// serves the #89 analytics filters; BTree, not Bitmap, despite the categorical
+/// shape - prefix LIKE (`tool_name LIKE 'mcp__%'`) errors on bitmap indexes
+/// (same upstream limitation documented for `messages.source_agent`).
 const PARTS_SCALAR_INDICES: &[(&str, BuiltinIndexType, &str)] = &[
     (
         "session_id",
@@ -4545,6 +4569,11 @@ const PARTS_SCALAR_INDICES: &[(&str, BuiltinIndexType, &str)] = &[
         "message_id",
         BuiltinIndexType::BTree,
         "parts_message_id_btree",
+    ),
+    (
+        "tool_name",
+        BuiltinIndexType::BTree,
+        "parts_tool_name_btree",
     ),
 ];
 
@@ -4749,29 +4778,78 @@ fn export_schema(table: Table) -> Arc<Schema> {
     }
 }
 
-fn ensure_schema_matches_archive(dataset: &Dataset, table: Table) -> Result<()> {
+/// Decide how an archive table's schema relates to this build's: identical ->
+/// import verbatim (`None`); missing exactly a derivable set of nullable
+/// columns (the archive predates an additive schema change) -> the recipe to
+/// derive them per batch; anything else -> a hard error naming the version fix.
+fn archive_schema_backfill(dataset: &Dataset, table: Table) -> Result<Option<ColumnBackfill>> {
+    use std::collections::BTreeSet;
     let expected = export_schema(table);
     let actual = lance::deps::arrow_schema::Schema::from(dataset.schema());
-    let actual_names: Vec<_> = actual.fields().iter().map(|field| field.name()).collect();
-    let expected_names: Vec<_> = expected.fields().iter().map(|field| field.name()).collect();
-    if actual_names != expected_names {
+    let actual_names: BTreeSet<&str> = actual.fields().iter().map(|f| f.name().as_str()).collect();
+    let expected_names: BTreeSet<&str> = expected
+        .fields()
+        .iter()
+        .map(|f| f.name().as_str())
+        .collect();
+    let extra: Vec<&str> = actual_names.difference(&expected_names).copied().collect();
+    if !extra.is_empty() {
         anyhow::bail!(
-            "{} archive table has columns {actual_names:?} but this pond build expects {expected_names:?}",
+            "{} archive table has columns {actual_names:?} but this pond build expects \
+             {expected_names:?} - the archive was written by a newer pond; upgrade pond \
+             to restore it",
             table.as_str(),
         );
     }
-    Ok(())
+    let missing: Vec<Field> = expected
+        .fields()
+        .iter()
+        .filter(|f| !actual_names.contains(f.name().as_str()))
+        .map(|f| f.as_ref().clone())
+        .collect();
+    if missing.is_empty() {
+        return Ok(None);
+    }
+    column_backfill(table.as_str(), &missing)
+        .map(Some)
+        .with_context(|| {
+            format!(
+                "{} archive predates a schema change this pond build cannot bridge; \
+                 restore it with the pond version that wrote it",
+                table.as_str(),
+            )
+        })
+}
+
+/// Extend an older-schema `batch` with the cells `spec` derives from it. The
+/// derived columns append after the scanned ones as-is: a scan may
+/// auto-convert JSON columns to their Arrow text form, and aligning batch
+/// columns to the stored schema (by name, with that conversion) is the merge
+/// path's job, not this function's.
+fn upgraded_batch(batch: &RecordBatch, spec: &ColumnBackfill) -> Result<RecordBatch> {
+    let derived = (spec.mapper)(batch)?;
+    let mut fields: Vec<Field> = batch
+        .schema()
+        .fields()
+        .iter()
+        .map(|field| field.as_ref().clone())
+        .collect();
+    let mut columns = batch.columns().to_vec();
+    for (field, column) in spec.output_schema.fields().iter().zip(derived.columns()) {
+        fields.push(field.as_ref().clone());
+        columns.push(column.clone());
+    }
+    RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
+        .context("failed to assemble upgraded batch")
 }
 
 async fn open_archive_table(table: Table, source: &Path) -> Result<Dataset> {
     let source_uri = source
         .to_str()
         .with_context(|| format!("archive path is not UTF-8: {}", source.display()))?;
-    let dataset = Dataset::open(source_uri)
+    Dataset::open(source_uri)
         .await
-        .with_context(|| format!("failed to open {} archive table", table.as_str()))?;
-    ensure_schema_matches_archive(&dataset, table)?;
-    Ok(dataset)
+        .with_context(|| format!("failed to open {} archive table", table.as_str()))
 }
 
 /// The composite primary-key columns each table's schema declares
@@ -4833,6 +4911,88 @@ pub(crate) fn message_schema() -> Arc<Schema> {
     ]))
 }
 
+/// Derives one batch of backfill cells from a batch of stored columns.
+pub(crate) type BackfillMapper = Box<dyn Fn(&RecordBatch) -> Result<RecordBatch> + Send + Sync>;
+
+/// One table's recipe for the additive-schema backfill: which stored columns
+/// to read and how to derive the missing ones. The substrate open path feeds
+/// this to `Dataset::add_columns`, so an existing store upgrades in place -
+/// never by re-ingest, which cannot recover sessions whose sources are gone
+/// (spec.md#session-durable-copy).
+pub(crate) struct ColumnBackfill {
+    pub read_columns: Vec<String>,
+    pub output_schema: Arc<Schema>,
+    pub mapper: BackfillMapper,
+}
+
+/// Build the recipe deriving `missing` for `table_name`, or fail when any of
+/// the columns cannot be derived from stored data.
+pub(crate) fn column_backfill(table_name: &str, missing: &[Field]) -> Result<ColumnBackfill> {
+    match table_name {
+        PARTS => parts_backfill(missing),
+        other => anyhow::bail!(
+            "table {other} is missing columns {:?} that this pond build cannot derive from stored data",
+            missing.iter().map(|f| f.name()).collect::<Vec<_>>(),
+        ),
+    }
+}
+
+fn parts_backfill(missing: &[Field]) -> Result<ColumnBackfill> {
+    for field in missing {
+        anyhow::ensure!(
+            ["tool_name", "call_id", "is_failure"].contains(&field.name().as_str())
+                && field.is_nullable(),
+            "column {PARTS}.{} cannot be derived from stored data",
+            field.name(),
+        );
+    }
+    let output_schema = Arc::new(Schema::new(missing.to_vec()));
+    let schema = output_schema.clone();
+    let mapper = move |batch: &RecordBatch| -> Result<RecordBatch> {
+        let rows = batch.num_rows();
+        let mut names: Vec<Option<String>> = Vec::with_capacity(rows);
+        let mut call_ids: Vec<Option<String>> = Vec::with_capacity(rows);
+        let mut failures: Vec<Option<bool>> = Vec::with_capacity(rows);
+        for row in 0..rows {
+            let type_name = string(batch, "type", row)?.context("part type is null")?;
+            // Only tool parts carry identity; skipping the JSONB decode for
+            // text/reasoning rows keeps the backfill pass cheap.
+            let kind = match type_name.as_str() {
+                "tool_call" | "tool_result" | "tool_approval_request" => {
+                    let body =
+                        json_column(batch, "variant_data", row)?.context("variant_data is null")?;
+                    Some(part_kind_from_json(&type_name, &body, None)?)
+                }
+                _ => None,
+            };
+            let (name, call_id, is_failure) = kind
+                .as_ref()
+                .map(tool_identity)
+                .unwrap_or((None, None, None));
+            names.push(name.map(str::to_owned));
+            call_ids.push(call_id.map(str::to_owned));
+            failures.push(is_failure);
+        }
+        let arrays: Vec<ArrayRef> = schema
+            .fields()
+            .iter()
+            .map(|field| -> ArrayRef {
+                match field.name().as_str() {
+                    "tool_name" => Arc::new(StringArray::from(names.clone())),
+                    "call_id" => Arc::new(StringArray::from(call_ids.clone())),
+                    _ => Arc::new(BooleanArray::from(failures.clone())),
+                }
+            })
+            .collect();
+        RecordBatch::try_new(schema.clone(), arrays).context("failed to build backfill batch")
+    };
+    Ok(ColumnBackfill {
+        read_columns: vec!["type".to_owned(), "variant_data".to_owned()],
+        output_schema,
+        mapper: Box::new(mapper),
+    })
+}
+
 pub(crate) fn part_schema() -> Arc<Schema> {
     Arc::new(Schema::new(vec![
         primary_field("session_id", DataType::Utf8, false),
@@ -4843,6 +5003,13 @@ pub(crate) fn part_schema() -> Arc<Schema> {
         // spec.md#model-part-provenance: conversation vs harness-injected; search
         // reads this column to exclude injected scaffolding.
         Field::new("provenance", DataType::Utf8, false),
+        // Materialized copies of the tool-part identity fields (#89): analytics
+        // must run on narrow native columns - a JSON getter over `variant_data`
+        // reads the whole multi-GB column, which times out on object stores.
+        // NULL for non-tool parts and absent source fields (spec.md#model-no-synthesis).
+        Field::new("tool_name", DataType::Utf8, true),
+        Field::new("call_id", DataType::Utf8, true),
+        Field::new("is_failure", DataType::Boolean, true),
         json_field("variant_data", false),
         legacy_blob_field("data", true),
         json_field("options", false),
@@ -5281,6 +5448,16 @@ fn parts_chunk(
         .collect();
     let blob_array = LargeBinaryArray::from_iter(blob_payloads);
 
+    let mut tool_names: Vec<Option<&str>> = Vec::with_capacity(parts.len());
+    let mut call_ids: Vec<Option<&str>> = Vec::with_capacity(parts.len());
+    let mut failures: Vec<Option<bool>> = Vec::with_capacity(parts.len());
+    for part in parts {
+        let (name, call_id, is_failure) = tool_identity(&part.kind);
+        tool_names.push(name);
+        call_ids.push(call_id);
+        failures.push(is_failure);
+    }
+
     RecordBatch::try_new(
         schema.clone(),
         vec![
@@ -5317,6 +5494,9 @@ fn parts_chunk(
                     .map(|part| part.provenance.as_str())
                     .collect::<Vec<_>>(),
             )),
+            Arc::new(StringArray::from(tool_names)),
+            Arc::new(StringArray::from(call_ids)),
+            Arc::new(BooleanArray::from(failures)),
             Arc::new(LargeBinaryArray::from_iter_values(
                 variant_data.iter().map(Vec::as_slice),
             )),
@@ -5602,6 +5782,12 @@ fn legacy_blob_field(name: &str, nullable: bool) -> Field {
     )
 }
 
+// Deliberately NO `lance-encoding:compression` metadata (#89): lance's
+// miniblock zstd compresses tiny chunks independently and cannot reach the
+// cross-row redundancy where the real ratio lives - measured 0% on real
+// corpora vs 4.8-7.4x full-window, while values > 32 KiB are already
+// compressed per-value by default. Tool analytics avoid the fat column via
+// the materialized tool_name/call_id/is_failure columns instead.
 fn json_field(name: &str, nullable: bool) -> Field {
     lance_arrow::json::json_field(name, nullable)
 }
@@ -5625,6 +5811,40 @@ fn json_bytes<T: Serialize>(value: &T) -> Result<Vec<u8>> {
 
 fn json_parse<T: DeserializeOwned>(value: &[u8]) -> Result<T> {
     serde_json::from_slice(value).context("failed to parse JSON field")
+}
+
+/// The materialized `(tool_name, call_id, is_failure)` cells for one part.
+/// Shared by the ingest write path and the schema-migration backfill (which
+/// reconstructs the `PartKind` via [`part_kind_from_json`]) so both derive
+/// identical cells. The approval request's `tool_call_id` is the same
+/// correlation key the call/result pair carries, surfaced under the one
+/// `call_id` column; absent source fields stay NULL
+/// (spec.md#model-no-synthesis).
+fn tool_identity(kind: &PartKind) -> (Option<&str>, Option<&str>, Option<bool>) {
+    match kind {
+        PartKind::ToolCall { name, call_id, .. } => (
+            name.as_deref().map(String::as_str),
+            call_id.as_deref().map(String::as_str),
+            None,
+        ),
+        PartKind::ToolResult {
+            name,
+            call_id,
+            is_failure,
+            ..
+        } => (
+            name.as_deref().map(String::as_str),
+            call_id.as_deref().map(String::as_str),
+            Some(*is_failure),
+        ),
+        PartKind::ToolApprovalRequest { tool_call_id, .. } => {
+            (None, Some(tool_call_id.as_str()), None)
+        }
+        PartKind::Text { .. }
+        | PartKind::Reasoning { .. }
+        | PartKind::File { .. }
+        | PartKind::ToolApprovalResponse { .. } => (None, None, None),
+    }
 }
 
 fn part_variant_json(kind: &PartKind) -> Result<Vec<u8>> {
@@ -5886,6 +6106,96 @@ mod tests {
             injected.is_none(),
             "a message whose only part is injected has null search_text"
         );
+    }
+
+    #[test]
+    fn parts_chunk_materializes_tool_identity_columns() -> anyhow::Result<()> {
+        let part = |ordinal: i32, kind: PartKind| Part {
+            session_id: "s1".to_owned(),
+            id: format!("p{ordinal}"),
+            message_id: "m1".to_owned(),
+            ordinal,
+            provenance: crate::wire::Provenance::Conversational,
+            options: ProviderOptions::new(),
+            kind,
+        };
+        let parts = vec![
+            part(
+                0,
+                PartKind::ToolCall {
+                    call_id: Some(Extracted::from_test_value("c1".to_owned())),
+                    name: Some(Extracted::from_test_value("Bash".to_owned())),
+                    params: serde_json::json!({}),
+                    provider_executed: false,
+                },
+            ),
+            part(
+                1,
+                PartKind::ToolResult {
+                    call_id: Some(Extracted::from_test_value("c1".to_owned())),
+                    name: Some(Extracted::from_test_value("Bash".to_owned())),
+                    is_failure: true,
+                    result: serde_json::json!({}),
+                },
+            ),
+            // Absent source fields stay NULL - never a synthesized sentinel.
+            part(
+                2,
+                PartKind::ToolCall {
+                    call_id: None,
+                    name: None,
+                    params: serde_json::json!({}),
+                    provider_executed: false,
+                },
+            ),
+            part(
+                3,
+                PartKind::ToolApprovalRequest {
+                    approval_id: "a1".to_owned(),
+                    tool_call_id: "c1".to_owned(),
+                },
+            ),
+            part(
+                4,
+                PartKind::Text {
+                    text: Some(Extracted::from_test_value("hi".to_owned())),
+                },
+            ),
+        ];
+        let payloads = vec![vec![1u8]; parts.len()];
+        let batch = parts_chunk(&parts, &payloads, &payloads)?;
+
+        let tool_name = |row| string(&batch, "tool_name", row).unwrap();
+        let call_id = |row| string(&batch, "call_id", row).unwrap();
+        let is_failure = batch
+            .column_by_name("is_failure")
+            .expect("is_failure column present")
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .expect("is_failure is boolean");
+
+        assert_eq!(tool_name(0).as_deref(), Some("Bash"));
+        assert_eq!(call_id(0).as_deref(), Some("c1"));
+        assert!(is_failure.is_null(0), "tool_call has no failure flag");
+
+        assert_eq!(tool_name(1).as_deref(), Some("Bash"));
+        assert_eq!(call_id(1).as_deref(), Some("c1"));
+        assert!(is_failure.value(1), "tool_result failure flag materialized");
+
+        assert_eq!(tool_name(2), None, "absent name stays NULL");
+        assert_eq!(call_id(2), None, "absent call_id stays NULL");
+
+        assert_eq!(tool_name(3), None);
+        assert_eq!(
+            call_id(3).as_deref(),
+            Some("c1"),
+            "approval request surfaces its tool_call_id as call_id",
+        );
+
+        assert_eq!(tool_name(4), None);
+        assert_eq!(call_id(4), None);
+        assert!(is_failure.is_null(4));
+        Ok(())
     }
 
     #[test]

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -4931,7 +4931,8 @@ pub(crate) fn column_backfill(table_name: &str, missing: &[Field]) -> Result<Col
     match table_name {
         PARTS => parts_backfill(missing),
         other => anyhow::bail!(
-            "table {other} is missing columns {:?} that this pond build cannot derive from stored data",
+            "table {other} is missing columns {:?} that this pond build cannot derive from \
+             stored data - use the pond version that wrote it",
             missing.iter().map(|f| f.name()).collect::<Vec<_>>(),
         ),
     }
@@ -4942,7 +4943,8 @@ fn parts_backfill(missing: &[Field]) -> Result<ColumnBackfill> {
         anyhow::ensure!(
             ["tool_name", "call_id", "is_failure"].contains(&field.name().as_str())
                 && field.is_nullable(),
-            "column {PARTS}.{} cannot be derived from stored data",
+            "column {PARTS}.{} cannot be derived from stored data - use the pond version \
+             that wrote it",
             field.name(),
         );
     }
@@ -4961,7 +4963,23 @@ fn parts_backfill(missing: &[Field]) -> Result<ColumnBackfill> {
                 "tool_call" | "tool_result" | "tool_approval_request" => {
                     let body =
                         json_column(batch, "variant_data", row)?.context("variant_data is null")?;
-                    Some(part_kind_from_json(&type_name, &body, None)?)
+                    // An undecodable body degrades to NULL cells (spec.md#model-no-synthesis:
+                    // a cell the stored record cannot justify stays NULL) rather than failing
+                    // the migration, which re-runs on every open and would leave the store
+                    // permanently un-openable over one bad row.
+                    match part_kind_from_json(&type_name, &body, None) {
+                        Ok(kind) => Some(kind),
+                        Err(error) => {
+                            tracing::warn!(
+                                session_id = string(batch, "session_id", row)?.as_deref(),
+                                part_id = string(batch, "id", row)?.as_deref(),
+                                error = %format!("{error:#}"),
+                                "stored tool part body failed to decode; its backfilled \
+                                 cells stay NULL",
+                            );
+                            None
+                        }
+                    }
                 }
                 _ => None,
             };
@@ -4987,7 +5005,12 @@ fn parts_backfill(missing: &[Field]) -> Result<ColumnBackfill> {
         RecordBatch::try_new(schema.clone(), arrays).context("failed to build backfill batch")
     };
     Ok(ColumnBackfill {
-        read_columns: vec!["type".to_owned(), "variant_data".to_owned()],
+        read_columns: vec![
+            "session_id".to_owned(),
+            "id".to_owned(),
+            "type".to_owned(),
+            "variant_data".to_owned(),
+        ],
         output_schema,
         mapper: Box::new(mapper),
     })
@@ -5813,13 +5836,12 @@ fn json_parse<T: DeserializeOwned>(value: &[u8]) -> Result<T> {
     serde_json::from_slice(value).context("failed to parse JSON field")
 }
 
-/// The materialized `(tool_name, call_id, is_failure)` cells for one part.
-/// Shared by the ingest write path and the schema-migration backfill (which
+/// The materialized `(tool_name, call_id, is_failure)` cells for one part -
+/// shared by the ingest write path and the schema-migration backfill (which
 /// reconstructs the `PartKind` via [`part_kind_from_json`]) so both derive
-/// identical cells. The approval request's `tool_call_id` is the same
-/// correlation key the call/result pair carries, surfaced under the one
-/// `call_id` column; absent source fields stay NULL
-/// (spec.md#model-no-synthesis).
+/// identical cells. The approval request's `tool_call_id` surfaces under the
+/// one `call_id` column (the same correlation key the call/result pair
+/// carries); absent source fields stay NULL (spec.md#model-no-synthesis).
 fn tool_identity(kind: &PartKind) -> (Option<&str>, Option<&str>, Option<bool>) {
     match kind {
         PartKind::ToolCall { name, call_id, .. } => (

--- a/src/snapshots/pond__tests__help_sql.snap
+++ b/src/snapshots/pond__tests__help_sql.snap
@@ -1,6 +1,5 @@
 ---
 source: src/main.rs
-assertion_line: 4791
 expression: sub.render_long_help().to_string()
 ---
 Run one read-only SQL query over the corpus.
@@ -27,6 +26,11 @@ Options:
 
   -o, --output-file <OUTPUT_FILE>
           Write the export bytes here instead of stdout (required for `--format parquet`; optional for ndjson). Ignored for text
+
+      --timeout <TIMEOUT>
+          Per-query timeout in seconds. Default 30, max 600 - raise it for a genuinely long-running query (e.g. a large remote-store scan)
+          
+          [default: 30]
 
   -h, --help
           Print help (see a summary with '-h')

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1040,8 +1040,9 @@ fn enrich(message: &str) -> String {
              project, content [system-role only], search_text [the conversational text], \
              embedding_model, options) | sessions(session_id, parent_session_id, \
              parent_message_id, source_agent, created_at, project, options) | \
-             parts(session_id, message_id, id, ordinal, type, provenance, variant_data, \
-             options). Part bodies (tool params/results, text) live in parts.variant_data - \
+             parts(session_id, message_id, id, ordinal, type, provenance, tool_name, \
+             call_id, is_failure, variant_data, options). Part bodies (tool params/results, \
+             text) live in parts.variant_data - \
              read them with json_extract(variant_data, '$.field'). For text search use \
              contains_tokens(search_text, '...') in WHERE, or the fts('messages', ...) \
              table function in FROM for ranked results; to read a transcript use pond_get. \

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -51,7 +51,19 @@ use parquet::arrow::ArrowWriter;
 const MEM_LIMIT_BYTES: usize = 512 * 1024 * 1024;
 /// Wall-clock cap on `collect()`. DataFusion 53 has no built-in query timeout,
 /// so this `tokio::time::timeout` is the only guard against a runaway plan.
-const QUERY_TIMEOUT: Duration = Duration::from_secs(30);
+/// Callers may raise it per query up to [`MAX_QUERY_TIMEOUT_SECS`].
+pub const DEFAULT_QUERY_TIMEOUT_SECS: u64 = 30;
+/// Ceiling on the caller-supplied timeout: `collect()` is cancellable only by
+/// this timeout, so an absurd value must not pin the server on a runaway scan.
+pub const MAX_QUERY_TIMEOUT_SECS: u64 = 600;
+
+fn effective_timeout(timeout_secs: Option<u64>) -> Duration {
+    Duration::from_secs(
+        timeout_secs
+            .unwrap_or(DEFAULT_QUERY_TIMEOUT_SECS)
+            .clamp(1, MAX_QUERY_TIMEOUT_SECS),
+    )
+}
 /// Byte budget for the inline (rendered table) result; rows are dropped to fit.
 const INLINE_BUDGET_BYTES: usize = 80_000;
 /// Hard ceiling on an export artifact: base64'd over `resources/read` it costs
@@ -151,6 +163,7 @@ pub async fn run(
     sql: &str,
     mode: Mode,
     inline_rows: usize,
+    timeout_secs: Option<u64>,
 ) -> Result<Outcome, SqlError> {
     let parsed = parse_and_gate(sql)?;
     if matches!(parsed.kind, StatementKind::Explain) && matches!(mode, Mode::Export(_)) {
@@ -215,16 +228,21 @@ pub async fn run(
     // planned fix is lance v8's FM-Index on variant_data (raw-byte substring
     // search via `contains(variant_data, 'needle')`); until it lands, the
     // message steers agents to predicates the current indexes can serve.
-    let collected = tokio::time::timeout(QUERY_TIMEOUT, df.collect())
+    let timeout = effective_timeout(timeout_secs);
+    let collected = tokio::time::timeout(timeout, df.collect())
         .await
         .map_err(|_| {
             SqlError::Query(format!(
-                "query exceeded the {}s limit; add a narrower WHERE or a LIMIT. If you were \
+                "query exceeded the {}s limit; add a narrower WHERE or a LIMIT, or raise \
+                 the per-query timeout (`timeout_seconds` on pond_sql_query, `--timeout` \
+                 on pond sql; max {MAX_QUERY_TIMEOUT_SECS}s) if it legitimately needs \
+                 longer. For tool analytics use the narrow native columns (tool_name, \
+                 call_id, is_failure) instead of json_get_* over variant_data. If you were \
                  substring-scanning variant_data (json_extract + LIKE), there is no \
-                 substring index on tool bodies yet: filter parts by type and \
-                 json_get_string(variant_data, 'name') first, or search conversational \
-                 text with contains_tokens(search_text, '...') instead.",
-                QUERY_TIMEOUT.as_secs()
+                 substring index on tool bodies yet: filter parts by type and tool_name \
+                 first, or search conversational text with \
+                 contains_tokens(search_text, '...') instead.",
+                timeout.as_secs()
             ))
         })?
         .map_err(|error| SqlError::Query(enrich(&format!("SQL error: {error}"))))?;
@@ -1517,5 +1535,19 @@ mod tests {
             .filter(|line| line.contains("line one"))
             .collect();
         assert_eq!(row_lines.len(), 1, "one physical line per row: {out}");
+    }
+
+    #[test]
+    fn effective_timeout_defaults_and_clamps() {
+        assert_eq!(
+            effective_timeout(None),
+            Duration::from_secs(DEFAULT_QUERY_TIMEOUT_SECS)
+        );
+        assert_eq!(effective_timeout(Some(60)), Duration::from_secs(60));
+        assert_eq!(effective_timeout(Some(0)), Duration::from_secs(1));
+        assert_eq!(
+            effective_timeout(Some(u64::MAX)),
+            Duration::from_secs(MAX_QUERY_TIMEOUT_SECS)
+        );
     }
 }

--- a/src/substrate.rs
+++ b/src/substrate.rs
@@ -3853,11 +3853,11 @@ async fn open_or_create_via_ns(
                     }
                 }
             }
-            let dataset = builder
+            let mut dataset = builder
                 .load()
                 .await
                 .with_context(|| format!("failed to open table {table_name}"))?;
-            ensure_schema_matches(&dataset, schema.as_ref(), table_name)?;
+            ensure_current_schema(&mut dataset, schema.as_ref(), table_name).await?;
             return Ok(dataset);
         }
         Err(error) => match &error {
@@ -3918,49 +3918,185 @@ fn scanner_with_prefilter(
     }
     Ok(scanner)
 }
-fn ensure_schema_matches(
-    dataset: &Dataset,
+/// How the on-disk schema relates to this build's expected schema.
+enum SchemaFit {
+    Match,
+    /// Expected columns absent on disk, every one nullable: the store
+    /// predates an additive schema change and upgrades in place.
+    MissingNullable(Vec<lance::deps::arrow_schema::Field>),
+    /// On-disk columns this build does not know: written by a newer pond.
+    /// Reads proceed (scans project known columns; extra ones are inert);
+    /// writes against the newer schema fail at the Lance layer, and the fix
+    /// is upgrading pond, not editing the store.
+    UnknownExtra(Vec<String>),
+}
+
+fn classify_schema(
+    actual: &lance::deps::arrow_schema::Schema,
     expected: &lance::deps::arrow_schema::Schema,
     table_name: &str,
-) -> Result<()> {
-    use lance::deps::arrow_schema::DataType;
+) -> Result<SchemaFit> {
     use std::collections::BTreeSet;
-    let actual = lance::deps::arrow_schema::Schema::from(dataset.schema());
     let actual_names: BTreeSet<&str> = actual.fields().iter().map(|f| f.name().as_str()).collect();
     let expected_names: BTreeSet<&str> = expected
         .fields()
         .iter()
         .map(|f| f.name().as_str())
         .collect();
-    if actual_names != expected_names {
-        anyhow::bail!(
+    let missing: Vec<_> = expected
+        .fields()
+        .iter()
+        .filter(|f| !actual_names.contains(f.name().as_str()))
+        .map(|f| f.as_ref().clone())
+        .collect();
+    let extra: Vec<String> = actual_names
+        .difference(&expected_names)
+        .map(|name| (*name).to_owned())
+        .collect();
+    match (missing.is_empty(), extra.is_empty()) {
+        (true, true) => Ok(SchemaFit::Match),
+        (false, true) if missing.iter().all(|f| f.is_nullable()) => {
+            Ok(SchemaFit::MissingNullable(missing))
+        }
+        (true, false) => Ok(SchemaFit::UnknownExtra(extra)),
+        _ => anyhow::bail!(
             "table {table_name} has columns {actual_names:?} but this pond build expects \
-             {expected_names:?} - the on-disk store predates a schema change; delete the \
-             data directory and re-run `pond ingest`",
-        );
+             {expected_names:?}, and the difference is not an additive nullable-column \
+             change this build can migrate - upgrade pond, or restore the store from a \
+             `pond copy` snapshot taken by the version that wrote it",
+        ),
     }
-    // Catch a vector-dim change (configured `[embeddings].dim` differs from
-    // the on-disk vector column width) early with a friendly message. Lance
-    // would otherwise reject the next write with an opaque schema-mismatch
-    // error inside the `merge_update` path.
-    for actual_field in actual.fields() {
-        let Some(expected_field) = expected.field_with_name(actual_field.name()).ok() else {
-            continue;
-        };
-        if let (DataType::FixedSizeList(_, actual_dim), DataType::FixedSizeList(_, expected_dim)) =
-            (actual_field.data_type(), expected_field.data_type())
-            && actual_dim != expected_dim
-        {
-            tracing::warn!(
-                table = table_name,
-                column = actual_field.name(),
-                actual_dim,
-                expected_dim,
-                "embedding dimension differs from config; open proceeds because model swaps are operator-driven",
-            );
+}
+
+/// Open-time schema reconciliation: a store missing this build's known
+/// nullable columns is backfilled IN PLACE via `Dataset::add_columns` - the
+/// values derive from data already stored, so no re-ingest is ever required
+/// (spec.md#session-durable-copy: a rotated source cannot supply rows again).
+/// Concurrent openers race benignly: `add_columns` commits through OCC, a
+/// losing writer sees a conflict, re-checks out latest, and finds the columns
+/// present.
+async fn ensure_current_schema(
+    dataset: &mut Dataset,
+    expected: &lance::deps::arrow_schema::Schema,
+    table_name: &str,
+) -> Result<()> {
+    use lance::deps::arrow_schema::DataType;
+    const MAX_MIGRATION_ATTEMPTS: usize = 3;
+    for _ in 0..MAX_MIGRATION_ATTEMPTS {
+        let actual = lance::deps::arrow_schema::Schema::from(dataset.schema());
+        match classify_schema(&actual, expected, table_name)? {
+            SchemaFit::Match => {
+                // Catch a vector-dim change (configured `[embeddings].dim`
+                // differs from the on-disk vector column width) early with a
+                // friendly message. Lance would otherwise reject the next
+                // write with an opaque schema-mismatch error inside the
+                // `merge_update` path.
+                for actual_field in actual.fields() {
+                    let Some(expected_field) = expected.field_with_name(actual_field.name()).ok()
+                    else {
+                        continue;
+                    };
+                    if let (
+                        DataType::FixedSizeList(_, actual_dim),
+                        DataType::FixedSizeList(_, expected_dim),
+                    ) = (actual_field.data_type(), expected_field.data_type())
+                        && actual_dim != expected_dim
+                    {
+                        tracing::warn!(
+                            table = table_name,
+                            column = actual_field.name(),
+                            actual_dim,
+                            expected_dim,
+                            "embedding dimension differs from config; open proceeds because model swaps are operator-driven",
+                        );
+                    }
+                }
+                return Ok(());
+            }
+            SchemaFit::UnknownExtra(extra) => {
+                tracing::warn!(
+                    table = table_name,
+                    ?extra,
+                    "store carries columns unknown to this pond build (written by a newer \
+                     version); reads proceed, writes need the newer pond",
+                );
+                return Ok(());
+            }
+            SchemaFit::MissingNullable(missing) => {
+                backfill_missing_columns(dataset, table_name, missing).await?;
+            }
         }
     }
-    Ok(())
+    anyhow::bail!(
+        "schema migration for table {table_name} did not converge after \
+         {MAX_MIGRATION_ATTEMPTS} attempts (a concurrent writer kept changing \
+         the schema); re-run once the other pond process finishes",
+    )
+}
+
+/// One in-place additive migration pass: derive the missing columns from
+/// stored data and commit them via `add_columns` (new column files only, no
+/// row rewrites). The recipe - which columns to read and how to derive the
+/// values - is consumer knowledge and lives in `sessions::column_backfill`.
+async fn backfill_missing_columns(
+    dataset: &mut Dataset,
+    table_name: &str,
+    missing: Vec<lance::deps::arrow_schema::Field>,
+) -> Result<()> {
+    use lance::dataset::{BatchUDF, NewColumnTransform};
+    let names: Vec<&str> = missing.iter().map(|f| f.name().as_str()).collect();
+    let spec = sessions::column_backfill(table_name, &missing)?;
+    // A full-column read over a remote store runs minutes; a silent stall
+    // reads as a hang, so this one-time event gets a stderr notice (same
+    // pattern as the embedding-model download notice in embed.rs).
+    let _ = crate::output::line_err(&format!(
+        "migrating {table_name}: backfilling {names:?} from stored data (one-time, in place)...",
+    ));
+    let started = std::time::Instant::now();
+    let mapper = spec.mapper;
+    // Boxed: `add_columns`' concrete future is enormous (it embeds DataFusion
+    // planner types), and inlining it here overflows rustc's auto-trait
+    // solver (E0275) once this future nests inside the open chain.
+    let migration: std::pin::Pin<
+        Box<dyn std::future::Future<Output = lance::Result<()>> + Send + '_>,
+    > = Box::pin(dataset.add_columns(
+        NewColumnTransform::BatchUDF(BatchUDF {
+            mapper: Box::new(move |batch| {
+                mapper(batch).map_err(|error| lance::Error::io(format!("{error:#}")))
+            }),
+            output_schema: spec.output_schema,
+            result_checkpoint: None,
+        }),
+        Some(spec.read_columns),
+        None,
+    ));
+    let result = migration.await;
+    match result {
+        Ok(()) => {
+            let _ = crate::output::line_err(&format!(
+                "migrated {table_name} in {:.1}s",
+                started.elapsed().as_secs_f64(),
+            ));
+            Ok(())
+        }
+        Err(error) => {
+            let error = anyhow::Error::from(error);
+            if is_commit_conflict(&error) {
+                // Another writer migrated (or wrote) concurrently; re-check
+                // out latest and let the caller re-classify.
+                dataset.checkout_latest().await?;
+                Ok(())
+            } else {
+                Err(error).with_context(|| {
+                    format!(
+                        "schema backfill failed for {table_name}; the one-time migration \
+                         writes new column files, so it needs write access to the store - \
+                         re-run any pond command with write-capable credentials to complete it",
+                    )
+                })
+            }
+        }
+    }
 }
 /// Object-store defaults injected for any non-local pond location. Each key
 /// is only set when neither the user-provided key nor its env-var-form alias

--- a/src/substrate.rs
+++ b/src/substrate.rs
@@ -3985,34 +3985,11 @@ async fn ensure_current_schema(
     for _ in 0..MAX_MIGRATION_ATTEMPTS {
         let actual = lance::deps::arrow_schema::Schema::from(dataset.schema());
         match classify_schema(&actual, expected, table_name)? {
-            SchemaFit::Match => {
-                // Catch a vector-dim change (configured `[embeddings].dim`
-                // differs from the on-disk vector column width) early with a
-                // friendly message. Lance would otherwise reject the next
-                // write with an opaque schema-mismatch error inside the
-                // `merge_update` path.
-                for actual_field in actual.fields() {
-                    let Some(expected_field) = expected.field_with_name(actual_field.name()).ok()
-                    else {
-                        continue;
-                    };
-                    if let (
-                        DataType::FixedSizeList(_, actual_dim),
-                        DataType::FixedSizeList(_, expected_dim),
-                    ) = (actual_field.data_type(), expected_field.data_type())
-                        && actual_dim != expected_dim
-                    {
-                        tracing::warn!(
-                            table = table_name,
-                            column = actual_field.name(),
-                            actual_dim,
-                            expected_dim,
-                            "embedding dimension differs from config; open proceeds because model swaps are operator-driven",
-                        );
-                    }
-                }
-                return Ok(());
+            SchemaFit::MissingNullable(missing) => {
+                backfill_missing_columns(dataset, table_name, missing).await?;
+                continue;
             }
+            SchemaFit::Match => {}
             SchemaFit::UnknownExtra(extra) => {
                 tracing::warn!(
                     table = table_name,
@@ -4020,12 +3997,32 @@ async fn ensure_current_schema(
                     "store carries columns unknown to this pond build (written by a newer \
                      version); reads proceed, writes need the newer pond",
                 );
-                return Ok(());
-            }
-            SchemaFit::MissingNullable(missing) => {
-                backfill_missing_columns(dataset, table_name, missing).await?;
             }
         }
+        // Catch a vector-dim change (configured `[embeddings].dim` differs
+        // from the on-disk vector column width) early with a friendly
+        // message. Lance would otherwise reject the next write with an
+        // opaque schema-mismatch error inside the `merge_update` path.
+        for actual_field in actual.fields() {
+            let Some(expected_field) = expected.field_with_name(actual_field.name()).ok() else {
+                continue;
+            };
+            if let (
+                DataType::FixedSizeList(_, actual_dim),
+                DataType::FixedSizeList(_, expected_dim),
+            ) = (actual_field.data_type(), expected_field.data_type())
+                && actual_dim != expected_dim
+            {
+                tracing::warn!(
+                    table = table_name,
+                    column = actual_field.name(),
+                    actual_dim,
+                    expected_dim,
+                    "embedding dimension differs from config; open proceeds because model swaps are operator-driven",
+                );
+            }
+        }
+        return Ok(());
     }
     anyhow::bail!(
         "schema migration for table {table_name} did not converge after \

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -592,6 +592,11 @@ Examples (4 patterns the agent should recognize):
         /// machine-readable JSON output.
         #[serde(default)]
         format: Option<String>,
+        /// Per-query timeout in seconds (default 30, max 600). Raise it for a
+        /// genuinely long-running query (e.g. a large remote-store scan);
+        /// prefer narrower predicates and the indexed/native columns first.
+        #[serde(default)]
+        timeout_seconds: Option<u64>,
     }
 
     fn parse_session_from(value: Option<String>) -> SessionFrom {
@@ -860,7 +865,15 @@ Examples (4 patterns the agent should recognize):
                 }
             };
 
-            match sql::run(&tables, &params.query, mode, inline_rows).await {
+            match sql::run(
+                &tables,
+                &params.query,
+                mode,
+                inline_rows,
+                params.timeout_seconds,
+            )
+            .await
+            {
                 Ok(sql::Outcome::Inline(text)) => Ok(tool_result(text)),
                 Ok(sql::Outcome::Export {
                     bytes,

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -288,11 +288,16 @@ NULL, source_agent text, created_at timestamp(us, UTC), project text, options js
 - parts(session_id text, message_id text, id text, ordinal int, type text \
 {text|reasoning|file|tool_call|tool_result|tool_approval_request|\
 tool_approval_response - exact strings, underscores not hyphens}, provenance \
-text {conversational|injected}, variant_data json, options json). The verbatim \
-part body lives in `variant_data`; its fields follow the part type, e.g. \
-tool_call carries {call_id, name, params}, tool_result carries {call_id, name, \
-is_failure, result}, text/reasoning carry {text}. FilePart binary payloads are \
-not exposed in SQL.
+text {conversational|injected}, tool_name text NULL, call_id text NULL, \
+is_failure boolean NULL, variant_data json, options json). `tool_name` / \
+`call_id` / `is_failure` are narrow native columns materialized from the tool \
+part bodies - ALWAYS prefer them over json_get_* on `variant_data` for tool \
+analytics (name filters, GROUP BY, call->result joins, failure rates); they are \
+NULL on non-tool parts (`is_failure` is non-NULL only on tool_result). The \
+verbatim part body lives in `variant_data`; its fields follow the part type, \
+e.g. tool_call carries {call_id, name, params}, tool_result carries {call_id, \
+name, is_failure, result}, text/reasoning carry {text}. FilePart binary \
+payloads are not exposed in SQL.
 Enum literals matter: a wrong value (e.g. 'tool-call') is valid SQL and silently \
 returns zero rows. Discovery from SQL works too: SELECT table_name, column_name, \
 data_type FROM information_schema.columns.
@@ -302,7 +307,7 @@ messages.session_id AND parts.message_id = messages.message_id. Subagents are \
 sessions whose source_agent matches '%/%' (e.g. 'claude-code/general-purpose').
 
 Indexed (fast) filter columns: messages.session_id / source_agent; \
-parts.session_id / message_id; sessions.session_id. \
+parts.session_id / message_id / tool_name; sessions.session_id. \
 Prefer equality/range predicates on these. Known limitation: prefix LIKE ('x%') and starts_with() FAIL \
 on bitmap-indexed columns (messages.source_agent) with \"LIKE \
 prefix queries are not supported for bitmap indexes\". Workarounds: equality, \
@@ -330,18 +335,16 @@ return NULL on a non-coercible value.
 json_get_string(json_get(variant_data, 'params'), 'command').
 - Also: json_array_contains(col, 'key', value), json_array_length(col, 'key').
 
-Worked example - tool usage and failure rates over the last week:
+Worked example - tool usage and failure rates over the last week, entirely on \
+the narrow native columns (no JSON getters):
 
-  SELECT json_get_string(c.variant_data, 'name') AS tool,
+  SELECT c.tool_name AS tool,
          COUNT(*) AS calls,
-         SUM(CASE WHEN json_get_bool(r.variant_data, 'is_failure') THEN 1 \
-ELSE 0 END) AS failures
+         SUM(CASE WHEN r.is_failure THEN 1 ELSE 0 END) AS failures
   FROM parts c
   JOIN messages m ON m.session_id = c.session_id AND m.message_id = c.message_id
   LEFT JOIN parts r ON r.session_id = c.session_id
-   AND r.type = 'tool_result'
-   AND json_get_string(r.variant_data, 'call_id') = \
-json_get_string(c.variant_data, 'call_id')
+   AND r.type = 'tool_result' AND r.call_id = c.call_id
   WHERE c.type = 'tool_call' AND m.timestamp >= now() - INTERVAL '7 days'
   GROUP BY tool ORDER BY calls DESC;
 
@@ -572,9 +575,12 @@ Examples (4 patterns the agent should recognize):
         /// embedding_model, options) | sessions(session_id,
         /// parent_session_id, parent_message_id, source_agent, created_at,
         /// project, options) | parts(session_id, message_id, id, ordinal,
-        /// type, provenance, variant_data, options). parts.type enums use
-        /// underscores: 'tool_call', 'tool_result', 'text', 'reasoning',
-        /// 'file'. JSON columns (variant_data, options) are JSONB: read
+        /// type, provenance, tool_name, call_id, is_failure, variant_data,
+        /// options). parts.type enums use underscores: 'tool_call',
+        /// 'tool_result', 'text', 'reasoning', 'file'. Tool analytics: use the
+        /// narrow native columns (tool_name, call_id, is_failure), not
+        /// json_get_* over variant_data. JSON columns (variant_data, options)
+        /// are JSONB: read
         /// fields with json_extract(col, '$.a.b') or json_get_string(col,
         /// 'key', ...), never CAST them. Text search: WHERE
         /// contains_tokens(search_text, 'words') to filter, FROM
@@ -793,14 +799,16 @@ Examples (4 patterns the agent should recognize):
                            (column discovery also works: SELECT column_name FROM \
                            information_schema.columns WHERE table_name = 'messages'). \
                            Routing: metadata analytics -> SQL on messages/sessions; tool-call \
-                           analytics -> parts WHERE type = 'tool_call' with \
-                           json_get_string(variant_data, 'name'); text search -> WHERE \
+                           analytics -> parts WHERE type = 'tool_call' on the narrow native \
+                           columns (tool_name, call_id, is_failure); text search -> WHERE \
                            contains_tokens(search_text, 'words') to filter or FROM \
                            fts('messages', '{...json...}') for BM25-ranked results, or \
                            pond_search for semantic recall; reading a transcript -> pond_get, \
                            not SQL. The embedding `vector` column is never returned (explicit \
                            projection is rejected; filtering in WHERE is fine). Control row \
                            count with SQL `LIMIT`; inline text output is capped at 100 rows. \
+                           Queries are wall-clock-capped at 30s by default; set \
+                           timeout_seconds (max 600) for a genuinely long-running query. \
                            format defaults to text (a row-capped rendered table); set \
                            format=parquet|ndjson to write the full result to a file returned as \
                            a pond-sql-export:// resource (ndjson for machine-readable JSON). \

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -28,6 +28,8 @@ mod recovery;
 mod remote_backend;
 #[path = "integration/s3_backend.rs"]
 mod s3_backend;
+#[path = "integration/schema_migration.rs"]
+mod schema_migration;
 #[path = "integration/search.rs"]
 mod search;
 #[path = "integration/session_scoped_pk.rs"]

--- a/tests/integration/schema_migration.rs
+++ b/tests/integration/schema_migration.rs
@@ -26,8 +26,12 @@ fn s(value: &str) -> Option<pond::adapter::Extracted<String>> {
 
 async fn seed_store(dir: &TempDir) -> anyhow::Result<()> {
     let store = Store::open_local(dir.path()).await?;
+    ingest_session(&store, SESSION_ID, "Bash").await
+}
+
+async fn ingest_session(store: &Store, session_id: &str, tool: &str) -> anyhow::Result<()> {
     let session = Session {
-        id: SESSION_ID.to_owned(),
+        id: session_id.to_owned(),
         parent_session_id: None,
         parent_message_id: None,
         source_agent: "claude-code".to_owned(),
@@ -37,12 +41,12 @@ async fn seed_store(dir: &TempDir) -> anyhow::Result<()> {
     };
     let assistant = Message::Assistant {
         id: "m-asst".to_owned(),
-        session_id: SESSION_ID.to_owned(),
+        session_id: session_id.to_owned(),
         timestamp: Utc::now(),
         options: Default::default(),
     };
     let part = |id: &str, ordinal: i32, kind: PartKind| Part {
-        session_id: SESSION_ID.to_owned(),
+        session_id: session_id.to_owned(),
         id: id.to_owned(),
         message_id: "m-asst".to_owned(),
         ordinal,
@@ -65,7 +69,7 @@ async fn seed_store(dir: &TempDir) -> anyhow::Result<()> {
             1,
             PartKind::ToolCall {
                 call_id: s("call-1"),
-                name: s("Bash"),
+                name: s(tool),
                 params: json!({ "command": "false" }),
                 provider_executed: false,
             },
@@ -75,14 +79,14 @@ async fn seed_store(dir: &TempDir) -> anyhow::Result<()> {
             2,
             PartKind::ToolResult {
                 call_id: s("call-1"),
-                name: s("Bash"),
+                name: s(tool),
                 is_failure: true,
                 result: json!("exit 1"),
             },
         )),
     ];
     let envelope = pond_ingest(
-        &store,
+        store,
         IngestRequest {
             protocol_version: PROTOCOL_VERSION,
             namespace: Some("local".to_owned()),
@@ -192,6 +196,26 @@ async fn old_schema_store_backfills_tool_columns_on_open() -> anyhow::Result<()>
         reopened.version().version,
         version_before,
         "a migrated store must not commit again on reopen",
+    );
+
+    // New ingest into the migrated store: `add_columns` appended the tool
+    // columns at the END of the on-disk schema while fresh batches carry them
+    // mid-schema, so this pins that the write path aligns columns by name,
+    // not position.
+    ingest_session(&store, "post-migration-session", "Grep").await?;
+    let text = run_sql(
+        &store,
+        "SELECT tool_name, call_id FROM parts \
+         WHERE session_id = 'post-migration-session' AND type = 'tool_call'",
+    )
+    .await?;
+    assert!(
+        text.contains("Grep"),
+        "post-migration ingest materializes tool_name: {text}",
+    );
+    assert!(
+        text.contains("call-1"),
+        "post-migration ingest materializes call_id: {text}",
     );
     Ok(())
 }

--- a/tests/integration/schema_migration.rs
+++ b/tests/integration/schema_migration.rs
@@ -1,0 +1,241 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+//! In-place additive schema migration: a store written before the
+//! materialized tool columns (#89) upgrades on first open via the
+//! `add_columns` backfill - values derive from stored `variant_data`, no
+//! re-ingest (spec.md#session-durable-copy). The pre-#89 store is simulated
+//! faithfully by dropping the materialized columns with raw Lance.
+
+use chrono::Utc;
+use lance::index::DatasetIndexExt;
+use pond::{
+    PROTOCOL_VERSION,
+    handlers::{IngestEvent, pond_ingest},
+    sessions::Store,
+    substrate::Table,
+    wire::{IngestEnvelope, IngestRequest, Message, Part, PartKind, Provenance, Session},
+};
+use serde_json::json;
+use tempfile::TempDir;
+
+const SESSION_ID: &str = "migration-test-session";
+
+fn s(value: &str) -> Option<pond::adapter::Extracted<String>> {
+    pond::adapter::extract_str(&json!({ "x": value }), "x")
+}
+
+async fn seed_store(dir: &TempDir) -> anyhow::Result<()> {
+    let store = Store::open_local(dir.path()).await?;
+    let session = Session {
+        id: SESSION_ID.to_owned(),
+        parent_session_id: None,
+        parent_message_id: None,
+        source_agent: "claude-code".to_owned(),
+        created_at: Utc::now(),
+        project: pond::adapter::extract_str(&json!({ "p": "/tmp/mig" }), "p").unwrap(),
+        options: Default::default(),
+    };
+    let assistant = Message::Assistant {
+        id: "m-asst".to_owned(),
+        session_id: SESSION_ID.to_owned(),
+        timestamp: Utc::now(),
+        options: Default::default(),
+    };
+    let part = |id: &str, ordinal: i32, kind: PartKind| Part {
+        session_id: SESSION_ID.to_owned(),
+        id: id.to_owned(),
+        message_id: "m-asst".to_owned(),
+        ordinal,
+        provenance: Provenance::Conversational,
+        options: Default::default(),
+        kind,
+    };
+    let events = vec![
+        IngestEvent::Session(session),
+        IngestEvent::Message(assistant),
+        IngestEvent::Part(part(
+            "p-text",
+            0,
+            PartKind::Text {
+                text: s("running a command"),
+            },
+        )),
+        IngestEvent::Part(part(
+            "p-call",
+            1,
+            PartKind::ToolCall {
+                call_id: s("call-1"),
+                name: s("Bash"),
+                params: json!({ "command": "false" }),
+                provider_executed: false,
+            },
+        )),
+        IngestEvent::Part(part(
+            "p-result",
+            2,
+            PartKind::ToolResult {
+                call_id: s("call-1"),
+                name: s("Bash"),
+                is_failure: true,
+                result: json!("exit 1"),
+            },
+        )),
+    ];
+    let envelope = pond_ingest(
+        &store,
+        IngestRequest {
+            protocol_version: PROTOCOL_VERSION,
+            namespace: Some("local".to_owned()),
+            events,
+        },
+    )
+    .await;
+    anyhow::ensure!(
+        matches!(envelope, IngestEnvelope::Success(_)),
+        "seed ingest failed: {envelope:?}",
+    );
+    Ok(())
+}
+
+async fn run_sql(store: &Store, sql: &str) -> anyhow::Result<String> {
+    let tables = pond::sql::Tables {
+        sessions: None,
+        messages: None,
+        parts: Some(store.dataset(Table::Parts).await?),
+    };
+    match pond::sql::run(&tables, sql, pond::sql::Mode::Inline, 100, None).await {
+        Ok(pond::sql::Outcome::Inline(text)) => Ok(text),
+        Ok(pond::sql::Outcome::Export { .. }) => anyhow::bail!("unexpected export outcome"),
+        Err(error) => anyhow::bail!("sql failed: {error:?}"),
+    }
+}
+
+#[tokio::test]
+async fn old_schema_store_backfills_tool_columns_on_open() -> anyhow::Result<()> {
+    let temp = TempDir::new()?;
+    seed_store(&temp).await?;
+
+    // Simulate a pre-#89 store faithfully: drop the materialized columns so
+    // `variant_data` is once again the only carrier of tool identity.
+    let parts_uri = temp.path().join("parts.lance");
+    let mut dataset = lance::dataset::Dataset::open(parts_uri.to_str().unwrap()).await?;
+    dataset
+        .drop_columns(&["tool_name", "call_id", "is_failure"])
+        .await?;
+    let stripped = lance::deps::arrow_schema::Schema::from(dataset.schema());
+    assert!(
+        stripped.field_with_name("tool_name").is_err(),
+        "drop_columns must remove tool_name: {stripped:?}",
+    );
+    drop(dataset);
+
+    // First open of `parts` runs the in-place backfill.
+    let store = Store::open_local(temp.path()).await?;
+    let migrated = store.dataset(Table::Parts).await?;
+    let schema = lance::deps::arrow_schema::Schema::from(migrated.schema());
+    for column in ["tool_name", "call_id", "is_failure"] {
+        assert!(
+            schema.field_with_name(column).is_ok(),
+            "backfill must restore {column}: {schema:?}",
+        );
+    }
+
+    // The backfilled cells match what ingest would have written - derived
+    // from the same PartKind decode.
+    let text = run_sql(
+        &store,
+        "SELECT tool_name, call_id FROM parts WHERE type = 'tool_call'",
+    )
+    .await?;
+    assert!(text.contains("Bash"), "tool_name backfilled: {text}");
+    assert!(text.contains("call-1"), "call_id backfilled: {text}");
+
+    let text = run_sql(
+        &store,
+        "SELECT tool_name, is_failure FROM parts WHERE type = 'tool_result'",
+    )
+    .await?;
+    assert!(text.contains("true"), "is_failure backfilled: {text}");
+
+    let text = run_sql(
+        &store,
+        "SELECT COUNT(*) AS n FROM parts WHERE tool_name IS NULL",
+    )
+    .await?;
+    assert!(
+        text.contains("| 1 |"),
+        "non-tool parts stay NULL (the text part): {text}",
+    );
+
+    // The declared scalar index on the backfilled column builds through the
+    // standard missing-index path on the next optimize.
+    store
+        .optimize_indices(None, &pond::substrate::MaintenancePolicy::always_compact())
+        .await?;
+    let indexed = store.dataset(Table::Parts).await?;
+    let indices = indexed.load_indices().await?;
+    assert!(
+        indices.iter().any(|i| i.name == "parts_tool_name_btree"),
+        "optimize must create the tool_name index on a migrated store: {:?}",
+        indices.iter().map(|i| i.name.clone()).collect::<Vec<_>>(),
+    );
+
+    // Idempotence: a second open classifies as Match and touches nothing.
+    drop(store);
+    let store = Store::open_local(temp.path()).await?;
+    let reopened = store.dataset(Table::Parts).await?;
+    let version_before = reopened.version().version;
+    drop(store);
+    let store = Store::open_local(temp.path()).await?;
+    let reopened = store.dataset(Table::Parts).await?;
+    assert_eq!(
+        reopened.version().version,
+        version_before,
+        "a migrated store must not commit again on reopen",
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn old_schema_archive_restores_with_derived_columns() -> anyhow::Result<()> {
+    let source = TempDir::new()?;
+    seed_store(&source).await?;
+
+    // Export an archive, then strip the materialized columns from the archive
+    // datasets - a faithful stand-in for an archive written by a pre-#89 pond.
+    let archive = TempDir::new()?;
+    {
+        let store = Store::open_local(source.path()).await?;
+        store.export_clean_lance_datasets(archive.path()).await?;
+    }
+    let parts_uri = archive.path().join("parts.lance");
+    let mut dataset = lance::dataset::Dataset::open(parts_uri.to_str().unwrap()).await?;
+    dataset
+        .drop_columns(&["tool_name", "call_id", "is_failure"])
+        .await?;
+    let archive_version = dataset.version().version;
+    drop(dataset);
+
+    // Restore into a fresh store: the import derives the missing cells at the
+    // read boundary - the archive itself is a snapshot and MUST stay untouched.
+    let restored_dir = TempDir::new()?;
+    let store = Store::open_local(restored_dir.path()).await?;
+    let imported = store.import_clean_lance_datasets(archive.path()).await?;
+    assert_eq!(imported.rows.parts, 3, "all archive parts imported");
+
+    let text = run_sql(
+        &store,
+        "SELECT tool_name, call_id FROM parts WHERE type = 'tool_call'",
+    )
+    .await?;
+    assert!(text.contains("Bash"), "tool_name derived on import: {text}");
+    assert!(text.contains("call-1"), "call_id derived on import: {text}");
+
+    let untouched = lance::dataset::Dataset::open(parts_uri.to_str().unwrap()).await?;
+    assert_eq!(
+        untouched.version().version,
+        archive_version,
+        "restore must never write into the archive",
+    );
+    Ok(())
+}

--- a/tests/integration/sql.rs
+++ b/tests/integration/sql.rs
@@ -578,6 +578,31 @@ async fn pond_sql_query_over_mcp() -> anyhow::Result<()> {
         "no raw newline inside a row: {text}"
     );
 
+    // 24. Materialized tool columns (#89): tool analytics run on the narrow
+    // native columns - indexed tool_name filter, call_id join, is_failure
+    // aggregate - with no json_get_* over variant_data anywhere in the plan.
+    let result = call(json!({
+        "sql": "SELECT c.tool_name, COUNT(*) AS calls, \
+                       SUM(CASE WHEN r.is_failure THEN 1 ELSE 0 END) AS failures \
+                FROM parts c \
+                LEFT JOIN parts r ON r.session_id = c.session_id \
+                 AND r.type = 'tool_result' AND r.call_id = c.call_id \
+                WHERE c.type = 'tool_call' AND c.tool_name = 'Bash' \
+                GROUP BY c.tool_name"
+    }))
+    .await?;
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "native tool-column analytics should work: {result:?}"
+    );
+    let text = first_text(&result).expect("inline result");
+    let squashed = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        squashed.contains("| Bash | 1 | 0 |"),
+        "one call joined to its non-failed result: {text}"
+    );
+
     client.cancel().await?;
     let _ = server_handle.await;
     Ok(())


### PR DESCRIPTION
# feat(parts)!: materialize tool columns + in-place schema migration; per-query SQL timeout

Closes #89.

## What

Remote-store tool analytics over `parts.variant_data` (multi-GB uncompressed JSONB) timed out hard: any JSON-touching query pulled the whole column over S3. This PR makes the common analytics shapes never touch the fat column:

- **3 derived storage columns on `parts`**: `tool_name` (Utf8), `call_id` (Utf8), `is_failure` (Boolean) - all nullable, extracted from the already-typed `PartKind` at write time (no-synthesis: absent stays NULL). `variant_data` remains the verbatim source of truth.
- **BTree scalar index on `tool_name`** (BTree, not Bitmap: prefix LIKE errors on bitmap indexes upstream).
- **Flawless in-place migration**: existing stores upgrade on first open - `classify_schema` detects the missing nullable columns and a one-time `add_columns` backfill derives them from stored `variant_data` (~seconds locally, no re-ingest, spec.md#session-durable-copy holds). Pre-#89 `.pond` archives restore via read-boundary derivation; the archive file is never modified. Stores written by a NEWER pond open read-only-compatibly with a warning (unknown extra columns).
- **Spec 5.6** (`session-additive-schema-backfill`): the derived-column class and the migration contract are now spec rules.
- **Per-query SQL timeout**: `timeout_seconds` on `pond_sql_query`, `--timeout` on `pond sql` (default 30s, clamp 1..600). The timeout error names the knob and steers to the native columns.
- SQL schema doc, tool description, and error hints rewritten around the native columns (flagship example no longer uses JSON getters).

## Explored and rejected: zstd on the JSON columns (Lever 1)

Measured 0.0% compression on the real corpus in 3 configs: lance miniblock zstd compresses 4 KiB chunks independently, and real JSON bodies carry cross-ROW redundancy, not within-body (raw same-bytes full-window zstd: 4.8-7.4x). `minichunk=32768` is silently rejected by the v2.1 `>= 32*1024` guard. Values >32 KiB are already auto-compressed by lance v8 per-value. WHY comment lives on `json_field()`; do not re-explore blind. (Miniblock chunk size becomes tunable in lance v9 - re-evaluate then.)

## Numbers (full real corpus)

Remote = `pond-bench-89`, 10,840 sessions / 1.81M messages / ~608K tool_call parts (28% MORE tool calls than the pre-#89 baseline store). Baseline = pond 0.12.2 on the pre-#89 copy.

| Query (remote S3) | Baseline | This PR |
|---|---|---|
| tool GROUP BY (JSON getter) | **TIMEOUT >30s** | 29.3s / TIMEOUT (same store - old form still dies) |
| tool GROUP BY (native `tool_name`) | - | **8.5-9.7s** |
| flagship failure-rate self-join 7d (JSON getters) | **TIMEOUT >30s** | **TIMEOUT** (reproduced) |
| flagship (native columns) | - | **23-24s** (one cold 32s outlier) |
| indexed point filter `tool_name='Bash'` | - | 4.7-8.0s |
| narrow COUNT control | 1.8s | 3.2-4.9s (larger corpus) |

Local: tool GROUP BY 1,693ms -> **48ms** (~35x); flagship 3,138ms -> **220ms** (~14x).

Residual (isolated, pre-existing, NOT this PR's scope): the 7-day scoping alone costs 11.8s - `messages.timestamp` has no index; every scalar index type funnels literals through the shared `safe_coerce_scalar` tz-dropping coercion (#75), so a timestamp index is blocked upstream. Unscoped flagship: 9.9s; sessions-scoped: 18.5s. The new `timeout_seconds` gives callers headroom for such shapes.

## No degradation (regression sweep)

- ingest_bench: profile identical (0.14s wall, same stage split) despite the 3 extra arrays per parts chunk.
- read_bench: within 1-2ms noise at every tail size.
- serve_mem on the new-schema corpus: FTS p50 7ms / vector 24ms / get 34ms / sql 10ms; idle 493.6 MiB and peak 1683 MiB PF - both targets PASS.
- Real-corpus S3 copy with the new schema: 40:28 total (upload ~14 min, index rebuild 26:21, verify 32s), `SYNCED - 2,933,838 rows, 0 duplicates`.
- Scalar-fold A/B on S3 (bonus, lance-8 delta segments): folding scalar indexes every sync costs ~6-10s of S3 round trips per sync (67s outlier) vs 0 deferred - the 50k deferral gate stays correct under v8; its comment rationale (whole-file rewrite) is stale and can be refreshed in a follow-up.

## Validation

- `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean, `cargo test` **272 passed / 0 failed**.
- New integration suite `schema_migration`: in-place backfill (values match ingest-time derivation, non-tool parts stay NULL, second open commits nothing, `tool_name` index builds on the migrated store via standard intents) + archive restore derivation (archive version byte-untouched).
- Migration exercised on a real store shape: seed -> raw-lance `drop_columns` -> reopen -> backfill notice -> correct values.

## Breaking

`feat!`: stores written by this version are unreadable by pond <= 0.12.2 (strict schema equality check in old binaries). Old stores upgrade automatically and silently on first open by a new binary; the only visible artifact is a one-time stderr notice. Production upgrade path: ship binary, first open migrates in place (backfill measured in seconds locally; remote pays one `add_columns` commit).

Do not merge until reviewed.
