### PR TITLE
fix(mcp): support stdio discovery startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -458,7 +458,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -469,7 +469,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -852,7 +852,7 @@ checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1184,7 +1184,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1463,7 +1463,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1993,6 +1993,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2003,7 +2013,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2016,7 +2026,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2027,7 +2050,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2038,7 +2061,18 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core 0.24.1",
+ "quote",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2497,7 +2531,7 @@ checksum = "1a3614234dd93578c92428cb4f408e020874f0d2b7e6c90c928d9d28b5df2ceb"
 dependencies = [
  "datafusion-doc",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2690,7 +2724,7 @@ dependencies = [
  "defmt-parser",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2741,7 +2775,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2751,7 +2785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2825,7 +2859,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2946,7 +2980,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3141,7 +3175,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3262,7 +3296,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3755,7 +3789,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4584,7 +4618,7 @@ dependencies = [
  "jiff-core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4629,7 +4663,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4648,7 +4682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4925,7 +4959,7 @@ checksum = "13e5e95e0fd3d74f7938f4bee623041421b323b5c61f242c8622a1f48a202527"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5724,7 +5758,7 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5929,7 +5963,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6590,7 +6624,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6671,7 +6705,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6886,7 +6920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6915,7 +6949,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "version_check",
  "yansi",
 ]
@@ -6945,7 +6979,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -6959,7 +6993,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7321,7 +7355,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7641,18 +7675,19 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "42b6914fac0be956fe704a38239c3f44a9f841d1b06a5713d2f638065593f5b5"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "futures",
  "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
+ "indexmap 2.14.0",
  "pastey",
  "pin-project-lite",
  "rand 0.10.1",
@@ -7672,15 +7707,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "cdf1c49bd4d52014b94db0877410db273c2008f01628b0252a2e9460ad9b7fda"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.1",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -8060,7 +8095,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8148,7 +8183,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8159,7 +8194,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8203,7 +8238,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8265,7 +8300,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8438,7 +8473,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8538,14 +8573,14 @@ checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "sse-stream"
-version = "0.2.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+checksum = "c25ac7aff0abd1dbc474536e40416e1102c7dd9bfba0b9861c6d357f835dcfb4"
 dependencies = [
  "bytes",
  "futures-util",
@@ -8631,7 +8666,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8669,6 +8704,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8685,7 +8731,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8805,7 +8851,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8816,7 +8862,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8973,7 +9019,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9241,7 +9287,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9700,7 +9746,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -9920,7 +9966,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9931,7 +9977,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10204,7 +10250,7 @@ dependencies = [
  "heck",
  "indexmap 2.14.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -10220,7 +10266,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -10498,7 +10544,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -10510,7 +10556,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -10531,7 +10577,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10551,7 +10597,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -10572,7 +10618,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10607,7 +10653,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/packages/pond/Cargo.toml
+++ b/packages/pond/Cargo.toml
@@ -241,7 +241,7 @@ lance-linalg = "11.0.0"
 # The `protoc` feature is activated via the non-Windows per-target gate below.
 lance = { version = "11.0.0" }
 lance-index = "11.0.0"
-# Re-declared so the MCP integration test can drive the server in-process via the `client` feature.
+# Re-declared so the MCP tests can drive the server in-process via the `client` feature.
 rmcp = { version = "3.2.0", features = ["client"] }
 # Re-declared so the opencode real-corpus restore oracle can read the source SQLite DB directly.
 rusqlite = { version = "0.40", features = ["bundled"] }

--- a/packages/pond/Cargo.toml
+++ b/packages/pond/Cargo.toml
@@ -153,7 +153,7 @@ object_store = { version = "0.13", default-features = false }
 # crate the SQL tool adds (lance reads/writes its own format, not parquet).
 # `arrow` feature only; results are written uncompressed via `ArrowWriter`.
 parquet = { version = "58.3", default-features = false, features = ["arrow"] }
-rmcp = { version = "1.7", features = ["transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "3.2.0", features = ["transport-io", "transport-streamable-http-server"] }
 # Already in the tree via lance-table (`IndexMetadata::fragment_bitmap`); named
 # directly so the address-domain staleness probe can compare fragment bitmaps
 # with set ops instead of decomposing them into hash sets.
@@ -242,7 +242,7 @@ lance-linalg = "11.0.0"
 lance = { version = "11.0.0" }
 lance-index = "11.0.0"
 # Re-declared so the MCP integration test can drive the server in-process via the `client` feature.
-rmcp = { version = "1.7", features = ["client"] }
+rmcp = { version = "3.2.0", features = ["client"] }
 # Re-declared so the opencode real-corpus restore oracle can read the source SQLite DB directly.
 rusqlite = { version = "0.40", features = ["bundled"] }
 insta = "1.47.2"

--- a/packages/pond/src/transport.rs
+++ b/packages/pond/src/transport.rs
@@ -348,10 +348,10 @@ pub mod mcp {
         ErrorData, RoleServer, ServerHandler, ServiceExt,
         handler::server::{router::tool::ToolRouter, wrapper::Parameters},
         model::{
-            AnnotateAble, CallToolResult, Content, ErrorCode as JsonRpcErrorCode, Implementation,
-            ListResourcesResult, ListToolsResult, Meta, PaginatedRequestParams, RawResource,
-            ReadResourceRequestParams, ReadResourceResult, ResourceContents, ServerCapabilities,
-            ServerInfo,
+            CallToolResult, ContentBlock, ErrorCode as JsonRpcErrorCode, Implementation,
+            ListResourcesResult, ListToolsResult, MetaObject, PaginatedRequestParams,
+            ReadResourceRequestParams, ReadResourceResponse, ReadResourceResult, Resource,
+            ResourceContents, ServerCapabilities, ServerInfo,
         },
         schemars,
         service::RequestContext,
@@ -946,13 +946,13 @@ Examples (4 patterns the agent should recognize):
             Parameters(params): Parameters<McpSearchParams>,
         ) -> Result<CallToolResult, ErrorData> {
             let Some(mode) = parse_search_mode(params.mode.as_deref()) else {
-                return Ok(CallToolResult::error(vec![Content::text(format!(
+                return Ok(CallToolResult::error(vec![ContentBlock::text(format!(
                     "unknown mode {:?}; use \"vector\" or \"fts\"",
                     params.mode.unwrap_or_default()
                 ))]));
             };
             let Some(sort_by) = parse_sort_by(params.sort_by.as_deref()) else {
-                return Ok(CallToolResult::error(vec![Content::text(format!(
+                return Ok(CallToolResult::error(vec![ContentBlock::text(format!(
                     "unknown sort_by {:?}; use \"relevance\" or \"recency\"",
                     params.sort_by.unwrap_or_default()
                 ))]));
@@ -992,7 +992,7 @@ Examples (4 patterns the agent should recognize):
                 // one: a JSON-RPC error makes plugin hosts tear down and respawn
                 // the pond child on every call.
                 SearchEnvelope::Error(envelope) if is_semantic_disabled(&envelope) => Ok(
-                    CallToolResult::error(vec![Content::text(envelope.error.message.clone())]),
+                    CallToolResult::error(vec![ContentBlock::text(envelope.error.message.clone())]),
                 ),
                 SearchEnvelope::Error(envelope) => Err(to_error_data(&envelope)),
             }
@@ -1110,7 +1110,7 @@ Examples (4 patterns the agent should recognize):
                 Some("parquet") => sql::Mode::Export(sql::Format::Parquet),
                 Some("ndjson") => sql::Mode::Export(sql::Format::Ndjson),
                 Some(other) => {
-                    return Ok(CallToolResult::error(vec![Content::text(format!(
+                    return Ok(CallToolResult::error(vec![ContentBlock::text(format!(
                         "unknown format {other:?}; use \"text\", \"parquet\", or \"ndjson\""
                     ))]));
                 }
@@ -1189,7 +1189,7 @@ Examples (4 patterns the agent should recognize):
                     }
                 }
                 Err(sql::SqlError::Query(message)) => {
-                    Ok(CallToolResult::error(vec![Content::text(message)]))
+                    Ok(CallToolResult::error(vec![ContentBlock::text(message)]))
                 }
                 Err(sql::SqlError::Infra(error)) => Err(ErrorData::internal_error(
                     format!("sql execution failed: {error}"),
@@ -1268,31 +1268,29 @@ Examples (4 patterns the agent should recognize):
             _request: Option<PaginatedRequestParams>,
             _context: RequestContext<RoleServer>,
         ) -> Result<ListResourcesResult, ErrorData> {
-            Ok(ListResourcesResult {
-                resources: vec![
-                    RawResource::new("schema://pond", "pond search schema").no_annotation(),
-                    RawResource::new("schema://pond-sql", "pond SQL table schema").no_annotation(),
-                    RawResource::new("stats://pond", "pond corpus stats").no_annotation(),
-                ],
-                next_cursor: None,
-                meta: None,
-            })
+            Ok(ListResourcesResult::with_all_items(vec![
+                Resource::new("schema://pond", "pond search schema"),
+                Resource::new("schema://pond-sql", "pond SQL table schema"),
+                Resource::new("stats://pond", "pond corpus stats"),
+            ]))
         }
 
         async fn read_resource(
             &self,
             request: ReadResourceRequestParams,
             _context: RequestContext<RoleServer>,
-        ) -> Result<ReadResourceResult, ErrorData> {
+        ) -> Result<ReadResourceResponse, ErrorData> {
             match request.uri.as_str() {
                 "schema://pond" => Ok(ReadResourceResult::new(vec![ResourceContents::text(
                     schema_doc_for(crate::embed::embeddings_enabled()),
                     request.uri,
-                )])),
+                )])
+                .into()),
                 "schema://pond-sql" => Ok(ReadResourceResult::new(vec![ResourceContents::text(
                     SQL_SCHEMA_DOC,
                     request.uri,
-                )])),
+                )])
+                .into()),
                 // `pond_sql` export artifacts: read the file pond wrote
                 // (parquet -> base64 blob, ndjson -> text). The filename is
                 // validated to a minted `<uuid>.<ext>` so the URI can't traverse.
@@ -1317,7 +1315,7 @@ Examples (4 patterns the agent should recognize):
                         ResourceContents::blob(STANDARD.encode(&bytes), request.uri)
                             .with_mime_type("application/vnd.apache.parquet")
                     };
-                    Ok(ReadResourceResult::new(vec![contents]))
+                    Ok(ReadResourceResult::new(vec![contents]).into())
                 }
                 "stats://pond" => {
                     let store = &self.state.store;
@@ -1393,7 +1391,8 @@ Examples (4 patterns the agent should recognize):
                     Ok(ReadResourceResult::new(vec![ResourceContents::text(
                         stats.to_string(),
                         request.uri,
-                    )]))
+                    )])
+                    .into())
                 }
                 other => Err(ErrorData::resource_not_found(
                     format!("unknown resource: {other}"),
@@ -1408,11 +1407,7 @@ Examples (4 patterns the agent should recognize):
             context: RequestContext<RoleServer>,
         ) -> Result<ListToolsResult, ErrorData> {
             let _ = (request, context);
-            let mut result = ListToolsResult {
-                tools: self.tool_router.list_all(),
-                next_cursor: None,
-                meta: None,
-            };
+            let mut result = ListToolsResult::with_all_items(self.tool_router.list_all());
             annotate_tool_limits(&mut result);
             annotate_search_mode_with(&mut result, crate::embed::embeddings_enabled());
             Ok(result)
@@ -1489,7 +1484,7 @@ Examples (4 patterns the agent should recognize):
                 "anthropic/maxResultSizeChars".to_owned(),
                 serde_json::json!(chars),
             );
-            tool.meta = Some(Meta(meta));
+            tool.meta = Some(MetaObject(meta));
         }
     }
 
@@ -1511,7 +1506,7 @@ Examples (4 patterns the agent should recognize):
     /// is the whole point on the MCP surface. Programmatic clients that want the
     /// structured wire shape use the HTTP `/v1/*` JSON API instead.
     fn tool_result(transcript: String) -> CallToolResult {
-        CallToolResult::success(vec![Content::text(transcript)])
+        CallToolResult::success(vec![ContentBlock::text(transcript)])
     }
 
     /// Build the `pond_sql` export result: a text summary plus a
@@ -1546,11 +1541,14 @@ Examples (4 patterns the agent should recognize):
                 path.display()
             ));
         }
-        let link = RawResource::new(uri, name.to_owned())
+        let link = Resource::new(uri, name.to_owned())
             .with_description(format!("pond SQL export ({}, {rows} rows)", format.ext()))
             .with_mime_type(format.mime().to_owned())
-            .with_size(u32::try_from(bytes).unwrap_or(u32::MAX));
-        CallToolResult::success(vec![Content::text(summary), Content::resource_link(link)])
+            .with_size(u64::try_from(bytes).unwrap_or(u64::MAX));
+        CallToolResult::success(vec![
+            ContentBlock::text(summary),
+            ContentBlock::resource_link(link),
+        ])
     }
 
     /// Accept only the export filenames pond mints (`<uuid>.parquet|ndjson`),
@@ -1602,6 +1600,51 @@ Examples (4 patterns the agent should recognize):
 
         use super::*;
         use crate::wire::{ErrorBody, ErrorCode};
+
+        #[tokio::test]
+        async fn discovery_startup_exposes_pond_tools() -> anyhow::Result<()> {
+            use rmcp::{ClientLifecycleMode, ClientServiceExt, model::ProtocolVersion};
+
+            tokio::time::timeout(std::time::Duration::from_secs(30), async {
+                let temp = tempfile::TempDir::new()?;
+                let server = PondMcp::new(AppState {
+                    store: Arc::new(crate::sessions::Store::open_local(temp.path()).await?),
+                    embedder: Arc::new(crate::embed::LazyEmbedder::candle()),
+                    search: crate::config::SearchConfig::default(),
+                });
+                let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+                let server_task = tokio::spawn(async move {
+                    server.serve(server_io).await?.waiting().await?;
+                    anyhow::Ok(())
+                });
+                let client = ()
+                    .serve_with_lifecycle(
+                        client_io,
+                        ClientLifecycleMode::Discover {
+                            preferred_versions: vec![ProtocolVersion::V_2026_07_28],
+                        },
+                    )
+                    .await?;
+                let info = client.peer_info().unwrap();
+                assert_eq!(info.server_info.as_ref().unwrap().name, "pond");
+                let tools = client.list_all_tools().await?;
+                let mut names: Vec<_> = tools.iter().map(|tool| tool.name.as_ref()).collect();
+                names.sort_unstable();
+                assert_eq!(
+                    names,
+                    [
+                        "pond_get_message",
+                        "pond_get_session",
+                        "pond_search",
+                        "pond_sql"
+                    ]
+                );
+                client.cancel().await?;
+                server_task.await??;
+                anyhow::Ok(())
+            })
+            .await?
+        }
 
         #[test]
         fn error_data_carries_code_and_retryability() {
@@ -1675,15 +1718,11 @@ Examples (4 patterns the agent should recognize):
         #[test]
         fn annotate_tool_limits_sets_anthropic_meta() {
             let schema = Arc::new(serde_json::Map::new());
-            let mut result = ListToolsResult {
-                tools: vec![
-                    Tool::new("pond_search", "Search", Arc::clone(&schema)),
-                    Tool::new("pond_get_session", "Get session", Arc::clone(&schema)),
-                    Tool::new("pond_get_message", "Get message", Arc::clone(&schema)),
-                ],
-                next_cursor: None,
-                meta: None,
-            };
+            let mut result = ListToolsResult::with_all_items(vec![
+                Tool::new("pond_search", "Search", Arc::clone(&schema)),
+                Tool::new("pond_get_session", "Get session", Arc::clone(&schema)),
+                Tool::new("pond_get_message", "Get message", Arc::clone(&schema)),
+            ]);
             annotate_tool_limits(&mut result);
             let value = |name: &str| {
                 result
@@ -1735,11 +1774,7 @@ Examples (4 patterns the agent should recognize):
         }
 
         fn listed_tools() -> ListToolsResult {
-            ListToolsResult {
-                tools: PondMcp::tool_router().list_all(),
-                next_cursor: None,
-                meta: None,
-            }
+            ListToolsResult::with_all_items(PondMcp::tool_router().list_all())
         }
 
         fn search_tool(result: &ListToolsResult) -> &Tool {

--- a/packages/pond/src/transport.rs
+++ b/packages/pond/src/transport.rs
@@ -1491,6 +1491,14 @@ Examples (4 patterns the agent should recognize):
     /// Run the stdio MCP server until the client disconnects. All diagnostics
     /// go to stderr (the shared `tracing` subscriber); stdout carries only
     /// JSON-RPC frames, written by rmcp's stdio transport (spec.md#scope).
+    ///
+    /// TODO(rust-sdk#1248): a first request carrying incomplete 2026-07-28
+    /// `_meta` is answered `-32602` and then still ends the process, so a
+    /// client opening with a malformed probe never gets to fall back. Upstream
+    /// is making that recoverable (rust-sdk#1157 -> #1160 shipped the error
+    /// response, <https://github.com/modelcontextprotocol/rust-sdk/pull/1248>
+    /// keeps the connection open), so pond stays on the default
+    /// `.serve(stdio())` and inherits it on the next rmcp bump.
     pub async fn serve_stdio(state: AppState) -> anyhow::Result<()> {
         let service = PondMcp::new(state)
             .serve(stdio())
@@ -1601,6 +1609,10 @@ Examples (4 patterns the agent should recognize):
         use super::*;
         use crate::wire::{ErrorBody, ErrorCode};
 
+        /// A 2026-07-28 client opens with `server/discover` before
+        /// `initialize`, which rmcp 1.7 treated as fatal. `V_2026_07_28` is
+        /// deliberately not `ProtocolVersion::LATEST` (2025-11-25) - `LATEST`
+        /// negotiates the classic handshake and stops exercising discovery.
         #[tokio::test]
         async fn discovery_startup_exposes_pond_tools() -> anyhow::Result<()> {
             use rmcp::{ClientLifecycleMode, ClientServiceExt, model::ProtocolVersion};

--- a/packages/pond/tests/integration/sql.rs
+++ b/packages/pond/tests/integration/sql.rs
@@ -182,14 +182,14 @@ fn first_text(result: &CallToolResult) -> Option<&str> {
     result
         .content
         .iter()
-        .find_map(|content| content.raw.as_text().map(|text| text.text.as_str()))
+        .find_map(|content| content.as_text().map(|text| text.text.as_str()))
 }
 
 fn resource_link_uri(result: &CallToolResult) -> Option<String> {
     result
         .content
         .iter()
-        .find_map(|content| content.raw.as_resource_link().map(|link| link.uri.clone()))
+        .find_map(|content| content.as_resource_link().map(|link| link.uri.clone()))
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/packages/pond/tests/integration/transport_mcp.rs
+++ b/packages/pond/tests/integration/transport_mcp.rs
@@ -323,6 +323,6 @@ async fn mcp_tools_round_trip_with_size_caps_and_error_mapping() -> anyhow::Resu
     assert_eq!(data.get("retryable"), Some(&json!(false)));
 
     client.cancel().await?;
-    let _ = server_handle.await;
+    server_handle.await??;
     Ok(())
 }

--- a/packages/pond/tests/integration/transport_mcp.rs
+++ b/packages/pond/tests/integration/transport_mcp.rs
@@ -171,7 +171,7 @@ fn tool_text(result: &CallToolResult) -> &str {
     result
         .content
         .first()
-        .and_then(|content| content.raw.as_text())
+        .and_then(|content| content.as_text())
         .map(|text| text.text.as_str())
         .expect("a tool result should carry a text block")
 }
@@ -193,7 +193,7 @@ async fn mcp_tools_round_trip_with_size_caps_and_error_mapping() -> anyhow::Resu
     let server_info = client
         .peer_info()
         .expect("server sent its initialize result");
-    assert_eq!(server_info.server_info.name, "pond");
+    assert_eq!(server_info.server_info.as_ref().unwrap().name, "pond");
 
     let tools = client.list_all_tools().await?;
     let meta_chars = |name: &str| -> Option<i64> {


### PR DESCRIPTION
## Summary

Upgrade rmcp from 1.7 to 3.2.0 and keep Pond on rmcp's default stdio server lifecycle. This adds the 2026-07-28 `server/discover` startup path used by dual-era MCP clients, while retaining legacy `initialize` support. Update the affected rmcp model APIs and add a focused discovery lifecycle regression test that verifies Pond exposes all four read-only tools.

Validation:

- `cargo check --tests`
- `cargo fmt --check`
- `cargo test --lib transport::mcp::tests::discovery_startup_exposes_pond_tools`

## Release note

Pond's stdio MCP server now supports the modern discovery startup used by dual-era clients such as Antigravity while remaining compatible with legacy MCP clients. No HTTP daemon or port workaround is needed.
