### PR TITLE
chore: release v0.14.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.14.9](https://github.com/tenequm/pond/compare/v0.14.8...v0.14.9) - 2026-08-12
+
+### <!-- 1 -->🎉 New Features
+- **adapter:** capture oh-my-pi (omp) sessions ([#142](https://github.com/tenequm/pond/pull/142)) ([f9e949e](https://github.com/tenequm/pond/commit/f9e949e285270db67bb0f8973de51742ab994b71))
+
+**Full Changelog**: https://github.com/tenequm/pond/compare/v0.14.8...v0.14.9
+
 ## [0.14.8](https://github.com/tenequm/pond/compare/v0.14.7...v0.14.8) - 2026-08-12
 
 The get family stops paying S3 for data it already holds resident: message-id resolution and session pages are now served from the mmap'd rowmap, cutting a cold `get-session <message-id>` from 166s to ~61s and a warm get's S3 round-trips by 63%.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6673,7 +6673,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pond-db"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/packages/pond/Cargo.toml
+++ b/packages/pond/Cargo.toml
@@ -3,7 +3,7 @@
 # crate). The library and binary stay `pond` via [lib]/[[bin]] below, so the
 # command and `use pond::...` are unchanged - only `cargo install pond-db` differs.
 name = "pond-db"
-version = "0.14.8"
+version = "0.14.9"
 edition = "2024"
 # MSRV pinned to the toolchain we build and test with (rust-toolchain.toml).
 rust-version = "1.95"


### PR DESCRIPTION



## 🤖 New release

* `pond-db`: 0.14.8 -> 0.14.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.9](https://github.com/tenequm/pond/compare/v0.14.8...v0.14.9) - 2026-08-12

### <!-- 1 -->🎉 New Features
- **adapter:** capture oh-my-pi (omp) sessions ([#142](https://github.com/tenequm/pond/pull/142)) ([f9e949e](https://github.com/tenequm/pond/commit/f9e949e285270db67bb0f8973de51742ab994b71))

**Full Changelog**: https://github.com/tenequm/pond/compare/v0.14.8...v0.14.9
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).