### PR TITLE
fix(cli): remove unused tracing progress layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6740,7 +6740,6 @@ dependencies = [
  "toml_edit 0.25.11+spec-1.1.0",
  "tower",
  "tracing",
- "tracing-indicatif",
  "tracing-subscriber",
  "url",
  "uuid",
@@ -9225,18 +9224,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
 dependencies = [
  "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-indicatif"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ef6990e0438749f0080573248e96631171a0b5ddfddde119aa5ba8c3a9c47e"
-dependencies = [
- "indicatif",
- "tracing",
- "tracing-core",
  "tracing-subscriber",
 ]
 

--- a/packages/pond/Cargo.toml
+++ b/packages/pond/Cargo.toml
@@ -156,7 +156,6 @@ tokio-stream = "0.1.18"
 toml = "1.1"
 toml_edit = "0.25"
 tracing = "0.1.44"
-tracing-indicatif = "0.3.14"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt"] }
 url = "2.5"
 uuid = { version = "1.23", features = ["v7"] }

--- a/packages/pond/src/main.rs
+++ b/packages/pond/src/main.rs
@@ -1648,9 +1648,10 @@ fn init_tracing(cli_level: tracing::level_filters::LevelFilter) {
             "{cli_level},lance::index::vector::builder=error,aws_config=error,lance::object_store::throttle=error,lance::io::exec::count_pushdown=error"
         ))
     });
+    // stdout is reserved for JSON-RPC frames and machine-readable command output.
     tracing_subscriber::registry()
         .with(filter)
-        .with(fmt::layer())
+        .with(fmt::layer().with_writer(std::io::stderr))
         .init();
 }
 

--- a/packages/pond/src/main.rs
+++ b/packages/pond/src/main.rs
@@ -123,8 +123,7 @@ impl From<CliSessionFrom> for SessionFrom {
 }
 use serde_json::{Value, json};
 use tokio::io::AsyncWriteExt;
-use tracing_indicatif::{IndicatifLayer, filter::IndicatifFilter};
-use tracing_subscriber::layer::{Layer, SubscriberExt};
+use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, fmt};
 use url::Url;
@@ -1626,15 +1625,6 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn opt_in_indicatif_layer<S>(
-    layer: IndicatifLayer<S>,
-) -> tracing_subscriber::filter::Filtered<IndicatifLayer<S>, IndicatifFilter<S>, S>
-where
-    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
-{
-    layer.with_filter(IndicatifFilter::new(false))
-}
-
 fn init_tracing(cli_level: tracing::level_filters::LevelFilter) {
     // Lance's IVF_SQ builder warns once per empty centroid during merge
     // (rust/lance/src/index/vector/builder.rs: "partition N is empty, skipping").
@@ -1658,16 +1648,9 @@ fn init_tracing(cli_level: tracing::level_filters::LevelFilter) {
             "{cli_level},lance::index::vector::builder=error,aws_config=error,lance::object_store::throttle=error,lance::io::exec::count_pushdown=error"
         ))
     });
-    // Keep progress bars opt-in. Without the filter, `-vv` turns every Lance
-    // and DataFusion span into a bar, and tracing-indicatif can panic when its
-    // pending footer is hidden by a non-terminal stderr target.
-    let indicatif_layer = IndicatifLayer::new();
-    let fmt_layer = fmt::layer().with_writer(indicatif_layer.get_stderr_writer());
-    let indicatif_layer = opt_in_indicatif_layer(indicatif_layer);
     tracing_subscriber::registry()
         .with(filter)
-        .with(fmt_layer)
-        .with(indicatif_layer)
+        .with(fmt::layer())
         .init();
 }
 
