### PR TITLE
docs(agents): record what a bench-gate row does and does not prove

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,8 @@ The wizard prompts (`pond init`, source discovery, etc.) go through cliclack/dia
 - Run the old-side row (the gate at the pre-change commit) BEFORE the new binary ever writes to the real store: writes mutate store state, so the old-side read baseline is unrecoverable afterwards except via s5cmd scratch copies (the lance 8->10 upgrade lost its sync-write baseline exactly this way). The gate's write metrics have no such hazard - they run on fixed synthetic scratch stores either way.
 - `POND_BIN=/path/to/pond moon run bench-gate` snapshots a prebuilt binary (e.g. the released one) through the CLI probes; the cargo-bench fields land null since those compile HEAD. A full old-side row needs the gate run from the old commit's checkout.
 - Rows are comparable only within the same `store` digest and `write_corpus` tag; the delta printer warns on store changes and flags rows with no write metrics.
+- The gate measures the paths its probes name and nothing else, so confirm a probe reads yours before citing a row as evidence - its `[sync] change-detection oracle` spent months timing a function with no production callers, leaving real sync-oracle changes unmeasured (#232). Otherwise add a probe, or measure separately and say so in the write-up.
+- One row does not bracket a change on a remote store: two runs 65 minutes apart on identical code moved `search_dated_s` +129%, `row_counts_ms` -59% and `open_store_ms` +90%, which buries a few hundred ms of real regression. Bracket a small effect with a targeted A/B over many runs (`hyperfine`, medians - S3 outliers drag means), each run on its own store path.
 
 ## Errors
 


### PR DESCRIPTION
Two bullets in the benchmarking section of `AGENTS.md`, both paid for during the #226 work, where a green gate row twice meant nothing.

**The gate measures only the paths its probes name.** Its `[sync] change-detection oracle` probe timed `Store::session_last_message_ids`, which had no production callers since the resident rowmap replaced it. Every gate run spent ~90 s measuring a dead path, and a change to the real sync oracle passed the gate untouched. The probe is fixed (#232); the rule that outlives it is to confirm a probe reads your path before citing a row as evidence. The section above these bullets says the gate "covers both in one run", which is exactly the impression worth correcting.

**One row cannot bracket a small change on a remote store.** Two runs 65 minutes apart on identical code moved `search_dated_s` +129%, `row_counts_ms` -59% and `open_store_ms` +90%. A few hundred ms of real regression is invisible under that, so a small effect needs a targeted A/B over many runs with medians, each run on its own store path.

Both are already written up in `docs/benchmarks/results.md`, but that file is read by someone who already went looking. `AGENTS.md` is what gets read before measuring, which is when the mistake gets made.

Docs only - no code, no tests, no behavior change.
