### PR TITLE
ci(windows): put the kache store on D: and uncap prefetch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,11 +165,17 @@ jobs:
   # The shipped msvc zip. Release-gated rather than per-PR: it produces an
   # artifact nobody consumes outside a release, and it is the only thing in the
   # pipeline that ever executes a Windows binary.
+  # `!cancelled()` is load-bearing: release-prep only runs on a main push, and a
+  # skipped `needs` skips its dependents, so a bare `needs:` would stop this ever
+  # running on the release PR.
   windows-dist:
+    needs: [release-prep]
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-plz-'))
+      !cancelled() && (
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-plz-')) ||
+        needs.release-prep.outputs.is_release == 'true'
+      )
     runs-on: windows-2025
     timeout-minutes: 180
     # Not cancellable, same rule as dist-build: this produces a release artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,17 @@ jobs:
     # REPLACES the +crt-static rustflags from .cargo/config.toml.
     env:
       BAZEL_REMOTE_AUTH: ""
+      # kache defaults its store to %LOCALAPPDATA% on C:, which on this image is
+      # a slow ~29 GB network-attached disk; D: is ~147 GB of fast local storage
+      # and already holds target/ (actions/runner-images#12416). Same volume as
+      # the build tree is also the precondition for any future hardlink restore.
+      KACHE_CACHE_DIR: D:\kache
+      # Prefetch stops at 2GiB of blobs or 300s of scheduling by default, and
+      # this graph is far past both - lance alone is 287 MB of ~790 crates. The
+      # crates the caps drop are the expensive ones, which is why lance and the
+      # datafusion set flip between hit and miss with an unchanged Cargo.lock.
+      KACHE_PREFETCH_MAX_BYTES: "0"
+      KACHE_PREFETCH_DEADLINE_SECS: "0"
     steps:
       # MUST precede checkout, and cannot live in the composite action (a local
       # action only resolves once the repo is checked out). pond's longest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,14 +88,14 @@ jobs:
   # runners - separate machines, separate disks, nothing shared - so Windows
   # contributes the longer of the two to a release, not the sum.
   #
-  # Plain cargo in both, NOT moon, and the reason is load-bearing: moon's task
+  # windows-verify runs moon's `pond:test-msvc`, never `pond:test`: the task
   # fingerprint carries command/args/deps/env/inputs/outputs but no OS or
-  # architecture (crates/task-hasher/src/task_fingerprint.rs). `moon run
-  # pond:test` here would compute the hash the Linux runner already stored for
-  # this commit, report "cached", and go green without compiling a single line
-  # on Windows - exactly the failure these jobs exist to prevent. They mirror
-  # packages/pond/moon.yml `test` and the dist leg of the root moon.yml
-  # `build-dist`; keep them in lockstep by hand.
+  # architecture (crates/task-hasher/src/task_fingerprint.rs), so sharing one
+  # task would hit the hash the Linux runner already stored and go green without
+  # compiling a line here. The differing command is what keeps them apart, and
+  # the remote cache is what lets a prose-only commit skip the leg entirely.
+  # windows-dist stays plain cargo, mirroring the dist leg of the root moon.yml
+  # `build-dist`; keep those two in lockstep by hand.
   #
   # The two carry DIFFERENT kache manifest-keys. Sharing one would make each
   # overwrite the other's warm-prefetch manifest, silently dropping both to a
@@ -125,8 +125,11 @@ jobs:
     concurrency: { group: "ci-windows-verify-${{ github.ref }}", cancel-in-progress: true }
     # RUSTFLAGS is deliberately absent: setting it anywhere in this job silently
     # REPLACES the +crt-static rustflags from .cargo/config.toml.
+    #
+    # BAZEL_REMOTE_AUTH is NOT blanked here, unlike the sibling jobs: moon only
+    # skips a task on a cache hit, and a hosted runner starts with an empty local
+    # cache every run, so without the remote there is nothing to hit.
     env:
-      BAZEL_REMOTE_AUTH: ""
       # kache defaults its store to %LOCALAPPDATA% on C:, which on this image is
       # a slow ~29 GB network-attached disk; D: is ~147 GB of fast local storage
       # and already holds target/ (actions/runner-images#12416). Same volume as
@@ -150,17 +153,34 @@ jobs:
       - name: Allow long paths in git
         shell: pwsh
         run: git config --system core.longpaths true
+      # Full history for the same reason build-and-test needs it: moon's vcs
+      # layer resolves vcs.defaultBranch, which a shallow PR checkout lacks.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/windows-bootstrap
         with:
           kache-access-key-id: ${{ secrets.KACHE_S3_ACCESS_KEY }}
           kache-secret-access-key: ${{ secrets.KACHE_S3_SECRET_KEY }}
           manifest-key: windows-verify
 
