### PR TITLE
chore: release v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.14.1](https://github.com/tenequm/pond/compare/v0.14.0...v0.14.1) - 2026-07-23
+
+### <!-- 2 -->🐛 Bug Fixes
+- **openclaw:** ingest stable file-era session stores cleanly and lower plugin floor to 2026.5.18 ([74ff3ad](https://github.com/tenequm/pond/commit/74ff3ad0bc31975ccb505757f5b3fb157bf103b7))
+
+### <!-- 5 -->📚 Documentation
+- add direct founder contact links (Telegram, X) to site and README ([#115](https://github.com/tenequm/pond/pull/115)) ([0e68339](https://github.com/tenequm/pond/commit/0e68339cef8bb6f9744b815defb6da4ac6881260))
+
+**Full Changelog**: https://github.com/tenequm/pond/compare/v0.14.0...v0.14.1
+
 ## [0.14.0](https://github.com/tenequm/pond/compare/v0.13.2...v0.14.0) - 2026-07-23
 
 Routes the MCP tool surface by intent, adds first-class OpenClaw ingestion, and makes local Lance stores crash-consistent (fsync on write + self-heal on open).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6674,7 +6674,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pond-db"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/packages/pond/Cargo.toml
+++ b/packages/pond/Cargo.toml
@@ -3,7 +3,7 @@
 # crate). The library and binary stay `pond` via [lib]/[[bin]] below, so the
 # command and `use pond::...` are unchanged - only `cargo install pond-db` differs.
 name = "pond-db"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 # MSRV pinned to the toolchain we build and test with (rust-toolchain.toml).
 rust-version = "1.95"


### PR DESCRIPTION



## 🤖 New release

* `pond-db`: 0.14.0 -> 0.14.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.1](https://github.com/tenequm/pond/compare/v0.14.0...v0.14.1) - 2026-07-23

### <!-- 2 -->🐛 Bug Fixes
- **openclaw:** ingest stable file-era session stores cleanly and lower plugin floor to 2026.5.18 ([74ff3ad](https://github.com/tenequm/pond/commit/74ff3ad0bc31975ccb505757f5b3fb157bf103b7))

### <!-- 5 -->📚 Documentation
- add direct founder contact links (Telegram, X) to site and README ([#115](https://github.com/tenequm/pond/pull/115)) ([0e68339](https://github.com/tenequm/pond/commit/0e68339cef8bb6f9744b815defb6da4ac6881260))

**Full Changelog**: https://github.com/tenequm/pond/compare/v0.14.0...v0.14.1
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).