### PR TITLE
fix(serve): let /mcp answer on the deployment's own hostname

### DIFF
--- a/docs/site/src/pages/reference/cli.mdx
+++ b/docs/site/src/pages/reference/cli.mdx
@@ -35,6 +35,7 @@ One machine-readable document for scripting. Top-level keys: `initialized` (whet
 
 ## Serve
 - `pond serve --transport http|stdio` - run the API (HTTP default)
+- `pond serve --host 0.0.0.0 --allowed-host <name>` - serve on a reachable address; `/mcp` answers only to loopback plus the `Host` names listed here (repeat the flag, or set `POND_ALLOWED_HOSTS`), `/v1/*` is ungated
 - `pond mcp` - alias for `pond serve --transport stdio`
 - `pond completions <shell>` - shell completion scripts
 - `pond skill` - print the bundled agent-onboarding SKILL.md

--- a/packages/pond/src/main.rs
+++ b/packages/pond/src/main.rs
@@ -733,7 +733,8 @@ pi-coding-agent that is ~/.pi/agent and the files land in sessions/<slug>/.")]
     #[command(after_long_help = "Examples:
   pond serve                       HTTP on 127.0.0.1:9797
   pond serve --port 8080
-  pond serve --transport stdio     same as `pond mcp`")]
+  pond serve --transport stdio     same as `pond mcp`
+  pond serve --host 0.0.0.0 --allowed-host pond.example.com   reached by name")]
     #[command(display_order = 16)]
     Serve {
         /// Wire transport: the HTTP API, or MCP over stdio.
@@ -755,6 +756,22 @@ pi-coding-agent that is ~/.pi/agent and the files land in sessions/<slug>/.")]
             default_value_t = 9797
         )]
         port: u16,
+        /// Public Host value the MCP route also accepts, on top of localhost.
+        ///
+        /// MCP over streamable HTTP validates the Host header against an
+        /// allowlist (the spec's DNS-rebinding defence), and the default list
+        /// is loopback only - so a server reached by any other name answers
+        /// /mcp with 403 until that name is listed here. Repeat the flag, or
+        /// set the env to a comma-separated list. The /v1/* routes are not
+        /// gated this way.
+        #[arg(
+            long = "allowed-host",
+            env = "POND_ALLOWED_HOSTS",
+            hide_env_values = true,
+            value_delimiter = ',',
+            value_name = "HOST"
+        )]
+        allowed_host: Vec<String>,
         /// Also run periodic sync in-process, reusing this server's store and
         /// embedding model (no separate `pond sync` child cold-loading a second
         /// ~500 MB model). Sync output goes to stderr/tracing; stdout stays
