### PR TITLE
fix(openclaw): ingest stable file-era session stores cleanly and lower plugin floor to 2026.5.18

### DIFF
--- a/packages/openclaw-pond/README.md
+++ b/packages/openclaw-pond/README.md
@@ -27,6 +27,19 @@ response is size-bounded (32 KB cap, then truncated with a note), so recall
 never floods the agent's context - no memory slot means nothing is injected
 into prompts the agent didn't ask for.
 
+## Supported OpenClaw versions
+
+The floor is OpenClaw **2026.5.18** (the first release carrying every plugin-SDK
+surface this plugin uses). Both session-store layouts ingest transparently:
+
+- On stable hosts (<= 2026.7.1) pond reads the file-based session store -
+  `sessions.json` plus per-session `<sessionId>.jsonl` transcripts (and their
+  archives).
+- On 2026.7.2+ pond reads the SQLite session store in openclaw-agent.sqlite.
+
+A session present in both forms is deduplicated by id, with the SQLite entry
+superseding the same-id file.
+
 ## Install
 
 ```bash

--- a/packages/openclaw-pond/package.json
+++ b/packages/openclaw-pond/package.json
@@ -24,7 +24,7 @@
     "typebox": "^1.3.3"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.5.18"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -41,7 +41,7 @@
       "./index.ts"
     ],
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.5.18"
     }
   }
 }

--- a/packages/pond/src/adapter/openclaw.rs
+++ b/packages/pond/src/adapter/openclaw.rs
@@ -1,19 +1,25 @@
 //! openclaw adapter (github.com/steipete/openclaw).
 //!
-//! OpenClaw keeps one WAL SQLite database per agent at
-//! `<root>/agents/<agentId>/agent/openclaw-agent.sqlite` (the Gateway process
-//! is the sole writer) plus a per-agent `<root>/agents/<agentId>/sessions/`
-//! directory holding archive files (`<sessionId>.jsonl.<reason>.<ts>[.zst]`,
-//! reason in {reset, bak, deleted}) and pre-SQLite legacy transcripts
-//! (`sessions.json` + `<sessionId>.jsonl`). `root` defaults to `~/.openclaw`,
-//! honors `$OPENCLAW_STATE_DIR`, and falls back to the legacy `~/.clawdbot`.
+//! Session storage moved into SQLite in openclaw 2026.7.2: the per-agent WAL
+//! database at `<root>/agents/<agentId>/agent/openclaw-agent.sqlite` (the
+//! Gateway process is the sole writer) grows `sessions` / `session_entries` /
+//! `transcript_events` tables holding the live transcript. Every stable release
+//! through 2026.7.1 stores sessions as files instead, under a per-agent
+//! `<root>/agents/<agentId>/sessions/` directory: `sessions.json` (the
+//! `sessionId` -> `sessionKey` map), live `<sessionId>.jsonl` transcripts, and
+//! archives (`<sessionId>.jsonl.<reason>.<ts>[.zst]`, reason in
+//! {reset, bak, deleted}). On 2026.6.5-2026.7.1 hosts openclaw-agent.sqlite
+//! already exists but carries only auth/agent state (no `sessions` table), so
+//! the DB is skipped and the file store is the sole session source. `root`
+//! defaults to `~/.openclaw`, honors `$OPENCLAW_STATE_DIR`, and falls back to
+//! the legacy `~/.clawdbot`.
 //!
 //! The transcript is a pi-coding-agent `FileEntry` stream: a `session` header
 //! then `message` / `custom_message` / `compaction` / `branch_summary` /
 //! `model_change` / `thinking_level_change` / `custom` / `label` /
 //! `session_info` entries, each with `id`/`parentId`/`timestamp`. pond already
-//! parses this family in `pi_coding_agent.rs`; OpenClaw's stream is richer and
-//! lives in SQLite, so the shapes are shared by precedent, not code.
+//! parses this family in `pi_coding_agent.rs`; OpenClaw's stream is richer, so
+//! the shapes are shared by precedent, not code.
 //!
 //! Tree-to-linear is A3 (locked plan decision 1): one pond session per OpenClaw
 //! session, ALL entries flattened in source order, `parentId` preserved in each
@@ -364,7 +370,17 @@ fn enumerate_and_peek(adapter: &OpenClawAdapter, peek: bool) -> Enumerated {
             match open_db(db_path)
                 .and_then(|conn| list_db_sessions(&conn, db_path).map(|rows| (conn, rows)))
             {
-                Ok((conn, rows)) => {
+                Ok((_, DbSessions::NoSessionsTable)) => {
+                    // Stable pre-2026.7.2 host: openclaw-agent.sqlite exists but
+                    // carries only auth/agent state, so the file store below is
+                    // the session source. Not an error - it is the production
+                    // path for every stable release through 2026.7.1.
+                    tracing::debug!(
+                        path = %db_path.display(),
+                        "openclaw: openclaw-agent.sqlite has no sessions table; using file sessions",
+                    );
+                }
+                Ok((conn, DbSessions::Present(rows))) => {
                     for (session_id, session_key) in rows {
                         if adapter.is_skipped(&session_key) {
                             continue;
@@ -652,10 +668,33 @@ fn join_error(join: tokio::task::JoinError) -> AdapterError {
     sqlite::join_error(NAME, join)
 }
 
-fn list_db_sessions(
-    conn: &Connection,
-    db_path: &Path,
-) -> Result<Vec<(String, String)>, AdapterError> {
+/// Outcome of enumerating a DB's `sessions` table: the routing rows, or the
+/// distinct "no such table" case a stable pre-2026.7.2 host presents (its
+/// openclaw-agent.sqlite holds only auth/agent state). The caller skips the
+/// latter silently rather than surfacing a spurious enumeration error.
+enum DbSessions {
+    Present(Vec<(String, String)>),
+    NoSessionsTable,
+}
+
+/// Detect the `sessions` table via `sqlite_master` before preparing the SELECT,
+/// so its absence is a clean control-flow signal (not a swallowed prepare error).
+fn has_sessions_table(conn: &Connection) -> rusqlite::Result<bool> {
+    conn.query_row(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'sessions' LIMIT 1",
+        [],
+        |_| Ok(()),
+    )
+    .optional()
+    .map(|row| row.is_some())
+}
+
+fn list_db_sessions(conn: &Connection, db_path: &Path) -> Result<DbSessions, AdapterError> {
+    if !has_sessions_table(conn)
+        .map_err(|error| db_error(db_path, "probe sessions table", &error))?
+    {
+        return Ok(DbSessions::NoSessionsTable);
+    }
     let mut stmt = conn
         .prepare("SELECT session_id, session_key FROM sessions ORDER BY session_id")
         .map_err(|error| db_error(db_path, "prepare session list", &error))?;
@@ -665,6 +704,7 @@ fn list_db_sessions(
         })
         .map_err(|error| db_error(db_path, "query session list", &error))?;
     rows.collect::<rusqlite::Result<Vec<_>>>()
+        .map(DbSessions::Present)
         .map_err(|error| db_error(db_path, "read session row", &error))
 }
 
@@ -2057,6 +2097,59 @@ mod tests {
             resolve_root(home, Some(&override_dir)),
             Some(override_dir.clone())
         );
+        Ok(())
+    }
+
+    #[test]
+    fn session_less_db_skips_silently_and_file_sessions_survive() -> anyhow::Result<()> {
+        let root = TempDir::new()?;
+        let agent_dir = root.path().join(AGENTS_SUBDIR).join("bot");
+
+        // Stable pre-2026.7.2 openclaw-agent.sqlite: auth/state tables only, no
+        // `sessions` table.
+        let db_path = agent_dir.join("agent").join("openclaw-agent.sqlite");
+        std::fs::create_dir_all(db_path.parent().unwrap())?;
+        let conn = Connection::open(&db_path)?;
+        conn.execute_batch(
+            "CREATE TABLE auth_profile_store (store_key TEXT PRIMARY KEY, store_json TEXT);",
+        )?;
+        drop(conn);
+
+        // File-era session store: a sessions.json map plus a live bare transcript.
+        let sessions_dir = agent_dir.join(SESSIONS_SUBDIR);
+        std::fs::create_dir_all(&sessions_dir)?;
+        std::fs::write(
+            sessions_dir.join("sessions.json"),
+            json!({ "agent:bot:main": { "sessionId": "sess-file" } }).to_string(),
+        )?;
+        std::fs::write(
+            sessions_dir.join("sess-file.jsonl"),
+            "{\"type\":\"session\",\"id\":\"sess-file\"}\n",
+        )?;
+
+        let adapter = OpenClawAdapter::new(root.path());
+        let Enumerated {
+            entries,
+            superseded,
+            errors,
+        } = enumerate_and_peek(&adapter, false);
+        assert!(
+            errors.is_empty(),
+            "a session-less DB is skipped without pushing an enumeration error",
+        );
+        assert_eq!(superseded, 0);
+        assert_eq!(entries.len(), 1, "the file session is enumerated");
+        match &entries[0].source {
+            SessionSource::File {
+                session_id,
+                session_key,
+                ..
+            } => {
+                assert_eq!(session_id, "sess-file");
+                assert_eq!(session_key, "agent:bot:main");
+            }
+            SessionSource::Db { .. } => panic!("expected a file session, not a DB session"),
+        }
         Ok(())
     }
 

--- a/packages/pond/tests/integration/adapter/openclaw.rs
+++ b/packages/pond/tests/integration/adapter/openclaw.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 
 use pond::{
     adapter::{AdapterFactory, OpenClawAdapter, OpenClawFactory, RestoreFidelity},
-    handlers::ingest_adapter,
+    handlers::{SyncEvent, SyncStatus, ingest_adapter},
     sessions::{SessionWithMessages, Store},
     wire::{Message, PartKind, Provenance},
 };
@@ -572,6 +572,86 @@ async fn zstd_reset_archive_ingests_as_ordinary_history() -> anyhow::Result<()> 
         session.messages.iter().any(|m| m.message.id() == "m-l1"),
         "reset archive is ordinary retained history",
     );
+    Ok(())
+}
+
+// -- Case (i) stable file-era store (openclaw <= 2026.7.1) --------------------
+
+// The layout every stable OpenClaw host has: sessions live as files
+// (sessions.json + a live bare `<sessionId>.jsonl`), while openclaw-agent.sqlite
+// exists (since 2026.6.5) but holds only auth/agent state - no `sessions` table.
+// The DB must be skipped silently and ingest must run clean off the file store.
+#[tokio::test(flavor = "multi_thread")]
+async fn stable_file_era_store_ingests_with_no_adapter_errors() -> anyhow::Result<()> {
+    let root = TempDir::new()?;
+    let agent_dir = root.path().join("agents").join("bot");
+
+    // Session-less openclaw-agent.sqlite: auth/agent-state tables only.
+    let db = db_path(root.path(), "bot");
+    std::fs::create_dir_all(db.parent().unwrap())?;
+    let conn = Connection::open(&db)?;
+    conn.execute_batch(
+        "CREATE TABLE auth_profile_store (store_key TEXT PRIMARY KEY, store_json TEXT);\n\
+         CREATE TABLE auth_profile_state (state_key TEXT PRIMARY KEY, state_json TEXT);",
+    )?;
+    drop(conn);
+
+    // File store: sessions.json map + a LIVE bare transcript (not an archive).
+    let sessions_dir = agent_dir.join("sessions");
+    std::fs::create_dir_all(&sessions_dir)?;
+    std::fs::write(
+        sessions_dir.join("sessions.json"),
+        json!({ "agent:bot:main": { "sessionId": "sess-live" } }).to_string(),
+    )?;
+    let lines = [
+        header("sess-live", "/work/repo", None),
+        user_msg("m-u", None, 1, "what is the plan?"),
+        assistant_msg("m-a", Some("m-u"), 2, "here is the plan"),
+    ];
+    let jsonl: String = lines.iter().map(|l| format!("{l}\n")).collect();
+    std::fs::write(sessions_dir.join("sess-live.jsonl"), jsonl)?;
+
+    // Capture every per-session outcome so a spurious DB error would show up as
+    // a Skipped status.
+    let store_dir = TempDir::new()?;
+    let store = Store::open_local(store_dir.path()).await?;
+    let adapter = OpenClawAdapter::new(root.path());
+    let mut skipped: Vec<String> = Vec::new();
+    let summary = ingest_adapter(&store, &adapter, &pond::adapter::NoopOracle, |event| {
+        if let SyncEvent::SessionDone(outcome) = event
+            && let SyncStatus::Skipped { reason } = outcome.status
+        {
+            skipped.push(reason);
+        }
+    })
+    .await?;
+    assert!(
+        skipped.is_empty(),
+        "the session-less DB is skipped silently, never surfaced as an error: {skipped:?}",
+    );
+    assert_eq!(summary.skipped_files, 0, "nothing reported unreadable");
+
+    let session = store
+        .get_session("sess-live")
+        .await?
+        .expect("live file-era session ingests");
+    assert_eq!(*session.session.project, "agent:bot:main");
+    assert_eq!(session.session.source_agent, "openclaw");
+
+    let text_of = |id: &str| {
+        parts_of(&session, id).iter().find_map(|p| match &p.kind {
+            PartKind::Text { text } => text.as_deref().cloned(),
+            _ => None,
+        })
+    };
+    assert_eq!(text_of("m-u").as_deref(), Some("what is the plan?"));
+    assert_eq!(text_of("m-a").as_deref(), Some("here is the plan"));
+    let user = session
+        .messages
+        .iter()
+        .find(|m| m.message.id() == "m-u")
+        .expect("user message present");
+    assert!(matches!(user.message, Message::User { .. }));
     Ok(())
 }
 


### PR DESCRIPTION
## Problem

Every OpenClaw stable release through 2026.7.1 stores sessions as files (`agents/<id>/sessions/sessions.json` + `<sessionId>.jsonl` + archives). Sessions-in-SQLite (`sessions` / `session_entries` tables) exists only in 2026.7.2-beta.3+. Verified against published npm tarballs (2026.5.18 through 2026.7.2-beta.3): `saveSessionStore` writes a plain JSON file in every stable dist; no `sessions` CREATE TABLE exists anywhere in stable bytes. PR #91322 (metadata -> sqlite) appears in the 2026.6.5 release record but did not ship in stable.

Two consequences pond got wrong:

1. **Spurious error on every stable 2026.6.5+ host.** Since 2026.6.5, `agents/<id>/agent/openclaw-agent.sqlite` exists but holds only auth/agent state - no `sessions` table. pond's `SELECT ... FROM sessions` failed with "no such table: sessions", producing a warn + AdapterError on every sync (ingest still succeeded via the file path, so the error was pure noise).
2. **Plugin floor blocked all stable users.** `openclaw-pond` declared `>=2026.7.2`, which the host install gate rejects for every stable release. Reachable userbase: ~0.3% of weekly npm downloads (beta only).

## Changes

- **Silent skip for session-less DBs** (`adapter/openclaw.rs`): `list_db_sessions` now probes `sqlite_master` for the `sessions` table first and returns a `DbSessions::NoSessionsTable` marker; `enumerate_and_peek` logs it at debug and moves on. Genuine DB failures (corrupt DB, I/O, malformed schema) still warn + surface as AdapterError - the probe's error path propagates, and a present-but-wrong-shape table still fails at prepare.
- **Module doc header** reframed to the verified timeline: files are the storage for all stable releases through 2026.7.1 (not a "pre-SQLite legacy"); SQLite sessions are 2026.7.2+; the 2026.6.5-2026.7.1 auth-only DB window is skipped.
- **Tests**: unit test `session_less_db_skips_silently_and_file_sessions_survive` (auth-only sqlite + file sessions -> zero errors, file session enumerated); integration case (i) `stable_file_era_store_ingests_with_no_adapter_errors` (sessions.json + bare live `.jsonl` + session-less sqlite -> full ingest, zero Skipped, texts intact).
- **Plugin floor** (`openclaw-pond`): `peerDependencies.openclaw` and `openclaw.compat.pluginApi` lowered `>=2026.7.2` -> `>=2026.5.18` (the hard floor: `redactToolPayloadText` is first exported from `plugin-sdk/logging-core` in 2026.5.18; every SDK surface the plugin uses is shape-identical 2026.5.18 -> 2026.7.1-2). Reachable userbase goes from ~0.3% to ~81.4% of weekly downloads (2026.6.10 alone is 41.5%). README gains a "Supported OpenClaw versions" section.

## Verification

- `cargo fmt --check`, `cargo clippy -- -D warnings`: clean
- `cargo test`: 231 lib + 32 bin + 64 integration passed, 0 failed (both new tests green)
- `openclaw-pond`: `npm run typecheck` clean, `npm test` 47/47 passed
- **Real-corpus smoke**: synced a copy of a real pre-2026.6.5 file-era `~/.openclaw` (host "bl") into an isolated store - 3 sessions / 4,841 messages ingested with zero adapter errors; bare `.jsonl` live transcripts resolved their session keys via `sessions.json` (`agent:main:main`, a telegram channel key, and a subagent correctly stored as `openclaw/subagent`)
