### PR TITLE
docs(guides): add a Dockhold worked example to the remote serve guide

### DIFF
--- a/docs/site/src/pages/guides/remote-serve.mdx
+++ b/docs/site/src/pages/guides/remote-serve.mdx
@@ -71,3 +71,50 @@ curl -sS -o /dev/null -w '%{http_code}\n' -X POST https://pond.example.com/mcp -
 ```
 
 The first returns a search envelope; the second prints `200`. A `403` on the second with a `200` on the first means the hostname is missing from `POND_ALLOWED_HOSTS`.
+
+## Worked example: Dockhold
+
+[Dockhold](https://dockhold.eu) builds the `Dockerfile` in a repo and puts it on an always-on HTTPS URL, with no servers to manage and hosting in the EU. Always-on is the part that earns its place here: the warm row map and the reused S3 client are exactly what make one long-lived `serve` faster than many cold ones, and a host that sleeps an idle app throws both away. Worth checking against whatever host you pick.
+
+The whole repo is one `Dockerfile`:
+
+```dockerfile
+FROM debian:bookworm-slim
+ARG POND_VERSION=latest
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl xz-utils; \
+    case "$(dpkg --print-architecture)" in \
+      amd64) target=x86_64-unknown-linux-gnu ;; \
+      arm64) target=aarch64-unknown-linux-gnu ;; \
+      *) echo "unsupported architecture" >&2; exit 1 ;; \
+    esac; \
+    if [ "$POND_VERSION" = "latest" ]; then \
+      base=https://github.com/tenequm/pond/releases/latest/download; \
+    else \
+      base="https://github.com/tenequm/pond/releases/download/v${POND_VERSION}"; \
+    fi; \
+    curl -fsSL "${base}/pond-${target}.tar.xz" | tar -xJ -C /usr/local/bin pond; \
+    apt-get purge -y --auto-remove curl xz-utils; \
+    rm -rf /var/lib/apt/lists/*
+
+ENV XDG_CACHE_HOME=/tmp/pond-cache
+CMD exec pond serve --host 0.0.0.0 --port ${PORT:-9797}
+```
+
+Three things in that `CMD`. The port is assigned at runtime, so it is shell form, to expand `$PORT`. `exec` matters as much: without it the shell stays PID 1, the platform's stop signal never reaches pond, and the clean stop above turns back into a kill. And the container runs as an arbitrary uid with no writable home, which is what `XDG_CACHE_HOME` is for.
+
+Connect the repo, then set four variables. The bucket URL is plain configuration; the two credentials go in the Vault, which encrypts them and injects them at runtime:
+
+| Variable | Where |
+| --- | --- |
+| `POND_STORAGE_PATH` | Variables |
+| `POND_CREDS_DEFAULT_ACCESS_KEY_ID` | Vault |
+| `POND_CREDS_DEFAULT_SECRET_ACCESS_KEY` | Vault |
+| `POND_ALLOWED_HOSTS` | Variables, on a second pass |
+
+`POND_ALLOWED_HOSTS` comes second because the served hostname only exists once the app does. Deploy, read the hostname off the dashboard, set it, let it roll out again. In between the app shows exactly the split described above: `/v1/search` answers and every `/mcp` request is a 403.
+
+For the gate, turn the app private. Every request then needs a token at the edge and gets a `401` without one, which covers "put auth in front" without running a proxy of your own. The boundary that creates is worth stating plainly: requests terminate TLS at the platform before they reach pond, and the token belongs to the app rather than to anything pond knows about.
+
+`PORT` is set by the platform, so read it and never define it. The filesystem is ephemeral, which suits a read side whose data lives in the bucket, though it does mean the cache starts cold after every deploy until the row map is warm again.


### PR DESCRIPTION
## Summary

Takes you up on the offer in #194: one section at the end of
`guides/remote-serve`, after the platform-neutral body. Nothing above it
changes, and the page still reads as host-agnostic with this appended.

It maps your five steps onto one host and adds nothing conceptual: the
`Dockerfile`, which of the four variables is plain config and which two are
secrets, why `POND_ALLOWED_HOSTS` needs a second pass, and the edge token gate
standing in for "put auth in front".

Two details in it are there because they cost me time rather than because they
are interesting:

- `exec` in the `CMD`. Without it the shell stays PID 1, the stop signal never
  reaches pond, and the clean stop you just documented in #198 quietly turns
  back into a kill. Shell form is still needed to expand the injected `$PORT`,
  so it has to be `CMD exec ...`.
- The hostname does not exist until the app does, so `POND_ALLOWED_HOSTS` can
  only be set on a second pass. In between you get precisely the split your
  page describes: `/v1/search` answering and `/mcp` on 403.

I also stated the trust boundary of the edge gate against myself, since the
page is right that `serve` has no auth of its own and a reader deserves to
know that TLS terminates at the platform before the request reaches pond.

Written in the page's voice, third person, no first-person disclosure baked
into the docs. Prose is ASCII, no em-dashes, and the section is plain markdown
with one table so the MDX compiles as-is. I could not run `pnpm build` here
(no `node_modules` in the checkout), so a rendering check on your side is worth
one look.

On what is verified: I have deployed pond on Dockhold and confirmed the 403 and
the `/v1` split on the real edge, and I verified `POND_ALLOWED_HOSTS` and the
five-second drain against a live S3 store locally. What I have not run is that
exact pair together on the platform, because the `--allowed-host` flag only
ships in the next release. Say the word and I will hold this until after the
release and re-run it end to end first.

Happy to cut anything that reads as too much, or to drop the section entirely
if it has stopped feeling worth the page space.

Disclosure: I am the founder of Dockhold.

## Release note