@@ -1536,6 +1553,7 @@ async fn run() -> anyhow::Result<()> {
             transport,
             host,
             port,
+            allowed_host,
             with_sync,
             sync_every,
             bootstrap,
@@ -1587,7 +1605,7 @@ async fn run() -> anyhow::Result<()> {
             match transport {
                 ServeTransport::Http => {
                     output(&format!("serve: http listening on http://{host}:{port}"))?;
-                    transport::http::serve(state, host, port).await?;
+                    transport::http::serve(state, host, port, allowed_host).await?;
                 }
                 ServeTransport::Stdio => {
                     eprintln!("serve: stdio MCP ready; stdout is reserved for JSON-RPC");

--- a/packages/pond/src/snapshots/pond__tests__help_serve.snap
+++ b/packages/pond/src/snapshots/pond__tests__help_serve.snap
@@ -27,6 +27,13 @@ Options:
           [env: POND_PORT]
           [default: 9797]
 
+      --allowed-host <HOST>
+          Public Host value the MCP route also accepts, on top of localhost.
+          
+          MCP over streamable HTTP validates the Host header against an allowlist (the spec's DNS-rebinding defence), and the default list is loopback only - so a server reached by any other name answers /mcp with 403 until that name is listed here. Repeat the flag, or set the env to a comma-separated list. The /v1/* routes are not gated this way.
+          
+          [env: POND_ALLOWED_HOSTS]
+
       --with-sync
           Also run periodic sync in-process, reusing this server's store and embedding model (no separate `pond sync` child cold-loading a second ~500 MB model). Sync output goes to stderr/tracing; stdout stays reserved for the transport
 
@@ -64,3 +71,4 @@ Examples:
   pond serve                       HTTP on 127.0.0.1:9797
   pond serve --port 8080
   pond serve --transport stdio     same as `pond mcp`
+  pond serve --host 0.0.0.0 --allowed-host pond.example.com   reached by name

--- a/packages/pond/src/transport.rs
+++ b/packages/pond/src/transport.rs
@@ -57,15 +57,31 @@ pub mod http {
     /// instead of pond's typed `validation_failed`.
     pub const HTTP_BODY_LIMIT_BYTES: usize = 8 * 1024 * 1024;
 
+    /// The `Host` authorities the `/mcp` route answers to: rmcp's loopback
+    /// defaults plus `extra`. The MCP spec (2025-06-18) makes a streamable-HTTP
+    /// server validate `Host` against an allowlist so a browser cannot reach a
+    /// local server by rebinding DNS, and rmcp's default list is loopback only.
+    /// A server reached by any other name therefore answers `/mcp` with 403
+    /// until that name is listed - `/v1/*` carries no such check.
+    fn mcp_allowed_hosts(extra: &[String]) -> Vec<String> {
+        let mut hosts = StreamableHttpServerConfig::default().allowed_hosts;
+        hosts.extend(extra.iter().cloned());
+        hosts
+    }
+
     /// Build the axum router: the `/v1/*` JSON handlers plus the nested `/mcp`
     /// streamable-HTTP MCP service. Public so the integration test can drive it
-    /// without binding a socket.
-    pub fn router(state: AppState) -> Router {
+    /// without binding a socket. `allowed_hosts` extends the `/mcp` route's
+    /// loopback `Host` allowlist (see [`mcp_allowed_hosts`]).
+    pub fn router(state: AppState, allowed_hosts: &[String]) -> Router {
         let mcp_state = state.clone();
         let mcp = StreamableHttpService::new(
             move || Ok(super::mcp::PondMcp::new(mcp_state.clone())),
             LocalSessionManager::default().into(),
-            StreamableHttpServerConfig::default(),
+            // `with_allowed_hosts` replaces the list, so the helper hands it
+            // the defaults plus the extras rather than the extras alone.
+            StreamableHttpServerConfig::default()
+                .with_allowed_hosts(mcp_allowed_hosts(allowed_hosts)),
         );
         Router::new()
             .route("/v1/search", post(search))
@@ -80,7 +96,14 @@ pub mod http {
     /// Bind and serve until ctrl-c. `--port 0` selects an OS-assigned free port;
     /// an unspecified host (`0.0.0.0` / `::`) logs a security notice because the
     /// personal pond is single-user and LAN exposure is opt-in (spec.md#scope).
-    pub async fn serve(state: AppState, host: String, port: u16) -> anyhow::Result<()> {
+    /// `allowed_hosts` names the public authorities the `/mcp` route accepts
+    /// (see [`mcp_allowed_hosts`]).
+    pub async fn serve(
+        state: AppState,
+        host: String,
+        port: u16,
+        allowed_hosts: Vec<String>,
+    ) -> anyhow::Result<()> {
         let ip: IpAddr = host
             .parse()
             .with_context(|| format!("invalid --host {host:?}"))?;
@@ -98,7 +121,7 @@ pub mod http {
             .local_addr()
             .context("failed to read bound address")?;
         tracing::info!(%local, "pond serve listening (HTTP /v1/*, MCP /mcp)");
-        axum::serve(listener, router(state))
+        axum::serve(listener, router(state, &allowed_hosts))
             .with_graceful_shutdown(shutdown_signal())
             .await
             .context("axum server error")
@@ -181,6 +204,37 @@ pub mod http {
             ErrorCode::Conflict => StatusCode::CONFLICT,
             ErrorCode::StorageUnavailable => StatusCode::SERVICE_UNAVAILABLE,
             ErrorCode::Internal => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+        use super::*;
+
+        /// The loopback defaults are never dropped - a hosted `serve` still has
+        /// to answer the local clients that reach it over a tunnel - and the
+        /// deployment's own names are appended in the order given.
+        #[test]
+        fn allowed_hosts_extend_the_loopback_defaults() {
+            let defaults = StreamableHttpServerConfig::default().allowed_hosts;
+            assert!(defaults.contains(&"localhost".to_owned()));
+
+            assert_eq!(mcp_allowed_hosts(&[]), defaults);
+
+            let hosted = mcp_allowed_hosts(&[
+                "pond.example.com".to_owned(),
+                "pond.internal:9797".to_owned(),
+            ]);
+            assert_eq!(&hosted[..defaults.len()], &defaults[..]);
+            assert_eq!(
+                &hosted[defaults.len()..],
+                &[
+                    "pond.example.com".to_owned(),
+                    "pond.internal:9797".to_owned()
+                ]
+            );
         }
     }
 }

--- a/packages/pond/tests/integration/transport_http.rs
+++ b/packages/pond/tests/integration/transport_http.rs
@@ -79,7 +79,83 @@ async fn router() -> anyhow::Result<(TempDir, Arc<Store>, Router)> {
         embedder: Arc::new(pond::embed::LazyEmbedder::from_loaded(Arc::new(backend))),
         search: pond::config::SearchConfig::default(),
     };
-    Ok((temp, store, http::router(state)))
+    Ok((temp, store, http::router(state, &[])))
+}
+
+/// The `/mcp` route validates `Host` against an allowlist (the MCP spec's
+/// DNS-rebinding defence, carried by rmcp) and that list is loopback-only
+/// unless `serve` is told otherwise - so a server reached by its own public
+/// name answers `/mcp` with 403 until that name is passed in. `/v1/*` carries
+/// no such check, which is why a hosted pond can look healthy on the JSON API
+/// while every MCP client is refused.
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_route_gates_on_the_host_allowlist() -> anyhow::Result<()> {
+    pond::embed::init_enabled(true);
+    let temp = TempDir::new()?;
+    let store = Arc::new(Store::open_local(temp.path()).await?);
+    let state = AppState {
+        store,
+        embedder: Arc::new(pond::embed::LazyEmbedder::from_loaded(Arc::new(
+            FakeBackend,
+        ))),
+        search: pond::config::SearchConfig::default(),
+    };
+    let app = http::router(state, &["pond.example.com".to_owned()]);
+
+    let initialize = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "pond-test", "version": "0"},
+        },
+    });
+
+    // Loopback keeps working: the defaults are extended, not replaced.
+    assert_eq!(
+        mcp_status(&app, "localhost", &initialize).await,
+        StatusCode::OK
+    );
+    // The name the deployment actually answers to.
+    assert_eq!(
+        mcp_status(&app, "pond.example.com", &initialize).await,
+        StatusCode::OK
+    );
+    // Anything else is still refused.
+    assert_eq!(
+        mcp_status(&app, "attacker.example.com", &initialize).await,
+        StatusCode::FORBIDDEN
+    );
+
+    // Same rejected `Host`, unrelated route: the JSON API is not gated.
+    let search = json!({"protocol_version": PROTOCOL_VERSION, "query": "anything"});
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/search")
+        .header("host", "attacker.example.com")
+        .header("content-type", "application/json")
+        .body(Body::from(search.to_string()))
+        .unwrap();
+    let status = app.clone().oneshot(request).await.unwrap().status();
+    assert_ne!(status, StatusCode::FORBIDDEN);
+
+    Ok(())
+}
+
+/// `POST /mcp` under one `Host`, reporting only the status - the allowlist is
+/// checked before the request is parsed, so the body never matters here.
+async fn mcp_status(app: &Router, host: &str, body: &Value) -> StatusCode {
+    let request = Request::builder()
+        .method("POST")
+        .uri("/mcp")
+        .header("host", host)
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    app.clone().oneshot(request).await.unwrap().status()
 }
 
 async fn post(app: &Router, path: &str, body: &Value) -> (StatusCode, HeaderMap, Value) {


### PR DESCRIPTION
## Summary

Following up on #194, where you said to file anything that breaks.

Running `pond serve` as a long-lived remote read side works, right up to the
part that matters: every request to `/mcp` comes back `403 Forbidden: Host
header is not allowed` as soon as the server is reached by any name other than
localhost. `POST /v1/search` on the same process answers 200 throughout. So a
hosted pond looks healthy on the JSON API and refuses every MCP client, which
is what made this take a while to pin down.

It is not pond's own code. `router()` builds `StreamableHttpService` with
`StreamableHttpServerConfig::default()`, and rmcp defaults `allowed_hosts` to
`["localhost", "127.0.0.1", "::1"]` as the MCP spec's DNS-rebinding defence.
rmcp's own field doc says public deployments should override that list. pond
never does, and exposes no way to, so there is no hostname that works.

Reproducible against the released binary, no source changes:

```sh
docker run --rm -p 9797:9797 debian:bookworm-slim sh -c '
  apt-get update -qq && apt-get install -y -qq curl xz-utils ca-certificates >/dev/null
  curl -fsSL https://github.com/tenequm/pond/releases/download/v0.16.3/pond-x86_64-unknown-linux-gnu.tar.xz \
    | tar -xJ -C /usr/local/bin pond
  pond sync >/dev/null 2>&1 || true
  pond serve --host 0.0.0.0'

# same process, same body, only the Host differs
curl -s -o /dev/null -w '%{http_code}\n' -X POST localhost:9797/mcp \
  -H 'content-type: application/json' \
  -H 'accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"p","version":"0"}}}'
# 200

curl -s -X POST localhost:9797/mcp -H 'Host: pond.example.com' ...
# Forbidden: Host header is not allowed   (403)

curl -s -o /dev/null -w '%{http_code}\n' -X POST localhost:9797/v1/search \
  -H 'Host: pond.example.com' -H 'content-type: application/json' \
  -d '{"protocol_version":1,"query":"anything"}'
# 200
```

pond logs the cause on the rejected request, which is how I found it:

```
WARN rmcp::transport::streamable_http_server::tower: rejected request with
  disallowed Host header (possible DNS rebinding attempt)
  host=NormalizedAuthority { host: "<the app's own hostname>", port: None }
```

I hit this on a real hosted deploy of `serve` against a remote store, and it
reproduces the same way in plain Docker, behind nginx, and on a Tailscale
hostname. Nothing about it is platform-specific.

## The change

`--allowed-host <HOST>`, repeatable, with `POND_ALLOWED_HOSTS` as the
comma-separated env mirror, matching how `--host` and `--port` already pair
with `POND_HOST` and `POND_PORT`.

The values are appended to rmcp's loopback defaults rather than replacing them,
so a server reached both through a tunnel and by its public name keeps working
on both. `pond serve` with no flag behaves exactly as before, and `/v1/*` is
not gated either way.

```sh
pond serve --host 0.0.0.0 --allowed-host pond.example.com
POND_HOST=0.0.0.0 POND_ALLOWED_HOSTS=pond.example.com pond serve
```

Diff is `transport.rs` (a helper plus the config), the `Serve` command's arg,
one line in `docs/site/src/pages/reference/cli.mdx`, the `serve` help snapshot,
and two tests.

## Deliberately left out

- **No wildcard.** rmcp reads an empty `allowed_hosts` as allow-any and I could
  have surfaced that as `--allowed-host '*'`. It is a footgun and naming the
  host costs one word. Some platforms only assign the hostname after the first
  deploy, which is a real argument for an escape hatch, so say the word if you
  want it and I will add it.
- **No `Origin` handling.** rmcp's `allowed_origins` defaults to empty, which
  disables that check. Turning it on is a separate call and nothing in the
  hosted path needs it.
- **`ops/examples/pi-fleet` untouched.** Its read-side is reached on
  `localhost:9797` from the host, so it is unaffected.

## Tests

- Unit test in `transport.rs`: the loopback defaults survive and the given
  names are appended in order.
- Integration test in `tests/integration/transport_http.rs`: `/mcp` accepts
  loopback and the configured name, 403s anything else, and the same rejected
  `Host` on `/v1/search` is not gated.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` and
`cargo test` are green on 1.95.0.

## Related

Two more things break on a supervised `serve`, both about it never stopping
when asked. They are in #195 rather than here, because one of them has
a design choice in it that is yours to make.

Disclosure: I work on Dockhold, which is where I was running pond when I hit
this.

## Release note

`pond serve` reached by a hostname other than localhost now answers MCP once
you name that host with `--allowed-host` (or `POND_ALLOWED_HOSTS`); without it
the `/mcp` route refuses every request with 403 while `/v1/*` keeps working.
Local use is unchanged.