+      # Pinned to the version .github/actions/bootstrap installs on Linux: the
+      # two share a remote cache, and moon refuses a cache written by another
+      # version. Located by search rather than by guessing the archive layout.
+      - name: Install moon
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $v = '2.4.6'
+          Invoke-WebRequest -Uri "https://github.com/moonrepo/moon/releases/download/v$v/moon_cli-x86_64-pc-windows-msvc.zip" -OutFile moon.zip
+          Expand-Archive moon.zip -DestinationPath C:\moon
+          $dir = (Get-ChildItem C:\moon -Filter moon.exe -Recurse | Select-Object -First 1).DirectoryName
+          $dir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       # Full suite, not a subset: DataFusion, axum and rmcp have no Windows CI
       # anywhere upstream, so this is the first place they ever run on Windows.
       - name: Test
-        run: cargo test --locked --target x86_64-pc-windows-msvc
+        run: moon run pond:test-msvc
 
   # The shipped msvc zip. Release-gated rather than per-PR: it produces an
   # artifact nobody consumes outside a release, and it is the only thing in the

--- a/docs/site/src/pages/get-started/quickstart.mdx
+++ b/docs/site/src/pages/get-started/quickstart.mdx
@@ -25,6 +25,8 @@ pond sync  # import, embed, index - every enabled adapter
 
 `sync` only ingests already-enabled adapters; it never enables on its own. Manage the set with `pond adapters list|discover|enable|disable`.
 
+Discovery is per-platform: adapters are found under `~/` on macOS and Linux, and under `%APPDATA%` / `%LOCALAPPDATA%` on Windows. Nothing to configure either way - `pond init` and `pond adapters discover` look in the right place for the OS they run on.
+
 ## Ask your agent
 
 It searches your history through pond:

--- a/docs/site/src/pages/guides/several-machines.mdx
+++ b/docs/site/src/pages/guides/several-machines.mdx
@@ -10,6 +10,8 @@ Concurrent writers are safe: Lance serializes commits through the object store's
 
 Within one machine, sync is single-flight: a second `pond sync` against the same store waits for the first (naming the holder), and the scheduled run passes `--no-wait` so ticks skip cleanly instead of queueing. `pond status --hosts` shows which machines feed the store - sessions and latest activity per ingest host.
 
+The machines need not share an OS: macOS, Linux, and Windows hosts can all feed one store, and each schedules its own syncs through its native scheduler.
+
 ## Mixed versions
 
 A release that changes the store schema (0.13.0 added materialized tool columns) migrates the store in place the first time the new binary opens it - a one-time backfill with a stderr notice - after which older binaries fail at open with a schema-mismatch error. When several machines share one bucket, upgrade pond on all of them together; a machine left on an older version stops syncing until it upgrades.

--- a/docs/site/src/pages/index.mdx
+++ b/docs/site/src/pages/index.mdx
@@ -2,7 +2,7 @@
 layout: blank
 showTopNav: true
 title: pond - lossless storage and search for AI agent sessions
-description: Pond ingests every AI agent session - Claude Code, Codex, OpenCode, Claude Desktop, Pi - losslessly into storage you own, then makes the whole corpus searchable and SQL-queryable over MCP. One Rust binary, Lance-backed, local by default.
+description: Pond ingests every AI agent session - Claude Code, Codex, OpenCode, OpenClaw, oh-my-pi, Claude Desktop, Pi - losslessly into storage you own, then makes the whole corpus searchable and SQL-queryable over MCP. One Rust binary, Lance-backed, local by default.
 ---
 
 import { HomePage } from 'vocs'
