### PR TITLE
chore: release v0.14.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.14.6](https://github.com/tenequm/pond/compare/v0.14.5...v0.14.6) - 2026-08-07
+
+### <!-- 2 -->🐛 Bug Fixes
+- exit quietly on a closed pipe instead of panicking ([3961cb3](https://github.com/tenequm/pond/commit/3961cb300b8d1e58677380e04e5d6030bda3813c))
+
+**Full Changelog**: https://github.com/tenequm/pond/compare/v0.14.5...v0.14.6
+
 ## [0.14.5](https://github.com/tenequm/pond/compare/v0.14.4...v0.14.5) - 2026-08-07
 
 ### <!-- 5 -->📚 Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6673,7 +6673,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pond-db"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/packages/pond/Cargo.toml
+++ b/packages/pond/Cargo.toml
@@ -3,7 +3,7 @@
 # crate). The library and binary stay `pond` via [lib]/[[bin]] below, so the
 # command and `use pond::...` are unchanged - only `cargo install pond-db` differs.
 name = "pond-db"
-version = "0.14.5"
+version = "0.14.6"
 edition = "2024"
 # MSRV pinned to the toolchain we build and test with (rust-toolchain.toml).
 rust-version = "1.95"


### PR DESCRIPTION



## 🤖 New release

* `pond-db`: 0.14.5 -> 0.14.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.6](https://github.com/tenequm/pond/compare/v0.14.5...v0.14.6) - 2026-08-07

### <!-- 2 -->🐛 Bug Fixes
- exit quietly on a closed pipe instead of panicking ([3961cb3](https://github.com/tenequm/pond/commit/3961cb300b8d1e58677380e04e5d6030bda3813c))

**Full Changelog**: https://github.com/tenequm/pond/compare/v0.14.5...v0.14.6
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).