### PR TITLE
fix(release): make the published tap formula pass brew style

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -654,7 +654,7 @@ jobs:
           # frozen_string_literal: true
 
           class Pond < Formula
-            desc "Lossless storage, full-text search, and optional semantic search for sessions from any AI agent client"
+            desc "Lossless storage and full-text/semantic search for AI agent sessions"
             homepage "https://pond.locker/"
             license "Apache-2.0"
 
@@ -666,10 +666,12 @@ jobs:
 
             on_macos do
               # Apple Silicon only: there is no x86_64-apple-darwin build, so
-              # depends_on refuses Intel before any download is attempted.
+              # the arch dependency refuses Intel before any download is attempted.
               depends_on arch: :arm64
-              url "$base/pond-aarch64-apple-darwin.tar.xz"
-              sha256 "$(sha aarch64-apple-darwin)"
+              on_arm do
+                url "$base/pond-aarch64-apple-darwin.tar.xz"
+                sha256 "$(sha aarch64-apple-darwin)"
+              end
             end
 
             on_linux do


### PR DESCRIPTION
`brew style tenequm/tap` reports three offenses in `Formula/pond.rb`, all originating from the heredoc this workflow publishes:

- `FormulaAudit/Desc`: description is 102 characters, limit 80 - shortened to "Lossless storage and full-text/semantic search for AI agent sessions".
- `FormulaAudit/ComponentsOrder` (x2): `url`/`sha256` cannot sit directly inside `on_macos`; nested them in `on_arm do` (matching the existing `on_linux` shape). The `depends_on arch: :arm64` Intel guard is unchanged.
- `FormulaAudit/Comments`: the comment line starting with `# depends_on` parses as commented-out code - reworded.

The same final content is applied directly to the tap so its CI goes green without waiting for the next pond release; this change keeps it from regressing then.

## Release notes

The Homebrew formula published to tenequm/homebrew-tap now passes `brew style`: shorter description, the macOS url/sha256 nested under `on_arm`, and a reworded comment.
