### PR TITLE
docs(site): per-page meta descriptions + richer homepage title for discoverability

### DIFF
--- a/docs/site/src/pages/get-started/connect-your-agents.mdx
+++ b/docs/site/src/pages/get-started/connect-your-agents.mdx
@@ -1,3 +1,7 @@
+---
+description: Register pond as an MCP server for Claude Code, Codex, OpenCode, and other clients, exposing pond_search, pond_get, and pond_sql_query over your full cross-client session history.
+---
+
 # Connect your agents
 
 pond is an MCP server. `pond init` registers it for detected clients. To add it by hand:

--- a/docs/site/src/pages/get-started/install.mdx
+++ b/docs/site/src/pages/get-started/install.mdx
@@ -1,3 +1,7 @@
+---
+description: Install pond on macOS and Linux via Homebrew (tenequm/tap/pond), Nix, or Cargo (the pond-db crate). One Rust binary, no external services.
+---
+
 # Install
 
 macOS and Linux. Windows is out of v1 scope.

--- a/docs/site/src/pages/get-started/quickstart.mdx
+++ b/docs/site/src/pages/get-started/quickstart.mdx
@@ -1,3 +1,7 @@
+---
+description: Get started with pond - pond init sets up storage, adapters, and MCP registration; pond sync ingests and embeds your Claude Code, Codex, and OpenCode sessions; then ask any agent about your past work.
+---
+
 # Quickstart
 
 Set up, ingest, ask.

--- a/docs/site/src/pages/guides/backup-and-restore.mdx
+++ b/docs/site/src/pages/guides/backup-and-restore.mdx
@@ -1,3 +1,7 @@
+---
+description: Back up and restore pond with .pond archives - compact, index-free Lance snapshots with embeddings preserved. pond copy snapshots and restores; restore is an idempotent deduped merge.
+---
+
 # Backup & restore
 
 A `.pond` archive is a compact, restorable snapshot: clean index-free Lance datasets plus a manifest, embeddings preserved.

--- a/docs/site/src/pages/guides/import-claude-ai.mdx
+++ b/docs/site/src/pages/guides/import-claude-ai.mdx
@@ -1,3 +1,7 @@
+---
+description: Import Claude.ai conversations into pond from the official data export with pond sync claude-ai-export --path. Accepts the .zip, an extracted directory, or conversations.json; idempotent.
+---
+
 # Import a Claude.ai export
 
 Claude.ai conversations have no local session files, so they arrive via the official data export instead of `pond sync`'s auto-discovery:

--- a/docs/site/src/pages/guides/remote-storage.mdx
+++ b/docs/site/src/pages/guides/remote-storage.mdx
@@ -1,3 +1,7 @@
+---
+description: Point pond at S3-compatible object storage - Hetzner, Cloudflare R2, Backblaze B2, MinIO, or AWS - via add-credentials, probe, copy, switch. Your local data stays as a backup.
+---
+
 # Remote storage
 
 pond stores data locally by default (`$XDG_DATA_HOME/pond`). To use an S3-compatible bucket (Hetzner, R2, B2, MinIO, AWS): add credentials, probe, copy, switch. Your local data is never modified - it stays as a backup.

--- a/docs/site/src/pages/guides/several-machines.mdx
+++ b/docs/site/src/pages/guides/several-machines.mdx
@@ -1,3 +1,7 @@
+---
+description: Share one pond store across several machines by pointing each config.toml at the same bucket. Lance optimistic concurrency makes concurrent syncs safe; pond status --hosts shows per-machine activity.
+---
+
 # Several machines, one bucket
 
 Point each machine's `config.toml` (or `POND_*` env) at the same URL and credentials, and run `pond sync` on each.

--- a/docs/site/src/pages/index.mdx
+++ b/docs/site/src/pages/index.mdx
@@ -1,7 +1,8 @@
 ---
 layout: blank
 showTopNav: true
-title: pond
+title: pond - lossless storage and search for AI agent sessions
+description: Pond ingests every AI agent session - Claude Code, Codex, OpenCode, Claude Desktop, Pi - losslessly into storage you own, then makes the whole corpus searchable and SQL-queryable over MCP. One Rust binary, Lance-backed, local by default.
 ---
 
 import { HomePage } from 'vocs'

--- a/docs/site/src/pages/reference/cli.mdx
+++ b/docs/site/src/pages/reference/cli.mdx
@@ -1,3 +1,7 @@
+---
+description: pond CLI reference - init, sync, search, serve, get, copy, sql, storage, creds, and schedule commands for ingesting, embedding, searching, and moving your AI agent session archive.
+---
+
 # CLI commands
 
 ```sh

--- a/docs/site/src/pages/reference/configuration.mdx
+++ b/docs/site/src/pages/reference/configuration.mdx
@@ -1,3 +1,7 @@
+---
+description: Configure pond via config.toml with POND_* environment overrides - storage backend, credentials, adapters, embeddings, and sync schedule, resolved with flag > env > config precedence.
+---
+
 # Configuration & environment
 
 Config lives in `config.toml`; every field has a `POND_*` env override. Precedence: flag > env > config > ambient cloud SDK chain > default. `pond config show` prints resolved values with secrets redacted and per-field source.

--- a/docs/site/src/pages/reference/exit-codes.mdx
+++ b/docs/site/src/pages/reference/exit-codes.mdx
@@ -1,3 +1,7 @@
+---
+description: pond exit codes for scripting and CI - branch on codes (0 success, 2 SQL/URL errors, 3-6 storage and copy failures) instead of parsing output text.
+---
+
 # Exit codes
 
 Branch on exit codes, not output text.

--- a/docs/site/src/pages/reference/mcp-tools.mdx
+++ b/docs/site/src/pages/reference/mcp-tools.mdx
@@ -1,3 +1,7 @@
+---
+description: pond's MCP tools - pond_search (vector or full-text search over agent sessions), pond_get (a full session or message by id), and pond_sql_query (read-only SQL over sessions, messages, and parts).
+---
+
 # MCP tools
 
 What your agent gets when pond is registered as an MCP server ([Connect your agents](/get-started/connect-your-agents)). The wire schemas ship with the server; this page is the human-facing summary.


### PR DESCRIPTION
## Why

`glim_web_search` (Exa) doesn't surface `tenequm/pond` for product queries - 0-star mirrors of the repo rank above it. Root cause is upstream at Exa: it ranks on **semantic similarity of captured page text**, not stars/backlinks, and our own canonical surfaces gave it weak, undifferentiated signal.

Two clean, **entirely invisible** metadata fixes (no visible page change - verified the description text lands only in `<meta description/og/twitter>`, never a rendered text node):

## Changes

- **`index.mdx`** - richer `<title>` (`pond - lossless storage and search for AI agent sessions`) + a landing `description`. The one-word `<title>pond</title>` was weak against semantic queries.
- **11 sub-pages** - each gets a unique, concept-dense `description`. Previously every page fell back to the same generic config description, so they all advertised the identical thing to the crawler. Now each page carries its own topic + real search terms (MCP tools, remote storage, install matrix, exit codes, etc.).

No body/visual content was added to any page. `sitemap.xml` + `robots.txt` already ship, so crawl discovery was never the gap.

## Verification

- `pnpm build` passes (37 pages generated).
- Descriptions present in `<head>` only; zero visible text nodes.