### PR TITLE
chore: release v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.17.1](https://github.com/tenequm/pond/compare/v0.17.0...v0.17.1) - 2026-09-09
+
+### <!-- 2 -->🐛 Bug Fixes
+- **mcp:** support stdio discovery startup ([#223](https://github.com/tenequm/pond/pull/223)) ([d0294af](https://github.com/tenequm/pond/commit/d0294af714c37f3d1b099639719cfc3840aac4fb))
+  Pond's stdio MCP server now supports the modern discovery startup used
+  by dual-era clients such as Antigravity while remaining compatible with
+  legacy MCP clients. No HTTP daemon or port workaround is needed.
+
+### <!-- 5 -->📚 Documentation
+- **readme:** add the vote-gated format-contract row to the roadmap ([e3073cb](https://github.com/tenequm/pond/commit/e3073cb40186848568ffd239fa2b27df07526d4a))
+- **readme:** roadmap after v0.17.0 - step 9 shipped, namespaces in progress, herdr plugin #219, Antigravity CLI replaces Gemini CLI ([ac08614](https://github.com/tenequm/pond/commit/ac0861454424937ce0b78ae1796a44e802d749d1))
+
+**Full Changelog**: https://github.com/tenequm/pond/compare/v0.17.0...v0.17.1
+
 ## [0.17.0](https://github.com/tenequm/pond/compare/v0.16.3...v0.17.0) - 2026-09-01
 
 ### <!-- 0 -->🛠 Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6766,7 +6766,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pond-db"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/packages/pond/Cargo.toml
+++ b/packages/pond/Cargo.toml
@@ -3,7 +3,7 @@
 # crate). The library and binary stay `pond` via [lib]/[[bin]] below, so the
 # command and `use pond::...` are unchanged - only `cargo install pond-db` differs.
 name = "pond-db"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2024"
 # MSRV pinned to the toolchain we build and test with (rust-toolchain.toml).
 rust-version = "1.95"


### PR DESCRIPTION



## 🤖 New release

* `pond-db`: 0.17.0 -> 0.17.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.17.1](https://github.com/tenequm/pond/compare/v0.17.0...v0.17.1) - 2026-09-09

### <!-- 2 -->🐛 Bug Fixes
- **mcp:** support stdio discovery startup ([#223](https://github.com/tenequm/pond/pull/223)) ([d0294af](https://github.com/tenequm/pond/commit/d0294af714c37f3d1b099639719cfc3840aac4fb))
  Pond's stdio MCP server now supports the modern discovery startup used
  by dual-era clients such as Antigravity while remaining compatible with
  legacy MCP clients. No HTTP daemon or port workaround is needed.

### <!-- 5 -->📚 Documentation
- **readme:** add the vote-gated format-contract row to the roadmap ([e3073cb](https://github.com/tenequm/pond/commit/e3073cb40186848568ffd239fa2b27df07526d4a))
- **readme:** roadmap after v0.17.0 - step 9 shipped, namespaces in progress, herdr plugin #219, Antigravity CLI replaces Gemini CLI ([ac08614](https://github.com/tenequm/pond/commit/ac0861454424937ce0b78ae1796a44e802d749d1))

**Full Changelog**: https://github.com/tenequm/pond/compare/v0.17.0...v0.17.1
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).