@@ -5953,22 +5936,6 @@ mod tests {
     #![allow(clippy::expect_used, clippy::unwrap_used)]
 
     use super::*;
-
-    #[test]
-    fn indicatif_layer_ignores_more_than_seven_unmarked_spans() {
-        fn enter_unmarked_spans(depth: usize) {
-            if depth == 0 {
-                return;
-            }
-            let span = tracing::info_span!("unmarked_test_span", depth);
-            let _guard = span.enter();
-            enter_unmarked_spans(depth - 1);
-        }
-
-        let subscriber =
-            tracing_subscriber::registry().with(opt_in_indicatif_layer(IndicatifLayer::new()));
-        tracing::subscriber::with_default(subscriber, || enter_unmarked_spans(8));
-    }
 
     #[test]
     fn serve_bootstrap_acts_only_on_a_fully_unconfigured_pond() -> anyhow::Result<()> {

--- a/packages/pond/src/main.rs
+++ b/packages/pond/src/main.rs
@@ -123,8 +123,8 @@ impl From<CliSessionFrom> for SessionFrom {
 }
 use serde_json::{Value, json};
 use tokio::io::AsyncWriteExt;
-use tracing_indicatif::IndicatifLayer;
-use tracing_subscriber::layer::SubscriberExt;
+use tracing_indicatif::{IndicatifLayer, filter::IndicatifFilter};
+use tracing_subscriber::layer::{Layer, SubscriberExt};
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, fmt};
 use url::Url;
@@ -1626,6 +1626,15 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
+fn opt_in_indicatif_layer<S>(
+    layer: IndicatifLayer<S>,
+) -> tracing_subscriber::filter::Filtered<IndicatifLayer<S>, IndicatifFilter<S>, S>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    layer.with_filter(IndicatifFilter::new(false))
+}
+
 fn init_tracing(cli_level: tracing::level_filters::LevelFilter) {
     // Lance's IVF_SQ builder warns once per empty centroid during merge
     // (rust/lance/src/index/vector/builder.rs: "partition N is empty, skipping").
@@ -1649,14 +1658,12 @@ fn init_tracing(cli_level: tracing::level_filters::LevelFilter) {
             "{cli_level},lance::index::vector::builder=error,aws_config=error,lance::object_store::throttle=error,lance::io::exec::count_pushdown=error"
         ))
     });
-    // `IndicatifLayer` routes both spans (when they opt-in via `pb_set_*`)
-    // and the fmt log writer through a shared draw target, so log lines
-    // never clobber an active progress bar. Today no pond span requests a
-    // bar, so the layer is essentially a "safe stderr writer for fmt that
-    // coexists with future bar-rendering spans"; the migration cost when we
-    // do start instrumenting spans (e.g. ingest, optimize) is zero.
+    // Keep progress bars opt-in. Without the filter, `-vv` turns every Lance
+    // and DataFusion span into a bar, and tracing-indicatif can panic when its
+    // pending footer is hidden by a non-terminal stderr target.
     let indicatif_layer = IndicatifLayer::new();
     let fmt_layer = fmt::layer().with_writer(indicatif_layer.get_stderr_writer());
+    let indicatif_layer = opt_in_indicatif_layer(indicatif_layer);
     tracing_subscriber::registry()
         .with(filter)
         .with(fmt_layer)
@@ -5946,6 +5953,22 @@ mod tests {
     #![allow(clippy::expect_used, clippy::unwrap_used)]
 
     use super::*;
+
+    #[test]
+    fn indicatif_layer_ignores_more_than_seven_unmarked_spans() {
+        fn enter_unmarked_spans(depth: usize) {
+            if depth == 0 {
+                return;
+            }
+            let span = tracing::info_span!("unmarked_test_span", depth);
+            let _guard = span.enter();
+            enter_unmarked_spans(depth - 1);
+        }
+
+        let subscriber =
+            tracing_subscriber::registry().with(opt_in_indicatif_layer(IndicatifLayer::new()));
+        tracing::subscriber::with_default(subscriber, || enter_unmarked_spans(8));
+    }
 
     #[test]
     fn serve_bootstrap_acts_only_on_a_fully_unconfigured_pond() -> anyhow::Result<()> {


### PR DESCRIPTION
## What changed

- remove the unused `tracing-indicatif` layer and dependency
- write tracing output directly through `tracing-subscriber`

## Why

Pond has no `indicatif.pb_show` spans. The unfiltered layer turned `-vv` dependency spans into progress bars and exposed the non-terminal panic tracked in `tracing-indicatif` issue #24:

https://github.com/emersonford/tracing-indicatif/issues/24

Its writer only suspends bars owned by its own `MultiProgress`. Pond's real progress bars are separate, so the layer did not protect them. Removing it eliminates the failing path and dead future plumbing.

## Checks

- `rustfmt 1.9.0-stable --edition 2024 --check packages/pond/src/main.rs`
- `cargo metadata --locked --offline --no-deps --format-version 1`
- `git diff --check`

A full compile remains with CI because this checkout has no reusable Cargo target and a prior cold Pond build used about 17.8 GiB.

Closes #128
