### PR TITLE
fix(substrate): prevent byte-capped compaction loops

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -185,6 +185,10 @@ An unenforced primary key on the primary-key columns, so merge-insert defaults t
 
 All of a consumer's datasets share one Lance cache and one object-store client. Why: one pool, rather than one per table, avoids multiplying connections and credential refreshes on object-store backends.
 
+#### `lance-compaction-filter`
+
+Automatic compaction runs only Lance-planned tasks that pass pond's filter. Tasks above the deletion-materialization threshold always run - reclaiming tombstones is useful even when layout does not improve. Any other task must strictly reduce the fragment count, and when its total bytes exceed one output file's byte budget, every input fragment's observed row width must let an output reach the row target within half that budget (headroom because re-encoding can widen rows relative to the input estimate). Missing file sizes fail closed and skip the optional rewrite. Why: Lance selects candidates by row count while the re-encoding writer splits output by bytes, so a task whose rows are too wide for the target emits outputs that are immediately re-selected - an unbounded rewrite loop (measured: a ~1 GB table rewrote ~30 GB across 31 syncs with zero net progress). A task whose whole volume fits one output cannot strand sub-target outputs, so the width test applies only beyond that point.
+
 ### 3.5 Concurrency
 
 pond processes are stateless workers. Several may write the same namespace at once; Lance optimistic concurrency control resolves append conflicts through manifest versioning. There is no external coordinator - object stores provide atomic conditional writes, the local filesystem uses Lance's commit lock - and no in-process write queue.
@@ -215,8 +219,6 @@ Writes commit data without folding indexes; index maintenance is operator-trigge
 | IVF_SQ (vector) | `optimize_indices(append)` | Stable-row-id IVF supports incremental fold via `IvfIndexBuilder::new_incremental`; centroids and per-dimension SQ ranges carry forward. |
 
 Index maintenance skips indexes whose columns no write has touched; this is sound because Lance prunes index coverage only for indexes whose fields overlap a write's modified fields. Why operator-triggered: matching Lance's own design (`table.optimize()` is the canonical periodic-maintenance op) avoids per-write index rebuilds that would otherwise dominate write cost.
-
-The default compaction filter also requires a planned non-deletion task's row target to fit within half the configured output byte budget at every input fragment's observed live-row width. The headroom covers the re-encoding writer's soft byte limit and binary-copy compaction's whole-file granularity. Missing file sizes skip the optional rewrite. Deletion materialization remains eligible because removing tombstoned rows is useful even when fragment layout does not improve.
 
 ### 3.8 Forward-compatibility seams
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -216,6 +216,8 @@ Writes commit data without folding indexes; index maintenance is operator-trigge
 
 Index maintenance skips indexes whose columns no write has touched; this is sound because Lance prunes index coverage only for indexes whose fields overlap a write's modified fields. Why operator-triggered: matching Lance's own design (`table.optimize()` is the canonical periodic-maintenance op) avoids per-write index rebuilds that would otherwise dominate write cost.
 
+The default compaction filter also requires a planned non-deletion task's row target to fit within half the configured output byte budget at every input fragment's observed live-row width. The headroom covers the re-encoding writer's soft byte limit and binary-copy compaction's whole-file granularity. Missing file sizes skip the optional rewrite. Deletion materialization remains eligible because removing tombstoned rows is useful even when fragment layout does not improve.
+
 ### 3.8 Forward-compatibility seams
 
 #### `lance-forward-compat`

--- a/packages/pond/src/config.rs
+++ b/packages/pond/src/config.rs
@@ -237,9 +237,9 @@ pub const DEFAULT_CONFIG_TOML: &str = "\
 # `pond sync` and `pond optimize`.
 #
 # - `compaction_fragment_cap` is the per-task fragment-count backstop: a
-#   planned compaction task touching at least this many fragments always runs
-#   even when the write-amplification veto would skip it. Default 64; 0
-#   disables the veto and runs every task Lance plans.
+#   planned compaction task touching at least this many fragments bypasses the
+#   write-amplification veto once its row target is attainable. Default 64; 0
+#   disables task filtering and runs every task Lance plans.
 # - `cleanup_older_than` is the manifest-retention window for the safe cleanup
 #   pass. Accepts `Ns` / `Nm` / `Nh` / `Nd` (default `1d`, floor `1h` - it is
 #   what protects in-flight readers). Versions older than this are reclaimed