@@ -57,7 +57,7 @@ pond init   # guided setup
 pond sync   # ingest, embed, index
 ```
 
-  <p style={{ fontSize: '0.875rem', opacity: 0.55, margin: 0 }}>Works with Claude Code · Codex CLI · OpenCode · Claude Desktop · Claude.ai · Pi</p>
+  <p style={{ fontSize: '0.875rem', opacity: 0.55, margin: 0 }}>Works with Claude Code · Codex CLI · OpenCode · OpenClaw · oh-my-pi · Claude Desktop · Claude.ai · Pi</p>
 
   <HomePage.Buttons>
     <HomePage.Button href="/get-started/quickstart" variant="accent">Get started</HomePage.Button>

--- a/docs/site/src/pages/index.mdx
+++ b/docs/site/src/pages/index.mdx
@@ -59,6 +59,8 @@ pond sync   # ingest, embed, index
 
   <p style={{ fontSize: '0.875rem', opacity: 0.55, margin: 0 }}>Works with Claude Code · Codex CLI · OpenCode · OpenClaw · oh-my-pi · Claude Desktop · Claude.ai · Pi</p>
 
+  <p style={{ fontSize: '0.875rem', opacity: 0.55, margin: 0 }}>Runs on macOS · Linux · Windows</p>
+
   <HomePage.Buttons>
     <HomePage.Button href="/get-started/quickstart" variant="accent">Get started</HomePage.Button>
     <HomePage.Button href="/why">Why pond?</HomePage.Button>

--- a/docs/site/src/pages/reference/cli.mdx
+++ b/docs/site/src/pages/reference/cli.mdx
@@ -13,7 +13,7 @@ pond <command> --help   # full flags for any command
 - `pond adapters list|discover|enable|disable` - manage which adapters sync ingests
 - `pond storage check|use` - probe a destination; switch the active store
 - `pond creds add|list|delete` - manage URL-scoped credential sets
-- `pond schedule start|stop|status|logs` - manage the automatic sync schedule
+- `pond schedule start|stop|status|logs` - manage the automatic sync schedule (launchd on macOS, systemd user timers or a fenced crontab block on Linux, Task Scheduler on Windows)
 - `pond config show|path|schema` - inspect resolved configuration
 
 ## Data

--- a/packages/pond/moon.yml
+++ b/packages/pond/moon.yml
@@ -31,13 +31,15 @@ tasks:
   lint:
     command: 'cargo clippy --locked -- -D warnings'
     inputs: ['@group(sources)', '@group(tests)']
-  # Mirrored by hand in ci.yml's windows-verify job (tests) as
-  # `cargo test --locked --target x86_64-pc-windows-msvc`. That job cannot run
-  # this task: moon's fingerprint carries no OS, so it would hit the hash the
-  # Linux runner already cached and report "cached" without compiling anything
-  # on Windows. Change the command here, change it there.
   test:
     command: 'cargo test --locked'
+    inputs: ['@group(sources)', '@group(tests)']
+  # The Windows leg. A separate task, not `test` run on a Windows runner:
+  # moon's fingerprint carries no OS, so sharing one task would hit the hash
+  # the Linux runner already cached and report "cached" without compiling
+  # anything on Windows. The differing command is what keeps the two apart.
+  test-msvc:
+    command: 'cargo test --locked --target x86_64-pc-windows-msvc'
     inputs: ['@group(sources)', '@group(tests)']
   # Cheap packaging gate: `cargo package --list` must contain every file the
   # code embeds via include_str!/include_bytes! (a full verify build is skipped


### PR DESCRIPTION
`windows-verify` swings between **17m54s and 51m02s** on an unchanged dependency tree. This changes two things and measures the result.

## What the job's own kache report shows

Across five runs on `feat/windows-adapter-paths`, the same expensive crates flip between hit and miss with no change to `Cargo.lock`:

| Run | Test step | Hit rate | Compiled | Top misses |
|---|---|---|---|---|
| `e780a50` | 22m38 | 98.7% | 10 | `lance`, `lance_index`, `lance_namespace_impls` |
| `43aa072` | 17m54 | 97.5% | 20 | `datafusion_optimizer`, `datafusion_sql`, `datafusion` |
| `26d27e5` | **51m02** | 91.6% | 67 | `lance` **and** the datafusion set **and** `candle_transformers` |
| `2163564` | 38m45 | 90.7% | 74 | same shape |

`lance` missed, then hit, then missed again. `GC: 0 entries evicted` rules out local eviction, and the commits in between touch only `packages/pond/**`, so it is not key instability.

## Cause 1: prefetch is capped far below this graph

kache defaults `KACHE_PREFETCH_MAX_BYTES` to **2GiB** and `KACHE_PREFETCH_DEADLINE_SECS` to **300**. This build is ~790 crates where `lance` alone is 287 MB. Prefetch stops well short, and what it drops is whatever it did not reach - biasing hard toward the largest artifacts. That matches the reported `Prefetch: 0/719 hits (0.0%)` and the size-correlated miss list. Both are set to `0` (unlimited) here.

## Cause 2: the store is on the slow, small disk

kache defaults to `%LOCALAPPDATA%\kache` on `C:`. Per [actions/runner-images#12416](https://github.com/actions/runner-images/issues/12416), `C:` has ~29 GB free and is network-attached, while `D:` has ~147 GB of fast local storage and already holds `target/` (`D:\a\pond\pond`). `KACHE_CACHE_DIR` moves the store to `D:`, which also removes the cross-volume copy the job warns about on every run, and is the precondition for a future `KACHE_WINDOWS_HARDLINK` restore.

## Baseline to beat

```
Test step:         38m 45s
Hit rate:          90.7% count / 76.7% by compile cost (719/793, 74 compiled)
Miss compile work: ~46 min aggregate
Cache hit overhead: ~7 min aggregate, avg 590ms/hit
Prefetch:          0/719 hits (0.0%)
```

Scoped to `windows-verify` only - `windows-dist` is release-gated and keeps the current settings until this is proven.

## Not done here

- `sync: true` on kache-action, which pulls up front via `kache sync --pull`. Kept in reserve: it is the blunt version of the same idea, and worth trying only if uncapping prefetch does not land.
- `KACHE_WINDOWS_HARDLINK`, which needs same-volume (this PR) but carries a corruption risk if a build rewrites a restored output in place.