### PR TITLE
fix(openclaw): keep session facts in the stored entry, drop host config

### DIFF
--- a/packages/pond/src/adapter/openclaw.rs
+++ b/packages/pond/src/adapter/openclaw.rs
@@ -1697,7 +1697,7 @@ fn build_session(
         openclaw.insert("cwd".to_owned(), cwd.clone());
     }
     if let Some(entry) = entry {
-        openclaw.insert("session_entry".to_owned(), entry.clone());
+        openclaw.insert("session_entry".to_owned(), session_entry_projection(entry));
     }
     if let Some(token) = generation {
         openclaw.insert("transcript_generation".to_owned(), json!(token));
@@ -1756,6 +1756,55 @@ struct Lineage {
     /// a parent session id (spec.md 4).
     parent_message_id: Option<String>,
     relation: Option<&'static str>,
+}
+
+/// Entry fields that describe the HOST rather than the session, and so are not
+/// projected into `options.openclaw.session_entry`.
+///
+/// Together they are 87% of a file-era entry (11.2 KB of 12.7 KB) and 91-94%
+/// of a DB-era one (21-24 KB of 23-25.5 KB), measured across the five captures.
+/// Neither is a fact about the session, and pond's model (sessions, messages,
+/// parts) has nowhere to put a fact about a host, so the only way to keep them
+/// is once per session forever. They go for different reasons:
+///
+/// - `skillsSnapshot` (858 B file-era, 8.9 KB DB-era) is the list of skills
+///   installed on the MACHINE. Byte-identical across every key in both eras'
+///   captures, so it is pure duplication.
+/// - `systemPromptReport` (11.2-15.1 KB) does vary per session, so it is not
+///   duplication - it is telemetry. Every leaf is a COUNT or a HASH of content
+///   held elsewhere: `systemPrompt` is `{chars, hash, projectContextChars}`,
+///   `tools` is per-tool `{name, summaryChars, summaryHash, schemaChars}`,
+///   `currentTurn` is `{promptChars, runtimeContextChars}`. No message, no tool
+///   call, no tool result - OpenClaw's own prompt-budget accounting.
+///
+/// `model-lossless-projection` is not an argument for keeping either: it
+/// protects the SESSION's content, and neither field carries any. The entry is
+/// also per-key and mutable, read at ingest, so a generation rotated out months
+/// ago would be stamped with the configuration as of the sync rather than as of
+/// the session - the same per-key-onto-every-generation error
+/// `is_root_generation` exists to prevent for lineage.
+///
+/// Everything else stays. The remaining ~700 B is genuinely per-session and is
+/// what `pond_sql` wants: `model`, `modelProvider`, token counts,
+/// `estimatedCostUsd`, the timestamps - and every lineage field
+/// (`parentSessionKey`, `usageFamilySessionIds`, `compactionCheckpoints`,
+/// `heartbeatIsolatedBaseSessionKey`), which is why this is a deny list rather
+/// than an allow list: an unrecognized field is kept, not dropped.
+const ENTRY_HOST_CONFIG_FIELDS: &[&str] = &["systemPromptReport", "skillsSnapshot"];
+
+/// Project a `sessions.json` / `session_nodes` entry for storage, dropping the
+/// host-configuration fields. A non-object entry (`json_or_string` yields a
+/// string for unparseable `entry_json`) passes through untouched.
+fn session_entry_projection(entry: &Value) -> Value {
+    let Some(object) = entry.as_object() else {
+        return entry.clone();
+    };
+    object
+        .iter()
+        .filter(|(key, _)| !ENTRY_HOST_CONFIG_FIELDS.contains(&key.as_str()))
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect::<serde_json::Map<_, _>>()
+        .into()
 }
 
 /// `sessions.json` `label` marking a session branched off a compaction

--- a/packages/pond/tests/integration/adapter/openclaw.rs
+++ b/packages/pond/tests/integration/adapter/openclaw.rs
@@ -889,6 +889,70 @@ async fn every_captured_transcript_is_ingested() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// The stored entry keeps what is true of the SESSION and drops what is true
+/// of the HOST.
+///
+/// `skillsSnapshot` is the machine's installed skills, byte-identical across
+/// every key; `systemPromptReport` is OpenClaw's prompt-budget telemetry, whose
+/// every leaf is a count or a hash of content held elsewhere. Together they are
+/// 87% of a file-era entry and 91-94% of a DB-era one, and neither carries a
+/// message, a tool call or a tool result. What remains has to stay useful,
+/// which is the second half of this test.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_stored_entry_drops_host_config_and_keeps_session_facts() -> anyhow::Result<()> {
+    let (store, _dir, ids) = ingest_capture("hooks-heartbeat").await;
+    let mut checked = 0usize;
+    for id in &ids {
+        let Some(session) = store.get_session(id).await? else {
+            continue;
+        };
+        let Some(entry) = session
+            .session
+            .options
+            .get("openclaw")
+            .and_then(|o| o.get("session_entry"))
+        else {
+            continue;
+        };
+        checked += 1;
+        for dropped in ["systemPromptReport", "skillsSnapshot"] {
+            assert!(
+                entry.get(dropped).is_none(),
+                "{id}: {dropped} describes the host, not this session, and is \
+                 identical on every session of the machine"
+            );
+        }
+        // The projection must not gut the entry: these are the per-session
+        // facts `pond_sql` exists to answer questions about.
+        assert!(
+            entry.get("sessionId").and_then(Value::as_str).is_some(),
+            "{id}: sessionId must survive"
+        );
+        assert!(
+            entry.get("updatedAt").is_some(),
+            "{id}: timestamps must survive"
+        );
+        assert!(
+            entry.get("sessionFile").is_some(),
+            "{id}: sessionFile must survive"
+        );
+        // A deny list, not an allow list: only two fields go. Anything else the
+        // capture happens to carry - token counts, cost, lineage keys, fields
+        // OpenClaw adds later - must still be there.
+        let kept = entry.as_object().map(serde_json::Map::len).unwrap_or(0);
+        assert!(
+            kept >= 5,
+            "{id}: entry projected down to {kept} fields; only \
+             systemPromptReport and skillsSnapshot should have been dropped"
+        );
+    }
+    assert!(
+        checked > 0,
+        "no session carried an entry; the assertions above proved nothing"
+    );
+    Ok(())
+}
+
 /// Cron runs group under their JOB, not one project per run: a
 /// `sessionTarget: "main"` run stores its own
 /// `...:cron:<jobId>:run:<startedAtMs>` key, and a project per run would make


