### PR TITLE
chore: release v0.14.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.14.5](https://github.com/tenequm/pond/compare/v0.14.4...v0.14.5) - 2026-08-07
+
+### <!-- 5 -->📚 Documentation
+- add server.json and MCP Registry name for official registry publishing ([59c926a](https://github.com/tenequm/pond/commit/59c926a9dcd8e6fd74345fc74d5daef6fcaba46e))
+
+**Full Changelog**: https://github.com/tenequm/pond/compare/v0.14.4...v0.14.5
+
 ## [0.14.4](https://github.com/tenequm/pond/compare/v0.14.3...v0.14.4) - 2026-07-30
 
 ### <!-- 2 -->🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6673,7 +6673,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pond-db"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/packages/pond/Cargo.toml
+++ b/packages/pond/Cargo.toml
@@ -3,7 +3,7 @@
 # crate). The library and binary stay `pond` via [lib]/[[bin]] below, so the
 # command and `use pond::...` are unchanged - only `cargo install pond-db` differs.
 name = "pond-db"
-version = "0.14.4"
+version = "0.14.5"
 edition = "2024"
 # MSRV pinned to the toolchain we build and test with (rust-toolchain.toml).
 rust-version = "1.95"


### PR DESCRIPTION



## 🤖 New release

* `pond-db`: 0.14.4 -> 0.14.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.5](https://github.com/tenequm/pond/compare/v0.14.4...v0.14.5) - 2026-08-07

### <!-- 5 -->📚 Documentation
- add server.json and MCP Registry name for official registry publishing ([59c926a](https://github.com/tenequm/pond/commit/59c926a9dcd8e6fd74345fc74d5daef6fcaba46e))

**Full Changelog**: https://github.com/tenequm/pond/compare/v0.14.4...v0.14.5
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).