### PR TITLE
docs: add direct founder contact links (Telegram, X) to site and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Issues and pull requests are welcome. The most useful contributions right now:
 
 For larger changes, open an issue first to discuss the direction. For security issues, see [SECURITY.md](.github/SECURITY.md).
 
-Questions or feedback? DM me on [Telegram](https://t.me/tenequm) or [X](https://x.com/opwizardx) - I answer personally.
+Questions or feedback? Start a [GitHub Discussion](https://github.com/tenequm/pond/discussions), or DM me on [Telegram](https://t.me/tenequm) or [X](https://x.com/opwizardx) - I answer personally.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ Issues and pull requests are welcome. The most useful contributions right now:
 
 For larger changes, open an issue first to discuss the direction. For security issues, see [SECURITY.md](.github/SECURITY.md).
 
+Questions or feedback? DM me on [Telegram](https://t.me/tenequm) or [X](https://x.com/opwizardx) - I answer personally.
+
 ## License
 
 [Apache-2.0](LICENSE) (c) 2026 tenequm

--- a/docs/site/src/pages/index.mdx
+++ b/docs/site/src/pages/index.mdx
@@ -61,6 +61,6 @@ pond sync   # ingest, embed, index
   </div>
 
   <p style={{ fontSize: '0.875rem', opacity: 0.55, margin: 0 }}>
-    Questions or feedback? DM me on <a href="https://t.me/tenequm">Telegram</a> or <a href="https://x.com/opwizardx">X</a> - I answer personally.
+    Questions or feedback? Start a <a href="https://github.com/tenequm/pond/discussions">GitHub Discussion</a>, or DM me on <a href="https://t.me/tenequm">Telegram</a> or <a href="https://x.com/opwizardx">X</a> - I answer personally.
   </p>
 </HomePage.Root>

--- a/docs/site/src/pages/index.mdx
+++ b/docs/site/src/pages/index.mdx
@@ -59,4 +59,8 @@ pond sync   # ingest, embed, index
       style={{ borderRadius: '12px', border: '1px solid rgba(128, 128, 128, 0.25)' }}
     />
   </div>
+
+  <p style={{ fontSize: '0.875rem', opacity: 0.55, margin: 0 }}>
+    Questions or feedback? DM me on <a href="https://t.me/tenequm">Telegram</a> or <a href="https://x.com/opwizardx">X</a> - I answer personally.
+  </p>
 </HomePage.Root>

--- a/docs/site/vocs.config.ts
+++ b/docs/site/vocs.config.ts
@@ -54,7 +54,11 @@ export default defineConfig({
     pattern: 'https://github.com/tenequm/pond/edit/main/docs/site/src/pages/:path',
     text: 'Suggest changes to this page',
   },
-  socials: [{ icon: 'github', link: 'https://github.com/tenequm/pond' }],
+  socials: [
+    { icon: 'github', link: 'https://github.com/tenequm/pond' },
+    { icon: 'telegram', link: 'https://t.me/tenequm' },
+    { icon: 'x', link: 'https://x.com/opwizardx' },
+  ],
   topNav: [
     { text: 'Quickstart', link: '/get-started/quickstart' },
     { text: 'Reference', link: '/reference/cli' },


### PR DESCRIPTION
Adds a direct line to the founder everywhere users land, as the pre-community contact surface.

- **vocs.config.ts**: Telegram and X added to `socials` - icons render in the top nav on every docs page (vocs supports both natively).
- **Landing page (index.mdx)**: closing line under the demo video - "Questions or feedback? DM me on Telegram or X - I answer personally."
- **README**: same line at the end of Contributing, next to the issues guidance.

Verified: `pnpm build` passes, links render on the homepage and inner pages.