### PR DESCRIPTION
`options.openclaw.session_entry` mirrored the whole `sessions.json` / `session_nodes` entry. Two of its fields describe the **machine**, not the session, and they are almost all of it.

| | file-era | DB-era |
|---|---|---|
| `skillsSnapshot` | 858 B | 8,906 B |
| `systemPromptReport` | 11.2 KB | 12.1-15.1 KB |
| entry total | 12.7 KB | 23-25.5 KB |
| **share dropped** | **87%** | **91-94%** |

Measured across the five committed captures.

## Why each one goes

**`skillsSnapshot`** is the list of skills installed on the host. Byte-identical across every key in both eras' captures, so keeping it stores one machine's configuration once per session, forever.

**`systemPromptReport`** does vary per session, so it is not duplication - it is telemetry. Every leaf is a count or a hash of content held elsewhere:

```
systemPrompt  {chars: 32809, hash: "1d7c05...", projectContextChars: 13738}
tools         [{name: "read", summaryChars: 303, schemaChars: 304, schemaHash: ...}, ...]
currentTurn   {promptChars: 34, runtimeContextChars: 0}
```

No message, no tool call, no tool result. It is OpenClaw's own prompt-budget accounting, and the real transcript comes from `transcript_events` / the `.jsonl` files on a completely separate path.

`model-lossless-projection` is not an argument for keeping either: it protects the session's **content**, and neither field carries any. Both would also be misattributed - the entry is per-key and mutable and is read at ingest, so a generation rotated out months ago was stamped with the configuration as of the sync rather than as of the session. That is the same per-key-onto-every-generation error `is_root_generation` exists to prevent for lineage.

## What stays

A deny list, not an allow list, so an unrecognized field is kept rather than dropped. The remaining ~700 B is what `pond_sql` exists to answer questions about - `model`, `modelProvider`, token counts, `estimatedCostUsd`, the timestamps, `sessionFile` - and every lineage field is conditional and survives untouched: `parentSessionKey`, `usageFamilySessionIds`, `compactionCheckpoints`, `heartbeatIsolatedBaseSessionKey`. A field OpenClaw adds later is kept too. The test asserts `kept >= 5` so a future widening of the deny list fails loudly.

## Why now rather than an issue

File-era sessions gained an entry in #228, which **has not shipped** - v0.17.1 is the latest release. So no client has written one yet, and landing this before 0.17.2 means the ~1.8k sessions #228 recovers on the reporter's host never carry the payload at all.

Session rows are written once (`sessions_owned` filters to sessions absent from the store), so a store that already holds fat entries from the DB-v1 path keeps them. This stops the bleeding; it does not rewrite history.

## Risk

Nothing in pond reads the field - it exists for `pond_sql` and human inspection. No primary key, no `entry_content_id`, no `merge_insert` path is touched, so there is no dedup or duplication exposure. A non-object entry (`json_or_string` yields a string for unparseable `entry_json`) passes through unchanged.

568 tests pass, `cargo clippy --locked --all-targets -- -D warnings` clean, `cargo fmt --check` clean.

## Release note

pond no longer copies OpenClaw's `systemPromptReport` and `skillsSnapshot` into each stored session. Both describe the host rather than the session and carry no conversational content, and together they were 87-94% of the stored entry. Model, token, cost, timestamp and lineage fields are unchanged.
