### PR TITLE
fix: ship SKILL.md in the published crate so cargo install compiles

### DIFF
--- a/.github/release-plz.toml
+++ b/.github/release-plz.toml
@@ -2,8 +2,8 @@
 publish = true
 # Skip the `cargo publish` verify build: build-and-test already compiled this
 # exact code on the self-hosted runner (with protoc + kache), and a cold lance
-# build on ubuntu-latest risks the publish timeout. Packaging is verified
-# locally via `cargo publish --dry-run` before release.
+# build on ubuntu-latest risks the publish timeout. Packaging contents are
+# gated in CI by pond:check-package (cargo package --list vs include_str!).
 publish_no_verify = true
 # Release whenever main has an unpublished version bump (the release-plz
 # default). The release PR still drives version/changelog; this just also covers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: ./.github/actions/bootstrap
       # One moon session: independent tasks interleave (cargo serializes the
       # heavy ones on its target-dir lock; format/changelog are instant).
-      - run: moon run pond:check-changelog pond:format pond:lint pond:test
+      - run: moon run pond:check-changelog pond:check-package pond:format pond:lint pond:test
 
   # Maintain the release PR, and report ONLY whether a release is pending.
   # Detection is the tag check - release-plz's own first gate is "skip a package

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ categories = ["command-line-utilities", "database", "artificial-intelligence"]
 # Publish only what `cargo install` compiles. The repo's bulk is dev-only:
 # tests/fixtures (~10 MiB) lives under tests/.
 # benches/ stays - the [[bench]] targets declare paths cargo resolves on build.
+# SKILL.md must ship: `pond skill` embeds it via include_str! (excluding it
+# broke `cargo install` for v0.10.0-v0.13.0; check-package guards this in CI).
 exclude = [
     "tests/",
     "docs/",
@@ -27,7 +29,6 @@ exclude = [
     "moon.yml",
     "AGENTS.md",
     "CLAUDE.md",
-    "SKILL.md",
     "flake.nix",
     "nix/",
     "**/.DS_Store",

--- a/moon.yml
+++ b/moon.yml
@@ -26,6 +26,12 @@ tasks:
     command: 'bash ops/scripts/check-changelog-headers.sh'
     toolchains: 'system'
     inputs: ['CHANGELOG.md', 'ops/scripts/check-changelog-headers.sh']
+  # Cheap packaging gate: `cargo package --list` must contain every file the
+  # code embeds via include_str!/include_bytes! (a full verify build is skipped
+  # at publish time - publish_no_verify in .github/release-plz.toml).
+  check-package:
+    command: 'bash ops/scripts/check-package-contents.sh'
+    inputs: ['@group(sources)', 'SKILL.md', 'ops/scripts/check-package-contents.sh']
 
   # Machine cross-compile on the pond-ci runner (no docker/buildkit): needs the
   # pond-runner image toolchain (zig 0.16 + cargo-zigbuild + macOS SDK via

--- a/ops/scripts/check-package-contents.sh
+++ b/ops/scripts/check-package-contents.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Every file the crate pulls in via include_str!/include_bytes! must survive
+# Cargo.toml's [package].exclude, or the published crate fails to compile on
+# `cargo install` (v0.10.0-v0.13.0 shipped broken: SKILL.md was excluded).
+set -euo pipefail
+
+packaged=$(cargo package --list --allow-dirty)
+
+bad=0
+while IFS= read -r hit; do
+  src=${hit%%:*}
+  path=$(printf '%s' "$hit" | sed -E 's/.*!\("([^"]+)"\).*/\1/')
+  resolved=$(python3 -c 'import os,sys; print(os.path.normpath(os.path.join(os.path.dirname(sys.argv[1]), sys.argv[2])))' "$src" "$path")
+  if ! grep -qxF "$resolved" <<< "$packaged"; then
+    echo "check-package: $src embeds '$path' but '$resolved' is not in the packaged crate - remove it from Cargo.toml [package].exclude" >&2
+    bad=1
+  fi
+done < <(grep -rnoE --include='*.rs' 'include_(str|bytes)!\("[^"]+"\)' src)
+
+exit "$bad"


### PR DESCRIPTION
## Problem

`cargo install pond-db` fails for every release since v0.10.0 (reported by Fabian):

```
error: couldn't read `.../pond-db-0.13.0/src/../SKILL.md`: No such file or directory
```

- v0.10.0 (dc2f3b56) added `pond skill`, which does `include_str!("../SKILL.md")` in `src/main.rs`.
- `SKILL.md` sits in `Cargo.toml`'s `exclude` (added as a dev-only file alongside `AGENTS.md`/`CLAUDE.md`), so the published `.crate` physically lacks the file the build needs. Verified against unpacked crates from crates.io: 0.9.0 is fine; 0.10.0 through 0.13.0 are all broken.
- Nothing caught it because `publish_no_verify = true` skips the verify build at publish time, and brew/nix/binstall install prebuilt binaries so the compile path never runs.

## Fix

- Remove `SKILL.md` from `exclude` (33-line file, negligible crate-size impact), with a comment explaining why it must ship.
- Add a cheap CI packaging gate (`pond:check-package`, wired into the build-and-test moon run): `cargo package --list` must contain every `include_str!`/`include_bytes!` target found in `src/`. No verify build needed; it is instant and catches exactly this class of breakage. Verified it fails against the pre-fix `Cargo.toml` and passes now.
- Update the stale `release-plz.toml` comment ("verified locally via cargo publish --dry-run") to point at the CI gate.

## Release note

This must land on `main` before release PR #103 (v0.13.1) merges, otherwise 0.13.1 ships equally broken for cargo installs.

fmt, clippy, and full `cargo test` pass locally (272 tests).