### PR TITLE
chore: release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.13.0](https://github.com/tenequm/pond/compare/v0.12.2...v0.13.0) - 2026-07-07
+
+### <!-- 0 -->🛠 Breaking Changes
+- **parts:** [**breaking**] materialize tool columns + in-place schema migration; per-query SQL timeout ([#100](https://github.com/tenequm/pond/pull/100)) ([5490122](https://github.com/tenequm/pond/commit/54901228e3f3389ce9494c5d7bda5f213ee559ab))
+
+### <!-- 5 -->📚 Documentation
+- update README for clarity and structure, add new sections on usage and maintenance ([8298db5](https://github.com/tenequm/pond/commit/8298db572481320b47075eac7ef2aafc54bb0884))
+- launch fold, memory-tool FAQ, OG/meta, vocs 2.3.3, reference-page fixes ([a3a3e65](https://github.com/tenequm/pond/commit/a3a3e654612ac82caca7066afaecba4f1ca6fb16))
+- **readme:** launch fold - hook quote, live search demo, real prompts ([d53226f](https://github.com/tenequm/pond/commit/d53226fe0bf619e601c009e440175f7ec1fa51f9))
+
+**Full Changelog**: https://github.com/tenequm/pond/compare/v0.12.2...v0.13.0
+
 ## [0.12.2](https://github.com/tenequm/pond/compare/v0.12.1...v0.12.2) - 2026-07-07
 
 ### <!-- 1 -->🎉 New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ## [0.13.0](https://github.com/tenequm/pond/compare/v0.12.2...v0.13.0) - 2026-07-07
 
+Tool analytics stop paying the JSON tax: the common query shapes now run on three narrow derived columns instead of the multi-GB `variant_data` blob, turning remote S3 tool GROUP BYs from hard >30s timeouts into ~9s answers (local: 1,693ms -> 48ms, ~35x). Existing stores upgrade themselves in place on first open - no re-ingest, no manual step - but once migrated they are unreadable by older pond binaries, so upgrade every machine that shares a store together.
+
 ### <!-- 0 -->🛠 Breaking Changes
 - **parts:** [**breaking**] materialize tool columns + in-place schema migration; per-query SQL timeout ([#100](https://github.com/tenequm/pond/pull/100)) ([5490122](https://github.com/tenequm/pond/commit/54901228e3f3389ce9494c5d7bda5f213ee559ab))
+  - **What breaks:** the `parts` table gains three derived nullable columns - `tool_name`, `call_id`, `is_failure` - plus a BTree scalar index on `tool_name`. pond <= 0.12.2 enforces strict schema equality, so a store first opened by 0.13.0 becomes **unreadable by older binaries**, and there is no downgrade path once migrated. `variant_data` stays the verbatim source of truth; the new columns are derived from it at write time.
+  - **What upgrading requires:** nothing manual. The first open by a 0.13.0 binary migrates the store in place: a one-time backfill derives the three columns from stored `variant_data` (seconds on a local store; one `add_columns` commit on a remote/S3 store), announced by a single stderr notice. If multiple machines sync into one shared store, upgrade all of them before the first 0.13.0 open - any host still on <= 0.12.2 loses access the moment the store migrates.
+  - Pre-0.13.0 `.pond` archives keep restoring unchanged: the columns are derived at the read boundary and the archive file is never modified.
+  - Also in this change: a per-query SQL timeout - `timeout_seconds` on `pond_sql_query`, `--timeout` on `pond sql` (default 30s, clamp 1..600); the timeout error names the knob and steers toward the native columns.
+  - Measured on the full real corpus (10,840 sessions / 1.81M messages / ~608K tool-call parts) over S3: tool GROUP BY timeout -> 8.5-9.7s, failure-rate self-join timeout -> 23-24s, indexed `tool_name = 'Bash'` point filter 4.7-8.0s. Ingest and read benchmarks unchanged within noise.
 
 ### <!-- 5 -->📚 Documentation
 - update README for clarity and structure, add new sections on usage and maintenance ([8298db5](https://github.com/tenequm/pond/commit/8298db572481320b47075eac7ef2aafc54bb0884))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6639,7 +6639,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pond-db"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 # crate). The library and binary stay `pond` via [lib]/[[bin]] below, so the
 # command and `use pond::...` are unchanged - only `cargo install pond-db` differs.
 name = "pond-db"
-version = "0.12.2"
+version = "0.13.0"
 edition = "2024"
 # MSRV pinned to the toolchain we build and test with (rust-toolchain.toml).
 rust-version = "1.95"


### PR DESCRIPTION
## 🤖 New release

* `pond-db`: 0.12.2 -> 0.13.0

<details open><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.13.0](https://github.com/tenequm/pond/compare/v0.12.2...v0.13.0) - 2026-07-07

Tool analytics stop paying the JSON tax: the common query shapes now run on three narrow derived columns instead of the multi-GB `variant_data` blob, turning remote S3 tool GROUP BYs from hard >30s timeouts into ~9s answers (local: 1,693ms -> 48ms, ~35x). Existing stores upgrade themselves in place on first open - no re-ingest, no manual step - but once migrated they are unreadable by older pond binaries, so upgrade every machine that shares a store together.

### <!-- 0 -->🛠 Breaking Changes
- **parts:** [**breaking**] materialize tool columns + in-place schema migration; per-query SQL timeout ([#100](https://github.com/tenequm/pond/pull/100)) ([5490122](https://github.com/tenequm/pond/commit/54901228e3f3389ce9494c5d7bda5f213ee559ab))
  - **What breaks:** the `parts` table gains three derived nullable columns - `tool_name`, `call_id`, `is_failure` - plus a BTree scalar index on `tool_name`. pond <= 0.12.2 enforces strict schema equality, so a store first opened by 0.13.0 becomes **unreadable by older binaries**, and there is no downgrade path once migrated. `variant_data` stays the verbatim source of truth; the new columns are derived from it at write time.
  - **What upgrading requires:** nothing manual. The first open by a 0.13.0 binary migrates the store in place: a one-time backfill derives the three columns from stored `variant_data` (seconds on a local store; one `add_columns` commit on a remote/S3 store), announced by a single stderr notice. If multiple machines sync into one shared store, upgrade all of them before the first 0.13.0 open - any host still on <= 0.12.2 loses access the moment the store migrates.
  - Pre-0.13.0 `.pond` archives keep restoring unchanged: the columns are derived at the read boundary and the archive file is never modified.
  - Also in this change: a per-query SQL timeout - `timeout_seconds` on `pond_sql_query`, `--timeout` on `pond sql` (default 30s, clamp 1..600); the timeout error names the knob and steers toward the native columns.
  - Measured on the full real corpus (10,840 sessions / 1.81M messages / ~608K tool-call parts) over S3: tool GROUP BY timeout -> 8.5-9.7s, failure-rate self-join timeout -> 23-24s, indexed `tool_name = 'Bash'` point filter 4.7-8.0s. Ingest and read benchmarks unchanged within noise.

### <!-- 5 -->📚 Documentation
- update README for clarity and structure, add new sections on usage and maintenance ([8298db5](https://github.com/tenequm/pond/commit/8298db572481320b47075eac7ef2aafc54bb0884))
- launch fold, memory-tool FAQ, OG/meta, vocs 2.3.3, reference-page fixes ([a3a3e65](https://github.com/tenequm/pond/commit/a3a3e654612ac82caca7066afaecba4f1ca6fb16))
- **readme:** launch fold - hook quote, live search demo, real prompts ([d53226f](https://github.com/tenequm/pond/commit/d53226fe0bf619e601c009e440175f7ec1fa51f9))

**Full Changelog**: https://github.com/tenequm/pond/compare/v0.12.2...v0.13.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).