@@ -418,10 +418,8 @@ pub struct SearchConfig {
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct MaintenanceConfig {
-    /// Sub-target fragment count past which the compaction phase runs (it also
-    /// runs once those fragments hold a whole target fragment's worth of rows).
-    /// Default 64 stops the automated sync re-compacting the trailing fragment
-    /// every pass; 0 compacts every pass.
+    /// Per-task fragment-count backstop for the write-amplification veto.
+    /// Default 64; 0 disables all task filtering.
     #[serde(default)]
     pub compaction_fragment_cap: Option<usize>,
     /// Manifest-retention window for the safe cleanup pass. Accepts

--- a/packages/pond/src/substrate.rs
+++ b/packages/pond/src/substrate.rs
@@ -5231,15 +5231,6 @@ mod tests {
         // Remainder reaches largest / COMPACTION_ABSORB_FACTOR -> kept.
         let tiered = [stat(400_000), stat(60_000), stat(40_000)];
         assert!(task_is_kept(&tiered, derived_target_rows(&tiered)));
-
-        let off_boundary = [
-            fragment(99_900_000, 100_000, 0),
-            fragment(100_100_000, 100_000, 0),
-        ];
-        assert!(task_is_kept(
-            &off_boundary,
-            derived_target_rows(&off_boundary),
-        ));
     }
 
     #[test]
@@ -5279,7 +5270,24 @@ mod tests {
     fn compaction_veto_uses_physical_rows_after_deletions() {
         let partially_deleted = || fragment(100_000_000, 100_000, 9_000);
         let task: Vec<FragmentStat> = std::iter::repeat_with(partially_deleted).take(3).collect();
-        assert!(task_is_kept(&task, 134_217));
+        assert!(task_is_kept(&task, derived_target_rows(&task)));
+    }
+
+    #[test]
+    fn compaction_filter_keeps_above_budget_off_boundary_task() {
+        let table = [
+            fragment(100_000_000, 150_000, 0),
+            fragment(100_000_000, 150_000, 0),
+            fragment(100_000_000, 150_000, 0),
+            fragment(100_000_000, 50_000, 0),
+        ];
+        let task = &table[..3];
+        let target = derived_target_rows(&table);
+        let total_bytes = task.iter().map(|stat| stat.bytes.unwrap()).sum::<u64>();
+
+        assert!(total_bytes > TARGET_FRAGMENT_BYTES);
+        assert!(target < derived_target_rows(task));
+        assert!(task_is_kept(task, target));
     }
 
     #[test]

--- a/packages/pond/src/substrate.rs
+++ b/packages/pond/src/substrate.rs
@@ -833,9 +833,9 @@ fn classify_check_error(
     }
 }
 
-/// Per-task fragment-count backstop: tasks this wide always run, bounding
-/// manifest growth even when the amplification veto would skip them. As
-/// policy cap, 0 disables the veto (tests).
+/// Per-task fragment-count backstop: tasks this wide bypass the amplification
+/// veto once their row target is attainable, bounding manifest growth. As
+/// policy cap, 0 disables all task filtering (tests).
 pub const DEFAULT_COMPACTION_FRAGMENT_CAP: usize = 64;
 
 /// Fragments are sized by bytes, not Lance's 1M-row default: kilobyte-average
@@ -843,7 +843,6 @@ pub const DEFAULT_COMPACTION_FRAGMENT_CAP: usize = 64;
 /// re-rewrites wholesale to absorb tiny appends (~190 GiB/day of churn).
 pub const TARGET_FRAGMENT_BYTES: u64 = 256 * 1024 * 1024;
 
-const MIN_TARGET_ROWS_PER_FRAGMENT: u64 = 50_000;
 /// Ceiling = Lance's own default.
 const MAX_TARGET_ROWS_PER_FRAGMENT: u64 = 1024 * 1024;
 
@@ -1003,16 +1002,16 @@ fn fragment_stat(fragment: &lance::table::format::Fragment) -> FragmentStat {
     }
 }
 
-/// Candidacy/merge target: HALF the rows a [`TARGET_FRAGMENT_BYTES`] fragment
-/// holds at the table's average row size. Compaction byte-caps every output
-/// fragment at [`TARGET_FRAGMENT_BYTES`] (`max_bytes_per_file`), so deriving the
-/// target at the FULL byte budget made `target == the largest fragment
-/// compaction can produce`: no output could ever satisfy `physical_rows >=
-/// target`, so the table was re-compacted every sync for a net-zero fragment
-/// change (measured ~100-120s/sync on the remote store, 30->30 fragments).
+/// Candidacy/merge target: HALF the rows the [`TARGET_FRAGMENT_BYTES`] output
+/// budget holds at the table's average row size. Deriving the target at the
+/// FULL byte budget made `target == the largest fragment re-encoding could
+/// reliably produce`: no output could ever satisfy `physical_rows >= target`,
+/// so the table was re-compacted every sync for a net-zero fragment change
+/// (measured ~100-120s/sync on the remote store, 30->30 fragments).
 /// Halving leaves 2x headroom so a byte-capped fragment lands comfortably above
 /// the target and FREEZES, making compaction productive (merge small -> freeze
-/// -> stop) instead of perpetual churn.
+/// -> stop) instead of perpetual churn. A row floor would make the target
+/// unreachable again for sufficiently wide rows.
 fn derived_target_rows(stats: &[FragmentStat]) -> usize {
     let (mut bytes, mut rows) = (0u64, 0u64);
     for stat in stats {
@@ -1026,32 +1025,55 @@ fn derived_target_rows(stats: &[FragmentStat]) -> usize {
     if bytes == 0 || rows == 0 {
         return MAX_TARGET_ROWS_PER_FRAGMENT as usize;
     }
-    let avg_row_bytes = (bytes / rows).max(1);
-    (TARGET_FRAGMENT_BYTES / 2 / avg_row_bytes)
-        .clamp(MIN_TARGET_ROWS_PER_FRAGMENT, MAX_TARGET_ROWS_PER_FRAGMENT) as usize
+    ((u128::from(TARGET_FRAGMENT_BYTES / 2) * u128::from(rows) / u128::from(bytes))
+        .clamp(1, u128::from(MAX_TARGET_ROWS_PER_FRAGMENT))) as usize
 }
 
-/// Amplification veto: skip tasks that mostly rewrite one big fragment to
-/// absorb fresh appends. Deletion-materialization tasks always pass (vetoing
-/// them would leave tombstones unreclaimed forever); compared in bytes when
-/// every file size is known, rows otherwise.
-fn keep_task(stats: &[FragmentStat], cap: usize, deletion_threshold: f32) -> bool {
+/// Skip tasks when any input fragment's live-row width cannot fit the row target
+/// within half the configured output byte budget, then apply the amplification
+/// veto. The headroom absorbs soft-cap row groups and whole-file binary copies.
+/// Deletion materialization always passes because its useful result is removing
+/// tombstoned rows.
+fn keep_task(
+    stats: &[FragmentStat],
+    cap: usize,
+    deletion_threshold: f32,
+    target_rows_per_fragment: usize,
+    max_bytes_per_file: u64,
+) -> bool {
     if stats.iter().any(|stat| {
         stat.rows > 0 && (stat.deleted_rows as f32 / stat.rows as f32) > deletion_threshold
     }) {
         return true;
     }
+    let mut total_bytes = 0u128;
+    for stat in stats {
+        let Some(bytes) = stat.bytes.map(u128::from) else {
+            return false;
+        };
+        let live_rows = u128::from(stat.rows.saturating_sub(stat.deleted_rows));
+        if bytes == 0
+            || live_rows == 0
+            || bytes * target_rows_per_fragment as u128 * 2
+                > live_rows * u128::from(max_bytes_per_file)
+        {
+            return false;
+        }
+        total_bytes += bytes;
+    }
+    if total_bytes == 0 {
+        return false;
+    }
     if stats.len() >= cap {
         return true;
     }
-    let weights: Vec<u64> = if stats.iter().all(|stat| stat.bytes.is_some()) {
-        stats.iter().filter_map(|stat| stat.bytes).collect()
-    } else {
-        stats.iter().map(|stat| stat.rows).collect()
-    };
-    let total: u64 = weights.iter().sum();
-    let largest = weights.iter().copied().max().unwrap_or(0);
-    (total - largest) * COMPACTION_ABSORB_FACTOR >= largest
+    let largest = stats
+        .iter()
+        .filter_map(|stat| stat.bytes)
+        .map(u128::from)
+        .max()
+        .unwrap_or(0);
+    (total_bytes - largest) * u128::from(COMPACTION_ABSORB_FACTOR) >= largest
 }
 
 /// Declarative description of one index pond keeps on a table. Created when
@@ -2982,13 +3004,15 @@ async fn optimize_table_compact(
                 &task_stats,
                 policy.compaction_fragment_cap,
                 compaction.materialize_deletions_threshold,
+                compaction.target_rows_per_fragment,
+                TARGET_FRAGMENT_BYTES,
             );
             if !keep {
                 tracing::debug!(
                     target: "pond::perf",
                     table = table.as_str(),
                     fragments = task_stats.len(),
-                    "compaction task vetoed: merge dominated by one large fragment",
+                    "compaction task vetoed: unreachable row target or excessive amplification",
                 );
             }
             keep
@@ -5162,49 +5186,91 @@ mod tests {
         storage_check(&resolved).await.expect("memory probe passes");
     }
 
-    fn stat(bytes: u64) -> FragmentStat {
+    fn fragment(bytes: u64, rows: u64, deleted_rows: u64) -> FragmentStat {
         FragmentStat {
             bytes: Some(bytes),
-            rows: bytes / 1_000,
-            deleted_rows: 0,
+            rows,
+            deleted_rows,
         }
+    }
+
+    fn stat(bytes: u64) -> FragmentStat {
+        fragment(bytes, bytes / 1_000, 0)
+    }
+
+    fn task_is_kept(stats: &[FragmentStat], target_rows_per_fragment: usize) -> bool {
+        keep_task(
+            stats,
+            64,
+            0.1,
+            target_rows_per_fragment,
+            TARGET_FRAGMENT_BYTES,
+        )
     }
 
     #[test]
     fn compaction_veto_blocks_absorb_keeps_peers() {
-        // One 665 MiB tail fragment + tiny appends -> vetoed.
-        let absorb = [stat(665_000_000), stat(1_000_000), stat(2_000_000)];
-        assert!(!keep_task(&absorb, 64, 0.1));
-        // Peer-sized merge halves fragment count -> kept.
-        let peers = [stat(300_000_000), stat(300_000_000)];
-        assert!(keep_task(&peers, 64, 0.1));
+        // One large candidate plus tiny appends -> vetoed.
+        let absorb = [stat(100_000_000), stat(1_000_000), stat(2_000_000)];
+        assert!(!task_is_kept(&absorb, 134_217));
+        // Peer-sized candidates can merge and reach the target.
+        let peers = [stat(100_000_000), stat(100_000_000)];
+        assert!(task_is_kept(&peers, 134_217));
         // Remainder reaches largest / COMPACTION_ABSORB_FACTOR -> kept.
         let tiered = [stat(400_000), stat(60_000), stat(40_000)];
-        assert!(keep_task(&tiered, 64, 0.1));
+        assert!(task_is_kept(&tiered, 1_000));
     }
 
     #[test]
     fn compaction_veto_passes_deletions_and_cap() {
         let mut deleting = stat(665_000_000);
         deleting.deleted_rows = deleting.rows / 5;
-        assert!(keep_task(&[deleting, stat(1_000)], 64, 0.1));
+        assert!(task_is_kept(
+            &[deleting, stat(1_000)],
+            MAX_TARGET_ROWS_PER_FRAGMENT as usize,
+        ));
 
-        let wide: Vec<FragmentStat> = std::iter::once(stat(665_000_000))
-            .chain(std::iter::repeat_with(|| stat(1_000)).take(63))
+        let wide: Vec<FragmentStat> = std::iter::once(stat(100_000_000))
+            .chain(std::iter::repeat_with(|| stat(100_000)).take(63))
             .collect();
-        assert!(keep_task(&wide, 64, 0.1));
+        assert!(task_is_kept(&wide, 134_217));
     }
 
     #[test]
-    fn compaction_veto_falls_back_to_rows_on_unknown_sizes() {
+    fn compaction_veto_fails_closed_on_unknown_sizes() {
         let mut unknown = stat(665_000_000);
         unknown.bytes = None;
-        // Rows comparison: 665k vs 3k -> still vetoed.
-        assert!(!keep_task(
-            &[unknown, stat(1_000_000), stat(2_000_000)],
-            64,
-            0.1
-        ));
+        assert!(!task_is_kept(&[unknown, stat(665_000_000)], 134_217));
+    }
+
+    #[test]
+    fn compaction_veto_uses_live_rows_after_deletions() {
+        let partially_deleted = || fragment(100_000_000, 100_000, 9_000);
+        let task: Vec<FragmentStat> = std::iter::repeat_with(partially_deleted).take(2).collect();
+        assert!(!task_is_kept(&task, 134_217));
+    }
+
+    #[test]
+    fn compaction_veto_rejects_byte_capped_second_cycle() {
+        // A 5 -> 4 rewrite still loops when all four outputs stay below target.
+        let wide_peer = || fragment(200_000_000, 2_000, 0);
+        let first_cycle: Vec<FragmentStat> = std::iter::repeat_with(wide_peer).take(5).collect();
+        let expected_outputs_by_bytes = 1_000_000_000u64.div_ceil(TARGET_FRAGMENT_BYTES) as usize;
+        assert_eq!(expected_outputs_by_bytes, 4);
+        assert!(expected_outputs_by_bytes < first_cycle.len());
+        let cap_sized_task: Vec<FragmentStat> =
+            std::iter::repeat_with(wide_peer).take(64).collect();
+
+        let second_cycle = [
+            fragment(TARGET_FRAGMENT_BYTES, 2_684, 0),
+            fragment(TARGET_FRAGMENT_BYTES, 2_684, 0),
+            fragment(TARGET_FRAGMENT_BYTES, 2_684, 0),
+            fragment(194_693_632, 1_948, 0),
+        ];
+
+        assert!(!task_is_kept(&first_cycle, 66_000));
+        assert!(!task_is_kept(&cap_sized_task, 66_000));
+        assert!(!task_is_kept(&second_cycle, 66_000));
     }
 
     #[test]
@@ -5312,7 +5378,7 @@ mod tests {
     }
 
     #[test]
-    fn derived_target_rows_tracks_row_size_and_clamps() {
+    fn derived_target_rows_tracks_row_size_and_byte_cap() {
         // ~1.3 KiB rows -> ~100k-row target (half the byte budget, for freeze
         // headroom over the 256 MiB output cap).
         let parts_like = [FragmentStat {
@@ -5332,7 +5398,7 @@ mod tests {
             derived_target_rows(&unknown),
             MAX_TARGET_ROWS_PER_FRAGMENT as usize
         );
-        // Tiny rows clamp at the ceiling, huge rows at the floor.
+        // Tiny rows clamp at the ceiling.
         let tiny = [FragmentStat {
             bytes: Some(1_000_000),
             rows: 100_000,
@@ -5342,15 +5408,26 @@ mod tests {
             derived_target_rows(&tiny),
             MAX_TARGET_ROWS_PER_FRAGMENT as usize
         );
-        let huge = [FragmentStat {
-            bytes: Some(1_000_000_000),
-            rows: 100,
+
+        let incident_parts = [FragmentStat {
+            bytes: Some(1_027_449_798),
+            rows: 105_087,
             deleted_rows: 0,
         }];
-        assert_eq!(
-            derived_target_rows(&huge),
-            MIN_TARGET_ROWS_PER_FRAGMENT as usize
+        let incident_target = derived_target_rows(&incident_parts);
+        assert_eq!(incident_target, 13_727);
+        assert!(
+            u128::from(incident_parts[0].bytes.unwrap()) * incident_target as u128 * 2
+                <= u128::from(incident_parts[0].rows) * u128::from(TARGET_FRAGMENT_BYTES)
         );
+
+        // A row larger than the half-cap still needs a usable target.
+        let huge = [FragmentStat {
+            bytes: Some(1_000_000_000),
+            rows: 1,
+            deleted_rows: 0,
+        }];
+        assert_eq!(derived_target_rows(&huge), 1);
     }
 
     #[test]

--- a/packages/pond/src/substrate.rs
+++ b/packages/pond/src/substrate.rs
@@ -1029,51 +1029,57 @@ fn derived_target_rows(stats: &[FragmentStat]) -> usize {
         .clamp(1, u128::from(MAX_TARGET_ROWS_PER_FRAGMENT))) as usize
 }
 
-/// Skip tasks when any input fragment's live-row width cannot fit the row target
-/// within half the configured output byte budget, then apply the amplification
-/// veto. The headroom absorbs soft-cap row groups and whole-file binary copies.
-/// Deletion materialization always passes because its useful result is removing
-/// tombstoned rows.
-fn keep_task(
+/// Name the first reason an optional compaction task cannot make progress.
+/// Deletion materialization always passes because removing tombstones is useful.
+fn task_veto_reason(
     stats: &[FragmentStat],
     cap: usize,
     deletion_threshold: f32,
     target_rows_per_fragment: usize,
     max_bytes_per_file: u64,
-) -> bool {
+) -> Option<&'static str> {
     if stats.iter().any(|stat| {
         stat.rows > 0 && (stat.deleted_rows as f32 / stat.rows as f32) > deletion_threshold
     }) {
-        return true;
+        return None;
     }
-    let mut total_bytes = 0u128;
+
+    let budget = u128::from(max_bytes_per_file);
+    if budget == 0 {
+        return Some("invalid_byte_budget");
+    }
+
+    let (mut total_bytes, mut largest) = (0u128, 0u128);
     for stat in stats {
         let Some(bytes) = stat.bytes.map(u128::from) else {
-            return false;
+            return Some("missing_sizes");
         };
-        let live_rows = u128::from(stat.rows.saturating_sub(stat.deleted_rows));
-        if bytes == 0
-            || live_rows == 0
-            || bytes * target_rows_per_fragment as u128 * 2
-                > live_rows * u128::from(max_bytes_per_file)
-        {
-            return false;
-        }
         total_bytes += bytes;
+        largest = largest.max(bytes);
     }
-    if total_bytes == 0 {
-        return false;
+
+    let minimum_outputs = total_bytes.div_ceil(budget).max(1);
+    if u128::try_from(stats.len()).unwrap_or(u128::MAX) <= minimum_outputs {
+        return Some("cannot_shrink");
     }
     if stats.len() >= cap {
-        return true;
+        return None;
     }
-    let largest = stats
-        .iter()
-        .filter_map(|stat| stat.bytes)
-        .map(u128::from)
-        .max()
-        .unwrap_or(0);
-    (total_bytes - largest) * u128::from(COMPACTION_ABSORB_FACTOR) >= largest
+
+    if total_bytes > budget {
+        for stat in stats {
+            let bytes = u128::from(stat.bytes.unwrap_or(0));
+            let rows = u128::from(stat.rows);
+            if rows == 0 || bytes * target_rows_per_fragment as u128 * 2 > rows * budget {
+                return Some("row_target_unattainable");
+            }
+        }
+    }
+
+    if (total_bytes - largest) * u128::from(COMPACTION_ABSORB_FACTOR) < largest {
+        return Some("absorb_veto");
+    }
+    None
 }
 
 /// Declarative description of one index pond keeps on a table. Created when
@@ -2998,24 +3004,29 @@ async fn optimize_table_compact(
 
     let mut plan = plan_compaction(dataset, &compaction).await?;
     if policy.compaction_fragment_cap > 0 {
+        let max_bytes_per_file = compaction
+            .max_bytes_per_file
+            .and_then(|bytes| u64::try_from(bytes).ok())
+            .unwrap_or_default();
         plan.tasks.retain(|task| {
             let task_stats: Vec<FragmentStat> = task.fragments.iter().map(fragment_stat).collect();
-            let keep = keep_task(
+            let reason = task_veto_reason(
                 &task_stats,
                 policy.compaction_fragment_cap,
                 compaction.materialize_deletions_threshold,
                 compaction.target_rows_per_fragment,
-                TARGET_FRAGMENT_BYTES,
+                max_bytes_per_file,
             );
-            if !keep {
+            if let Some(reason) = reason {
                 tracing::debug!(
                     target: "pond::perf",
                     table = table.as_str(),
                     fragments = task_stats.len(),
-                    "compaction task vetoed: unreachable row target or excessive amplification",
+                    reason,
+                    "compaction task vetoed",
                 );
             }
-            keep
+            reason.is_none()
         });
     }
     if plan.tasks.is_empty() {
@@ -5199,55 +5210,100 @@ mod tests {
     }
 
     fn task_is_kept(stats: &[FragmentStat], target_rows_per_fragment: usize) -> bool {
-        keep_task(
+        task_veto_reason(
             stats,
             64,
             0.1,
             target_rows_per_fragment,
             TARGET_FRAGMENT_BYTES,
         )
+        .is_none()
     }
 
     #[test]
     fn compaction_veto_blocks_absorb_keeps_peers() {
         // One large candidate plus tiny appends -> vetoed.
         let absorb = [stat(100_000_000), stat(1_000_000), stat(2_000_000)];
-        assert!(!task_is_kept(&absorb, 134_217));
+        assert!(!task_is_kept(&absorb, derived_target_rows(&absorb)));
         // Peer-sized candidates can merge and reach the target.
         let peers = [stat(100_000_000), stat(100_000_000)];
-        assert!(task_is_kept(&peers, 134_217));
+        assert!(task_is_kept(&peers, derived_target_rows(&peers)));
         // Remainder reaches largest / COMPACTION_ABSORB_FACTOR -> kept.
         let tiered = [stat(400_000), stat(60_000), stat(40_000)];
-        assert!(task_is_kept(&tiered, 1_000));
+        assert!(task_is_kept(&tiered, derived_target_rows(&tiered)));
+
+        let off_boundary = [
+            fragment(99_900_000, 100_000, 0),
+            fragment(100_100_000, 100_000, 0),
+        ];
+        assert!(task_is_kept(
+            &off_boundary,
+            derived_target_rows(&off_boundary),
+        ));
     }
 
     #[test]
     fn compaction_veto_passes_deletions_and_cap() {
         let mut deleting = stat(665_000_000);
         deleting.deleted_rows = deleting.rows / 5;
+        let deleting_task = [deleting, stat(1_000)];
         assert!(task_is_kept(
-            &[deleting, stat(1_000)],
-            MAX_TARGET_ROWS_PER_FRAGMENT as usize,
+            &deleting_task,
+            derived_target_rows(&deleting_task),
         ));
 
         let wide: Vec<FragmentStat> = std::iter::once(stat(100_000_000))
             .chain(std::iter::repeat_with(|| stat(100_000)).take(63))
             .collect();
-        assert!(task_is_kept(&wide, 134_217));
+        assert!(task_is_kept(&wide, derived_target_rows(&wide)));
     }
 
     #[test]
     fn compaction_veto_fails_closed_on_unknown_sizes() {
         let mut unknown = stat(665_000_000);
         unknown.bytes = None;
-        assert!(!task_is_kept(&[unknown, stat(665_000_000)], 134_217));
+        let task = [unknown, stat(665_000_000)];
+        assert_eq!(
+            task_veto_reason(
+                &task,
+                64,
+                0.1,
+                derived_target_rows(&task),
+                TARGET_FRAGMENT_BYTES
+            ),
+            Some("missing_sizes"),
+        );
     }
 
     #[test]
-    fn compaction_veto_uses_live_rows_after_deletions() {
+    fn compaction_veto_uses_physical_rows_after_deletions() {
         let partially_deleted = || fragment(100_000_000, 100_000, 9_000);
-        let task: Vec<FragmentStat> = std::iter::repeat_with(partially_deleted).take(2).collect();
-        assert!(!task_is_kept(&task, 134_217));
+        let task: Vec<FragmentStat> = std::iter::repeat_with(partially_deleted).take(3).collect();
+        assert!(task_is_kept(&task, 134_217));
+    }
+
+    #[test]
+    fn compaction_filter_keeps_real_mixed_width_tasks_below_budget() {
+        let four_fragment_task = [
+            fragment(26_612_870, 9_281, 0),
+            fragment(14_242_314, 4_400, 0),
+            fragment(54_111_122, 20_988, 0),
+            fragment(517_923, 166, 0),
+        ];
+        assert!(task_is_kept(&four_fragment_task, 58_468));
+
+        let nine_fragment_task = [
+            fragment(13_547_709, 3_946, 0),
+            fragment(344_320, 155, 0),
+            fragment(134_209, 34, 0),
+            fragment(54_624_719, 15_759, 0),
+            fragment(1_364_162, 292, 0),
+            fragment(110_225_801, 32_826, 0),
+            fragment(8_151_118, 1_840, 0),
+            fragment(728_590, 79, 0),
+            fragment(685_184, 128, 0),
+        ];
+        assert!(task_is_kept(&nine_fragment_task, 58_468));
     }
 
     #[test]
@@ -5268,9 +5324,15 @@ mod tests {
             fragment(194_693_632, 1_948, 0),
         ];
 
-        assert!(!task_is_kept(&first_cycle, 66_000));
-        assert!(!task_is_kept(&cap_sized_task, 66_000));
-        assert!(!task_is_kept(&second_cycle, 66_000));
+        assert_eq!(
+            task_veto_reason(&first_cycle, 64, 0.1, 66_000, TARGET_FRAGMENT_BYTES),
+            Some("row_target_unattainable"),
+        );
+        assert!(task_is_kept(&cap_sized_task, 66_000));
+        assert_eq!(
+            task_veto_reason(&second_cycle, 64, 0.1, 66_000, TARGET_FRAGMENT_BYTES),
+            Some("cannot_shrink"),
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #123

## Root cause

Lance selects compaction candidates by row count, while re-encoding can split output at a soft byte limit. Wide-row output can remain below the row target and become a candidate again on the next sync.

The incident table had 1,027,449,798 data-file bytes across 105,087 physical rows, or about 9,777 bytes per row. Pond derived a half-budget target of 13,727 rows, then raised it to the fixed 50,000-row floor. That target could not fit inside the configured 256 MiB output budget.

A one-pass fragment-count reduction does not prove convergence. A five-fragment task can become four byte-capped fragments and then rewrite those four on every later sync.

## Fix

- Derive the row target from observed physical row width without a fixed row floor.
- Require every optional compaction task to strictly reduce fragment count, based on `ceil(total task bytes / max_bytes_per_file)`.
- When a task exceeds one output file's byte budget, require every input fragment's observed physical-row width to let an output reach the row target within half that budget.
- Fail closed when file sizes or the configured byte budget are unavailable.
- Keep deletion materialization eligible. Preserve the 64-fragment backstop and the existing absorb veto after the strict-shrink check.
- Log the skip reason as `missing_sizes`, `invalid_byte_budget`, `cannot_shrink`, `row_target_unattainable`, or `absorb_veto`.

This adds no CLI command, dependency, migration, cleanup behavior, or scheduler behavior.

## Regression coverage

Unit coverage includes the measured incident target, the 5 -> 4 -> 4 rewrite loop, strict-shrink behavior, missing sizes, deletion precedence, physical-row accounting after deletions, the 64-fragment backstop, productive peer merges, and the absorb veto.

The kept cases include both real mixed-width tasks from review and an above-budget off-boundary task. That last fixture derives its target from the whole table while filtering one planned task, so it exercises the conditional width gate without relying on exact boundary equality.

## Validation

- On code head `b7a1727`, Rust 1.95 passed `cargo fmt`, `cargo clippy --locked --offline -- -D warnings`, and the full test suite with 363 passed and 1 ignored.
- The test-only follow-up `e74de1f` passes Rust 1.95 `rustfmt --check`, `git diff --check`, and an independent exact-integer check of the new fixture. Final-head CI is [run 30198684977](https://github.com/tenequm/pond/actions/runs/30198684977).
- A normal optimize canary on the affected store reduced active `parts` fragments from 14 to 6. An immediate second pass made zero file changes. Row counts, corpus hashes, protected transcript hashes, and the FTS result remained identical.

The canary validated end-to-end convergence on the affected store. Its productive task fit below one output budget, so the above-budget width branch is covered by the focused unit fixture.
