### PR TITLE
ci: gate winget-publish on the package existing upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -656,7 +656,20 @@ jobs:
     env:
       BAZEL_REMOTE_AUTH: ""
     steps:
-      - uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
+      # winget-releaser hard-fails until the package exists upstream; self-clears once microsoft/winget-pkgs#419055 merges.
+      - id: winget
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          if gh api repos/microsoft/winget-pkgs/contents/manifests/t/tenequm/pond >/dev/null 2>&1; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::winget package tenequm.pond is not yet in microsoft/winget-pkgs (microsoft/winget-pkgs#419055 still open); skipping winget-releaser"
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.winget.outputs.present == 'true'
+        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
           identifier: tenequm.pond
           version: ${{ needs.dist-build.outputs.v }}


### PR DESCRIPTION
Every release currently ends with a red `winget-publish` job: winget-releaser errors with `Package tenequm.pond does not exist in the winget-pkgs repository` because our initial submission, microsoft/winget-pkgs#419055, is still open.

This adds a probe step that checks `manifests/t/tenequm/pond` via `gh api` before invoking the releaser, and gates the releaser on it. When the package is absent the job emits a `::notice::` and finishes green; every releaser input is unchanged.

The gate is self-clearing - once #419055 merges the probe returns 200 and the step runs exactly as before, with no follow-up commit required.
