### PR TITLE
chore: release v0.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.14.4](https://github.com/tenequm/pond/compare/v0.14.3...v0.14.4) - 2026-07-30
+
+### <!-- 2 -->🐛 Bug Fixes
+- **cli:** gate log color on a tty, and cover the stdout contract ([e617b3f](https://github.com/tenequm/pond/commit/e617b3f3fce57c2b90e702fe8d90c1999680fd38))
+- **cli:** remove unused tracing progress layer ([#129](https://github.com/tenequm/pond/pull/129)) ([74f2659](https://github.com/tenequm/pond/commit/74f2659bde3c3bed00a09c0374abf99c30491bc1))
+
+### <!-- 6 -->🧹 Chores
+- **ci:** prune stale lock entries and close moon cache-input gaps ([058c3c9](https://github.com/tenequm/pond/commit/058c3c98001be23a7c0d54981329538642e933fd))
+
+**Full Changelog**: https://github.com/tenequm/pond/compare/v0.14.3...v0.14.4
+
 ## [0.14.3](https://github.com/tenequm/pond/compare/v0.14.2...v0.14.3) - 2026-07-28
 
 Automatic compaction now provably converges: a task filter built on a shrinkability guarantee replaces the fixed row floor that could rewrite wide-row tables forever.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6673,7 +6673,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pond-db"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/packages/pond/Cargo.toml
+++ b/packages/pond/Cargo.toml
@@ -3,7 +3,7 @@
 # crate). The library and binary stay `pond` via [lib]/[[bin]] below, so the
 # command and `use pond::...` are unchanged - only `cargo install pond-db` differs.
 name = "pond-db"
-version = "0.14.3"
+version = "0.14.4"
 edition = "2024"
 # MSRV pinned to the toolchain we build and test with (rust-toolchain.toml).
 rust-version = "1.95"


### PR DESCRIPTION



## 🤖 New release

* `pond-db`: 0.14.3 -> 0.14.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.4](https://github.com/tenequm/pond/compare/v0.14.3...v0.14.4) - 2026-07-30

### <!-- 2 -->🐛 Bug Fixes
- **cli:** gate log color on a tty, and cover the stdout contract ([e617b3f](https://github.com/tenequm/pond/commit/e617b3f3fce57c2b90e702fe8d90c1999680fd38))
- **cli:** remove unused tracing progress layer ([#129](https://github.com/tenequm/pond/pull/129)) ([74f2659](https://github.com/tenequm/pond/commit/74f2659bde3c3bed00a09c0374abf99c30491bc1))

### <!-- 6 -->🧹 Chores
- **ci:** prune stale lock entries and close moon cache-input gaps ([058c3c9](https://github.com/tenequm/pond/commit/058c3c98001be23a7c0d54981329538642e933fd))

**Full Changelog**: https://github.com/tenequm/pond/compare/v0.14.3...v0.14.4
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).