### PR TITLE
chore: release v0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.14.2](https://github.com/tenequm/pond/compare/v0.14.1...v0.14.2) - 2026-07-24
+
+### <!-- 1 -->🎉 New Features
+- nanoclaw + hermes adapters and hermes-pond recall plugin ([#121](https://github.com/tenequm/pond/pull/121)) ([1ed0189](https://github.com/tenequm/pond/commit/1ed01895514d8257f9bd34774b4cd73c151b5dc9))
+
+**Full Changelog**: https://github.com/tenequm/pond/compare/v0.14.1...v0.14.2
+
 ## [0.14.1](https://github.com/tenequm/pond/compare/v0.14.0...v0.14.1) - 2026-07-23
 
 ### <!-- 2 -->🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6674,7 +6674,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pond-db"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/packages/pond/Cargo.toml
+++ b/packages/pond/Cargo.toml
@@ -3,7 +3,7 @@
 # crate). The library and binary stay `pond` via [lib]/[[bin]] below, so the
 # command and `use pond::...` are unchanged - only `cargo install pond-db` differs.
 name = "pond-db"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2024"
 # MSRV pinned to the toolchain we build and test with (rust-toolchain.toml).
 rust-version = "1.95"


### PR DESCRIPTION



## 🤖 New release

* `pond-db`: 0.14.1 -> 0.14.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.2](https://github.com/tenequm/pond/compare/v0.14.1...v0.14.2) - 2026-07-24

### <!-- 1 -->🎉 New Features
- nanoclaw + hermes adapters and hermes-pond recall plugin ([#121](https://github.com/tenequm/pond/pull/121)) ([1ed0189](https://github.com/tenequm/pond/commit/1ed01895514d8257f9bd34774b4cd73c151b5dc9))

**Full Changelog**: https://github.com/tenequm/pond/compare/v0.14.1...v0.14.2
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).