### PR TITLE
fix(serve): stop cleanly when a supervisor asks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6747,6 +6747,7 @@ dependencies = [
  "tokenizers",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "toml_edit 0.25.11+spec-1.1.0",
  "tower",

--- a/packages/pond/Cargo.toml
+++ b/packages/pond/Cargo.toml
@@ -173,6 +173,10 @@ thiserror = "2.0.18"
 tokenizers = { version = "0.22", default-features = false, features = ["progressbar", "onig"] }
 tokio = { version = "1.52", features = ["fs", "io-util", "io-std", "macros", "net", "rt", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-stream = "0.1.18"
+# `CancellationToken` for shutdown: cancelling the token rmcp's streamable-HTTP
+# service was built with tears down live MCP sessions, which is what lets axum's
+# graceful shutdown finish. Already in the tree as an rmcp dependency.
+tokio-util = "0.7.18"
 toml = "1.1"
 toml_edit = "0.25"
 tracing = "0.1.44"

--- a/packages/pond/src/transport.rs
+++ b/packages/pond/src/transport.rs
@@ -27,7 +27,11 @@ pub mod http {
     //! `POST /v1/get-message`, and the `/mcp` route carrying rmcp's
     //! streamable-HTTP MCP transport.
 
-    use std::net::{IpAddr, SocketAddr};
+    use std::{
+        future::Future,
+        net::{IpAddr, SocketAddr},
+        time::Duration,
+    };
 
     use anyhow::Context;
     use axum::{
@@ -41,6 +45,7 @@ pub mod http {
         StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
     };
     use tokio::net::TcpListener;
+    use tokio_util::sync::CancellationToken;
 
     use super::AppState;
     use crate::{
@@ -69,11 +74,23 @@ pub mod http {
         hosts
     }
 
+    /// How long shutdown waits after the MCP sessions have been cancelled before
+    /// the process exits regardless. Cancelling the token closes the live
+    /// streams, so the drain normally finishes far inside this; the deadline is
+    /// only a backstop, so that a client which ignores the close cannot hold the
+    /// process open the way an uncancelled stream used to.
+    const SHUTDOWN_DRAIN: Duration = Duration::from_secs(5);
+
     /// Build the axum router: the `/v1/*` JSON handlers plus the nested `/mcp`
     /// streamable-HTTP MCP service. Public so the integration test can drive it
     /// without binding a socket. `allowed_hosts` extends the `/mcp` route's
-    /// loopback `Host` allowlist (see [`mcp_allowed_hosts`]).
-    pub fn router(state: AppState, allowed_hosts: &[String]) -> Router {
+    /// loopback `Host` allowlist (see [`mcp_allowed_hosts`]); cancelling
+    /// `mcp_shutdown` tears down live MCP sessions (see [`serve_with_shutdown`]).
+    pub fn router(
+        state: AppState,
+        allowed_hosts: &[String],
+        mcp_shutdown: CancellationToken,
+    ) -> Router {
         let mcp_state = state.clone();
         let mcp = StreamableHttpService::new(
             move || Ok(super::mcp::PondMcp::new(mcp_state.clone())),
@@ -81,7 +98,8 @@ pub mod http {
             // `with_allowed_hosts` replaces the list, so the helper hands it
             // the defaults plus the extras rather than the extras alone.
             StreamableHttpServerConfig::default()
-                .with_allowed_hosts(mcp_allowed_hosts(allowed_hosts)),
+                .with_allowed_hosts(mcp_allowed_hosts(allowed_hosts))
+                .with_cancellation_token(mcp_shutdown),
         );
         Router::new()
             .route("/v1/search", post(search))
@@ -121,14 +139,82 @@ pub mod http {
             .local_addr()
             .context("failed to read bound address")?;
         tracing::info!(%local, "pond serve listening (HTTP /v1/*, MCP /mcp)");
-        axum::serve(listener, router(state, &allowed_hosts))
-            .with_graceful_shutdown(shutdown_signal())
-            .await
-            .context("axum server error")
+        serve_with_shutdown(listener, state, &allowed_hosts, shutdown_signal()).await
     }
 
+    /// The serving half of [`serve`], with the stop trigger injected. Public so
+    /// the integration test can drive a real socket and a real MCP stream
+    /// without raising a process signal.
+    ///
+    /// Stopping is two-stage, because axum's graceful shutdown waits for every
+    /// in-flight connection and an MCP client holds its `GET /mcp` stream open
+    /// for the life of the session: cancelling the token the streamable-HTTP
+    /// service was built with ends those sessions so the drain can finish, and
+    /// [`SHUTDOWN_DRAIN`] then bounds the wait for anything that ignored it.
+    pub async fn serve_with_shutdown(
+        listener: TcpListener,
+        state: AppState,
+        allowed_hosts: &[String],
+        stop: impl Future<Output = ()> + Send + 'static,
+    ) -> anyhow::Result<()> {
+        let mcp_shutdown = CancellationToken::new();
+        // Fires when `stop` does, so the drain deadline is measured from the
+        // stop request rather than from startup. An un-cancelled token's
+        // `cancelled()` never resolves, which is exactly what keeps the
+        // deadline arm below inert while the server is running normally.
+        let stopping = CancellationToken::new();
+        let server = axum::serve(listener, router(state, allowed_hosts, mcp_shutdown.clone()))
+            .with_graceful_shutdown({
+                let stopping = stopping.clone();
+                async move {
+                    stop.await;
+                    tracing::info!("shutdown: closing MCP sessions, then draining");
+                    mcp_shutdown.cancel();
+                    stopping.cancel();
+                }
+            });
+        tokio::select! {
+            result = server => result.context("axum server error"),
+            () = async move {
+                stopping.cancelled().await;
+                tokio::time::sleep(SHUTDOWN_DRAIN).await;
+            } => {
+                tracing::warn!(
+                    seconds = SHUTDOWN_DRAIN.as_secs(),
+                    "shutdown: connections still open after the drain window; exiting anyway"
+                );
+                Ok(())
+            }
+        }
+    }
+
+    /// Resolve on the first stop request: ctrl-c everywhere, and SIGTERM too on
+    /// unix. SIGTERM is what a container runtime or a service manager sends,
+    /// and a server running as PID 1 gets no default disposition for a signal
+    /// it has not handled - so without this arm `serve` ignored the stop
+    /// outright and was killed when the supervisor's grace period ran out.
     async fn shutdown_signal() {
-        let _ = tokio::signal::ctrl_c().await;
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{SignalKind, signal};
+
+            match signal(SignalKind::terminate()) {
+                Ok(mut terminate) => {
+                    tokio::select! {
+                        _ = tokio::signal::ctrl_c() => {}
+                        _ = terminate.recv() => {}
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "no SIGTERM handler; stopping on ctrl-c only");
+                    let _ = tokio::signal::ctrl_c().await;
+                }
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = tokio::signal::ctrl_c().await;
+        }
     }
 
     async fn search(

--- a/packages/pond/src/transport.rs
+++ b/packages/pond/src/transport.rs
@@ -74,12 +74,22 @@ pub mod http {
         hosts
     }
 
-    /// How long shutdown waits after the MCP sessions have been cancelled before
-    /// the process exits regardless. Cancelling the token closes the live
-    /// streams, so the drain normally finishes far inside this; the deadline is
-    /// only a backstop, so that a client which ignores the close cannot hold the
-    /// process open the way an uncancelled stream used to.
-    const SHUTDOWN_DRAIN: Duration = Duration::from_secs(5);
+    /// How long [`serve_with_shutdown`] waits, after the MCP sessions have been
+    /// cancelled, before returning regardless. Cancelling the token closes the
+    /// live streams, so the drain normally finishes far inside this; the
+    /// deadline is only a backstop, so that a client which ignores the close
+    /// cannot hold the process open the way an uncancelled stream used to. It
+    /// bounds this function's return, not the process: `main` still drops the
+    /// runtime afterwards, which waits on `spawn_blocking` work already started.
+    ///
+    /// Returning on the deadline can truncate an in-flight `POST /v1/ingest`
+    /// between commits, since messages and parts commit before the session row:
+    /// a stop landing in that gap leaves message rows whose session row is not
+    /// written yet. Every Lance commit is atomic and the next ingest of that
+    /// session rewrites the missing row, so the store converges. The bound stays
+    /// anyway - exempting ingest would leave the drain unbounded in exactly the
+    /// case that can hold the process open.
+    pub const SHUTDOWN_DRAIN: Duration = Duration::from_secs(5);
 
     /// Build the axum router: the `/v1/*` JSON handlers plus the nested `/mcp`
     /// streamable-HTTP MCP service. Public so the integration test can drive it
@@ -158,25 +168,22 @@ pub mod http {
         stop: impl Future<Output = ()> + Send + 'static,
     ) -> anyhow::Result<()> {
         let mcp_shutdown = CancellationToken::new();
-        // Fires when `stop` does, so the drain deadline is measured from the
-        // stop request rather than from startup. An un-cancelled token's
-        // `cancelled()` never resolves, which is exactly what keeps the
-        // deadline arm below inert while the server is running normally.
-        let stopping = CancellationToken::new();
         let server = axum::serve(listener, router(state, allowed_hosts, mcp_shutdown.clone()))
             .with_graceful_shutdown({
-                let stopping = stopping.clone();
+                let mcp_shutdown = mcp_shutdown.clone();
                 async move {
                     stop.await;
                     tracing::info!("shutdown: closing MCP sessions, then draining");
                     mcp_shutdown.cancel();
-                    stopping.cancel();
                 }
             });
         tokio::select! {
             result = server => result.context("axum server error"),
+            // rmcp only ever derives `child_token()` from this token and never
+            // cancels it, so it resolves exactly when the arm above cancels it:
+            // the deadline runs from the stop request, not from startup.
             () = async move {
-                stopping.cancelled().await;
+                mcp_shutdown.cancelled().await;
                 tokio::time::sleep(SHUTDOWN_DRAIN).await;
             } => {
                 tracing::warn!(

--- a/packages/pond/tests/integration/transport_http.rs
+++ b/packages/pond/tests/integration/transport_http.rs
@@ -3,9 +3,16 @@
 //! HTTP+JSON transport (spec.md#protocol, spec.md#protocol):
 //! `POST /v1/search`, `POST /v1/get-session`, and `POST /v1/get-message`
 //! are thin adapters over the shared wire handlers. The router is driven via
-//! `tower::ServiceExt::oneshot` - no socket bind, no HTTP client dependency.
+//! `tower::ServiceExt::oneshot` - no HTTP client dependency. The exception is
+//! `shutdown_completes_while_an_mcp_stream_is_open`, which does bind a socket:
+//! the hang it covers is in the connection drain, and `oneshot` never opens a
+//! connection to drain.
 
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{
+    net::SocketAddr,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use axum::{
     Router,
@@ -90,6 +97,20 @@ async fn router() -> anyhow::Result<(TempDir, Arc<Store>, Router)> {
     ))
 }
 
+/// An `AppState` over an empty store, for the tests that never read a row: the
+/// fixture corpus [`router`] ingests would only add cost to them.
+async fn empty_state(temp: &TempDir) -> anyhow::Result<AppState> {
+    // The vector arm is refused unless this instance opted in.
+    pond::embed::init_enabled(true);
+    Ok(AppState {
+        store: Arc::new(Store::open_local(temp.path()).await?),
+        embedder: Arc::new(pond::embed::LazyEmbedder::from_loaded(Arc::new(
+            FakeBackend,
+        ))),
+        search: pond::config::SearchConfig::default(),
+    })
+}
+
 /// Shutdown has to finish while an MCP client is attached. axum's graceful
 /// shutdown waits for every in-flight connection, and a streamable-HTTP client
 /// holds its `GET /mcp` stream open for the whole session, so before the
@@ -98,16 +119,8 @@ async fn router() -> anyhow::Result<(TempDir, Arc<Store>, Router)> {
 /// `oneshot` against the `Router` never binds one.
 #[tokio::test(flavor = "multi_thread")]
 async fn shutdown_completes_while_an_mcp_stream_is_open() -> anyhow::Result<()> {
-    pond::embed::init_enabled(true);
     let temp = TempDir::new()?;
-    let store = Arc::new(Store::open_local(temp.path()).await?);
-    let state = AppState {
-        store,
-        embedder: Arc::new(pond::embed::LazyEmbedder::from_loaded(Arc::new(
-            FakeBackend,
-        ))),
-        search: pond::config::SearchConfig::default(),
-    };
+    let state = empty_state(&temp).await?;
 
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
@@ -134,20 +147,34 @@ async fn shutdown_completes_while_an_mcp_stream_is_open() -> anyhow::Result<()> 
     .await?;
     // Guard against this test quietly going vacuous: if the stream were ever
     // refused, the connection would close and shutdown would finish for the
-    // wrong reason. With the session cancel removed, this test takes the full
-    // SHUTDOWN_DRAIN instead of milliseconds, which is what proves the open
-    // stream is really what blocks the drain.
+    // wrong reason, still green.
     assert!(
-        head.starts_with("HTTP/1.1 200"),
+        head.starts_with("HTTP/1.1 200")
+            && head
+                .to_ascii_lowercase()
+                .contains("content-type: text/event-stream"),
         "the /mcp stream has to be established for this test to mean anything:\n{head}"
     );
 
+    let started = Instant::now();
     stop.send(()).expect("serve task should still be running");
 
     let served = tokio::time::timeout(Duration::from_secs(30), server)
         .await
         .expect("serve must stop while a client holds its /mcp stream open")?;
     served?;
+
+    // This is what pins the session teardown rather than the backstop. Drop
+    // `.with_cancellation_token(..)` in transport.rs and the deadline arm still
+    // returns `Ok(())`, just after SHUTDOWN_DRAIN, so every assertion above
+    // stays green; bounding the elapsed time is what fails.
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < http::SHUTDOWN_DRAIN,
+        "shutdown took {elapsed:?}, so the drain deadline returned rather than \
+         the MCP session teardown letting it finish inside SHUTDOWN_DRAIN ({:?})",
+        http::SHUTDOWN_DRAIN
+    );
     drop(stream);
     Ok(())
 }
@@ -190,17 +217,27 @@ async fn mcp_session(addr: SocketAddr) -> anyhow::Result<String> {
 /// rather than through a client crate: the point is to own the socket and
 /// decide when it closes, which is what this test is about.
 async fn request(stream: &mut TcpStream, raw: &str) -> anyhow::Result<String> {
-    stream.write_all(raw.as_bytes()).await?;
-    let mut head = Vec::new();
-    let mut byte = [0_u8; 1];
-    while !head.ends_with(b"\r\n\r\n") {
-        if stream.read(&mut byte).await? == 0 {
-            anyhow::bail!("connection closed before the response head was complete");
+    // Deadlined: the read below has no natural end, so a regression that stalls
+    // before emitting headers would hang this test until the CI runner's limit
+    // instead of failing it.
+    tokio::time::timeout(RESPONSE_HEAD_TIMEOUT, async {
+        stream.write_all(raw.as_bytes()).await?;
+        let mut head = Vec::new();
+        let mut byte = [0_u8; 1];
+        while !head.ends_with(b"\r\n\r\n") {
+            if stream.read(&mut byte).await? == 0 {
+                anyhow::bail!("connection closed before the response head was complete");
+            }
+            head.push(byte[0]);
         }
-        head.push(byte[0]);
-    }
-    Ok(String::from_utf8_lossy(&head).into_owned())
+        Ok(String::from_utf8_lossy(&head).into_owned())
+    })
+    .await
+    .map_err(|_| anyhow::anyhow!("timed out waiting for a response head"))?
 }
+
+/// Deadline on one request/response head (see [`request`]).
+const RESPONSE_HEAD_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// The `/mcp` route validates `Host` against an allowlist (the MCP spec's
 /// DNS-rebinding defence, carried by rmcp) and that list is loopback-only
@@ -210,16 +247,8 @@ async fn request(stream: &mut TcpStream, raw: &str) -> anyhow::Result<String> {
 /// while every MCP client is refused.
 #[tokio::test(flavor = "multi_thread")]
 async fn mcp_route_gates_on_the_host_allowlist() -> anyhow::Result<()> {
-    pond::embed::init_enabled(true);
     let temp = TempDir::new()?;
-    let store = Arc::new(Store::open_local(temp.path()).await?);
-    let state = AppState {
-        store,
-        embedder: Arc::new(pond::embed::LazyEmbedder::from_loaded(Arc::new(
-            FakeBackend,
-        ))),
-        search: pond::config::SearchConfig::default(),
-    };
+    let state = empty_state(&temp).await?;
     let app = http::router(
         state,
         &["pond.example.com".to_owned()],

--- a/packages/pond/tests/integration/transport_http.rs
+++ b/packages/pond/tests/integration/transport_http.rs
@@ -5,7 +5,7 @@
 //! are thin adapters over the shared wire handlers. The router is driven via
 //! `tower::ServiceExt::oneshot` - no socket bind, no HTTP client dependency.
 
-use std::sync::Arc;
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use axum::{
     Router,
@@ -24,6 +24,10 @@ use pond::{
 };
 use serde_json::{Value, json};
 use tempfile::TempDir;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+};
 use tower::ServiceExt;
 
 const FIXTURES: &str = "tests/fixtures/adapter/claude_code/projects";
@@ -79,7 +83,123 @@ async fn router() -> anyhow::Result<(TempDir, Arc<Store>, Router)> {
         embedder: Arc::new(pond::embed::LazyEmbedder::from_loaded(Arc::new(backend))),
         search: pond::config::SearchConfig::default(),
     };
-    Ok((temp, store, http::router(state, &[])))
+    Ok((
+        temp,
+        store,
+        http::router(state, &[], tokio_util::sync::CancellationToken::new()),
+    ))
+}
+
+/// Shutdown has to finish while an MCP client is attached. axum's graceful
+/// shutdown waits for every in-flight connection, and a streamable-HTTP client
+/// holds its `GET /mcp` stream open for the whole session, so before the
+/// session cancel this hung until the supervisor killed the process. Driven
+/// over a real socket, because the hang is in the connection drain and a
+/// `oneshot` against the `Router` never binds one.
+#[tokio::test(flavor = "multi_thread")]
+async fn shutdown_completes_while_an_mcp_stream_is_open() -> anyhow::Result<()> {
+    pond::embed::init_enabled(true);
+    let temp = TempDir::new()?;
+    let store = Arc::new(Store::open_local(temp.path()).await?);
+    let state = AppState {
+        store,
+        embedder: Arc::new(pond::embed::LazyEmbedder::from_loaded(Arc::new(
+            FakeBackend,
+        ))),
+        search: pond::config::SearchConfig::default(),
+    };
+
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let (stop, stopped) = tokio::sync::oneshot::channel::<()>();
+    let server = tokio::spawn(async move {
+        http::serve_with_shutdown(listener, state, &[], async move {
+            let _ = stopped.await;
+        })
+        .await
+    });
+
+    let session = mcp_session(addr).await?;
+    // Hold it: an initialized session's `GET /mcp` is the long-lived SSE stream
+    // a connected agent keeps open. Reading the head proves it is established;
+    // the socket then stays in scope, unread and unclosed, across the shutdown.
+    let mut stream = TcpStream::connect(addr).await?;
+    let head = request(
+        &mut stream,
+        &format!(
+            "GET /mcp HTTP/1.1\r\nHost: localhost\r\nAccept: text/event-stream\r\n\
+             Mcp-Session-Id: {session}\r\n\r\n"
+        ),
+    )
+    .await?;
+    // Guard against this test quietly going vacuous: if the stream were ever
+    // refused, the connection would close and shutdown would finish for the
+    // wrong reason. With the session cancel removed, this test takes the full
+    // SHUTDOWN_DRAIN instead of milliseconds, which is what proves the open
+    // stream is really what blocks the drain.
+    assert!(
+        head.starts_with("HTTP/1.1 200"),
+        "the /mcp stream has to be established for this test to mean anything:\n{head}"
+    );
+
+    stop.send(()).expect("serve task should still be running");
+
+    let served = tokio::time::timeout(Duration::from_secs(30), server)
+        .await
+        .expect("serve must stop while a client holds its /mcp stream open")?;
+    served?;
+    drop(stream);
+    Ok(())
+}
+
+/// Initialize an MCP session over a fresh connection and return its id.
+async fn mcp_session(addr: SocketAddr) -> anyhow::Result<String> {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "pond-test", "version": "0"},
+        },
+    })
+    .to_string();
+    let mut stream = TcpStream::connect(addr).await?;
+    let head = request(
+        &mut stream,
+        &format!(
+            "POST /mcp HTTP/1.1\r\nHost: localhost\r\n\
+             Content-Type: application/json\r\n\
+             Accept: application/json, text/event-stream\r\n\
+             Content-Length: {}\r\n\r\n{body}",
+            body.len()
+        ),
+    )
+    .await?;
+    head.lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("mcp-session-id")
+                .then(|| value.trim().to_owned())
+        })
+        .ok_or_else(|| anyhow::anyhow!("no mcp-session-id in response head:\n{head}"))
+}
+
+/// Write one raw HTTP/1.1 request and read back just the response head. Raw
+/// rather than through a client crate: the point is to own the socket and
+/// decide when it closes, which is what this test is about.
+async fn request(stream: &mut TcpStream, raw: &str) -> anyhow::Result<String> {
+    stream.write_all(raw.as_bytes()).await?;
+    let mut head = Vec::new();
+    let mut byte = [0_u8; 1];
+    while !head.ends_with(b"\r\n\r\n") {
+        if stream.read(&mut byte).await? == 0 {
+            anyhow::bail!("connection closed before the response head was complete");
+        }
+        head.push(byte[0]);
+    }
+    Ok(String::from_utf8_lossy(&head).into_owned())
 }
 
 /// The `/mcp` route validates `Host` against an allowlist (the MCP spec's
@@ -100,7 +220,11 @@ async fn mcp_route_gates_on_the_host_allowlist() -> anyhow::Result<()> {
         ))),
         search: pond::config::SearchConfig::default(),
     };
-    let app = http::router(state, &["pond.example.com".to_owned()]);
+    let app = http::router(
+        state,
+        &["pond.example.com".to_owned()],
+        tokio_util::sync::CancellationToken::new(),
+    );
 
     let initialize = json!({
         "jsonrpc": "2.0",


### PR DESCRIPTION
## Summary

Closes #195, both parts, in the shape you asked for.

**SIGTERM.** `shutdown_signal` awaited `ctrl_c` only, which on unix is SIGINT.
It now selects over SIGINT and SIGTERM, and falls back to ctrl-c alone (with a
warning) if the SIGTERM handler cannot be installed. `cfg(not(unix))` is
unchanged.

**The drain.** Option 1, as you picked. `serve` builds a `CancellationToken`,
hands it to `StreamableHttpServerConfig::with_cancellation_token`, and cancels
it when the stop signal fires, so live MCP sessions are torn down and axum's
graceful shutdown can finish on its own. A 5 second bounded drain sits behind
that as the backstop, so a client that ignores the close cannot hold the
process open either.

`tokio-util` is now a direct dependency. It was already in the tree via rmcp,
so the lockfile gains exactly one line and no version moves.

## Shape of the change

`serve` splits in two. It still binds, logs, and owns the signal handler, then
hands off to `serve_with_shutdown(listener, state, allowed_hosts, stop)`, which
takes the stop trigger as a future. That is what lets the test drive a real
socket and a real MCP stream without raising a process signal inside the test
binary.

## Test

`shutdown_completes_while_an_mcp_stream_is_open` in
`tests/integration/transport_http.rs`, over a real loopback socket rather than
`oneshot` against the `Router`, because the hang was in the connection drain
and `oneshot` never binds one.

It initializes an MCP session, opens `GET /mcp`, asserts the response head is
a 200 `text/event-stream`, then holds the socket unread and unclosed across the
shutdown and asserts `serve_with_shutdown` returns.

The 200 assertion is there because the test is easy to make vacuous: if the
stream were ever refused, the connection would close and shutdown would finish
for the wrong reason, still green. The control that convinced me it is real is
removing the `cancel()` and leaving everything else alone:

```
with the session cancel      0.02 s
cancel removed, backstop only 5.03 s   (SHUTDOWN_DRAIN)
```

So the open stream genuinely is what blocks the drain, the cancel is what
clears it, and the backstop catches the case where a client ignores the close.
The comment on the assertion names that control so the next person can rerun
it.

The requests are written to the socket by hand. pond has no HTTP client
dependency and this needs to own the socket and decide when it closes, which
is the whole point of the test, so a client crate would have been both a new
dependency and less precise about the thing under test.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` and
`cargo test` are green on 1.95.0.

Disclosure: I am the founder of Dockhold, which is where I was running pond
when I hit both of these. Neither is specific to it.

## Release note

`pond serve` now stops when a supervisor asks it to. It handles SIGTERM as well
as ctrl-c, and shutdown no longer hangs when an agent is connected: live MCP
sessions are closed and the drain is bounded, so restarts finish instead of
waiting for the process to be killed.

