### PR TITLE
chore: release v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.16.1](https://github.com/tenequm/pond/compare/v0.16.0...v0.16.1) - 2026-08-25
+
+### <!-- 1 -->🎉 New Features
+- bench-gate measures writes and stamps the binary, one row per run ([#183](https://github.com/tenequm/pond/pull/183)) ([ec6dad3](https://github.com/tenequm/pond/commit/ec6dad321c062198ffcebd0bd605305319546bd5))
+
+### <!-- 2 -->🐛 Bug Fixes
+- self-heal the timestamp zonemap after compaction orphans its fragment references ([#185](https://github.com/tenequm/pond/pull/185)) ([eeb2676](https://github.com/tenequm/pond/commit/eeb267667529e31548782889a2338411243a1c5e))
+
+**Full Changelog**: https://github.com/tenequm/pond/compare/v0.16.0...v0.16.1
+
 ## [0.16.0](https://github.com/tenequm/pond/compare/v0.15.1...v0.16.0) - 2026-08-25
 
 Date-scoped search stops full-scanning. The storage engine moves to Lance 10.0.0, and `messages` gains a `timestamp` zonemap that prunes date-bounded queries at the index instead of the table: on a 2.9M-row remote store a served `--from-date` search went from ~2 minutes to 5-6 s (~20x), and the date filter now costs nothing over an unfiltered search instead of +25 s. COUNT pushdown fires under stable row ids too (`pond sql` count 2.1 s -> 1.3 s). Writes are unchanged: a matched-store A/B measured sync at parity on both cold and warm runs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [0.16.1](https://github.com/tenequm/pond/compare/v0.16.0...v0.16.1) - 2026-08-25
 
+Date-filtered search stays correct across compaction. 0.16.0's timestamp zonemap indexes rows by *address* (fragment id plus offset), and Lance never remaps those addresses when compaction rewrites a fragment - it refreshes the index's fragment list while the index body keeps pointing at fragments that no longer exist. Every pond version's compaction does this, 0.16.0's own included. The result was a date-filtered search that either failed outright (`storage_unavailable`, naming a missing fragment) or, once a later index fold cleaned up the dangling references, silently dropped the rewritten rows from its results. Ordinary search, `pond get-session`, `pond get-message`, and `pond sql` were never affected, and no data was ever at risk - the index went stale, the store did not.
+
+pond now checks the index against the store's live fragments at the end of every maintenance run and rebuilds it when they disagree. Because the check runs immediately after compaction, a machine repairs its own damage within the same `pond sync` or `pond optimize`, and picks up another machine's on the next one. The rebuild only fires when compaction actually rewrote indexed fragments.
+
+**Upgrading:** just upgrade - a store that is already broken is repaired by the first `pond sync` or `pond optimize` a 0.16.1 binary runs, with no manual step (`pond optimize --rebuild` still works if you want it now). This is the version that ends the cycle: until every machine writing to a shared store is on 0.16.1, any older binary's compaction can break date filters again, so upgrade the writers, not just the readers.
+
 ### <!-- 1 -->🎉 New Features
 - bench-gate measures writes and stamps the binary, one row per run ([#183](https://github.com/tenequm/pond/pull/183)) ([ec6dad3](https://github.com/tenequm/pond/commit/ec6dad321c062198ffcebd0bd605305319546bd5))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6683,7 +6683,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pond-db"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/packages/pond/Cargo.toml
+++ b/packages/pond/Cargo.toml
@@ -3,7 +3,7 @@
 # crate). The library and binary stay `pond` via [lib]/[[bin]] below, so the
 # command and `use pond::...` are unchanged - only `cargo install pond-db` differs.
 name = "pond-db"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 # MSRV pinned to the toolchain we build and test with (rust-toolchain.toml).
 rust-version = "1.95"


### PR DESCRIPTION
## [0.16.1](https://github.com/tenequm/pond/compare/v0.16.0...v0.16.1) - 2026-08-25

Date-filtered search stays correct across compaction. 0.16.0's timestamp zonemap indexes rows by *address* (fragment id plus offset), and Lance never remaps those addresses when compaction rewrites a fragment - it refreshes the index's fragment list while the index body keeps pointing at fragments that no longer exist. Every pond version's compaction does this, 0.16.0's own included. The result was a date-filtered search that either failed outright (`storage_unavailable`, naming a missing fragment) or, once a later index fold cleaned up the dangling references, silently dropped the rewritten rows from its results. Ordinary search, `pond get-session`, `pond get-message`, and `pond sql` were never affected, and no data was ever at risk - the index went stale, the store did not.

pond now checks the index against the store's live fragments at the end of every maintenance run and rebuilds it when they disagree. Because the check runs immediately after compaction, a machine repairs its own damage within the same `pond sync` or `pond optimize`, and picks up another machine's on the next one. The rebuild only fires when compaction actually rewrote indexed fragments.

**Upgrading:** just upgrade - a store that is already broken is repaired by the first `pond sync` or `pond optimize` a 0.16.1 binary runs, with no manual step (`pond optimize --rebuild` still works if you want it now). This is the version that ends the cycle: until every machine writing to a shared store is on 0.16.1, any older binary's compaction can break date filters again, so upgrade the writers, not just the readers.

### <!-- 1 -->🎉 New Features
- bench-gate measures writes and stamps the binary, one row per run ([#183](https://github.com/tenequm/pond/pull/183)) ([ec6dad3](https://github.com/tenequm/pond/commit/ec6dad321c062198ffcebd0bd605305319546bd5))

### <!-- 2 -->🐛 Bug Fixes
- self-heal the timestamp zonemap after compaction orphans its fragment references ([#185](https://github.com/tenequm/pond/pull/185)) ([eeb2676](https://github.com/tenequm/pond/commit/eeb267667529e31548782889a2338411243a1c5e))

**Full Changelog**: https://github.com/tenequm/pond/compare/v0.16.0...v0.16.1

