### PR TITLE
chore: release v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## [0.13.1](https://github.com/tenequm/pond/compare/v0.13.0...v0.13.1) - 2026-07-13
 
+Fixes `cargo install pond-db`, broken for every release since v0.10.0: `pond skill` embeds SKILL.md via `include_str!`, but the file was excluded from the published crate, so the .crate on crates.io could not compile. Installs via brew, nix, and cargo-binstall were unaffected (they ship prebuilt binaries). CI now gates packaging so this class of breakage cannot recur.
+
 ### <!-- 2 -->🐛 Bug Fixes
-- ship SKILL.md in the published crate so cargo install compiles ([#105](https://github.com/tenequm/pond/pull/105)) ([4c2213e](https://github.com/tenequm/pond/commit/4c2213e0ab7489c740d56084059cd9acc5ae1bfd))
+- ship SKILL.md in the published crate so cargo install compiles ([#105](https://github.com/tenequm/pond/pull/105)) ([4c2213e](https://github.com/tenequm/pond/commit/4c2213e0ab7489c740d56084059cd9acc5ae1bfd)) - drops SKILL.md from `Cargo.toml`'s exclude list and adds a `check-package` CI gate: `cargo package --list` must contain every `include_str!`/`include_bytes!` target, since publishing skips the verify build (`publish_no_verify`)
 
 ### <!-- 5 -->📚 Documentation
 - **site:** lead the demo with the pond status scene ([ba67eca](https://github.com/tenequm/pond/commit/ba67ecabd34f488141fca18cfd694ed6c76d78e8))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.13.1](https://github.com/tenequm/pond/compare/v0.13.0...v0.13.1) - 2026-07-13
+
+### <!-- 2 -->🐛 Bug Fixes
+- ship SKILL.md in the published crate so cargo install compiles ([#105](https://github.com/tenequm/pond/pull/105)) ([4c2213e](https://github.com/tenequm/pond/commit/4c2213e0ab7489c740d56084059cd9acc5ae1bfd))
+
+### <!-- 5 -->📚 Documentation
+- **site:** lead the demo with the pond status scene ([ba67eca](https://github.com/tenequm/pond/commit/ba67ecabd34f488141fca18cfd694ed6c76d78e8))
+
+### <!-- 6 -->🧹 Chores
+- **bench:** add fmindex_probe substring-index comparison harness ([a9c38cf](https://github.com/tenequm/pond/commit/a9c38cf3cdb140b2f33bac2dbd6aa3f2c2db945f))
+
+**Full Changelog**: https://github.com/tenequm/pond/compare/v0.13.0...v0.13.1
+
 ## [0.13.0](https://github.com/tenequm/pond/compare/v0.12.2...v0.13.0) - 2026-07-07
 
 Tool analytics stop paying the JSON tax: the common query shapes now run on three narrow derived columns instead of the multi-GB `variant_data` blob, turning remote S3 tool GROUP BYs from hard >30s timeouts into ~9s answers (local: 1,693ms -> 48ms, ~35x). Existing stores upgrade themselves in place on first open - no re-ingest, no manual step - but once migrated they are unreadable by older pond binaries, so upgrade every machine that shares a store together.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6639,7 +6639,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pond-db"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 # crate). The library and binary stay `pond` via [lib]/[[bin]] below, so the
 # command and `use pond::...` are unchanged - only `cargo install pond-db` differs.
 name = "pond-db"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 # MSRV pinned to the toolchain we build and test with (rust-toolchain.toml).
 rust-version = "1.95"


### PR DESCRIPTION



## 🤖 New release

* `pond-db`: 0.13.0 -> 0.13.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.13.1](https://github.com/tenequm/pond/compare/v0.13.0...v0.13.1) - 2026-07-13

### <!-- 2 -->🐛 Bug Fixes
- ship SKILL.md in the published crate so cargo install compiles ([#105](https://github.com/tenequm/pond/pull/105)) ([4c2213e](https://github.com/tenequm/pond/commit/4c2213e0ab7489c740d56084059cd9acc5ae1bfd))

### <!-- 5 -->📚 Documentation
- **site:** lead the demo with the pond status scene ([ba67eca](https://github.com/tenequm/pond/commit/ba67ecabd34f488141fca18cfd694ed6c76d78e8))

### <!-- 6 -->🧹 Chores
- **bench:** add fmindex_probe substring-index comparison harness ([a9c38cf](https://github.com/tenequm/pond/commit/a9c38cf3cdb140b2f33bac2dbd6aa3f2c2db945f))

**Full Changelog**: https://github.com/tenequm/pond/compare/v0.13.0...v0.13.1
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).