### PR TITLE
fix(mcp): emit the SEP-2549 cache hints 2026-07-28 clients require

### DIFF
--- a/packages/pond/src/transport.rs
+++ b/packages/pond/src/transport.rs
@@ -348,10 +348,11 @@ pub mod mcp {
         ErrorData, RoleServer, ServerHandler, ServiceExt,
         handler::server::{router::tool::ToolRouter, wrapper::Parameters},
         model::{
-            CallToolResult, ContentBlock, ErrorCode as JsonRpcErrorCode, Implementation,
-            ListResourcesResult, ListToolsResult, MetaObject, PaginatedRequestParams,
-            ReadResourceRequestParams, ReadResourceResponse, ReadResourceResult, Resource,
-            ResourceContents, ServerCapabilities, ServerInfo,
+            CacheScope, CallToolResult, ContentBlock, ErrorCode as JsonRpcErrorCode,
+            Implementation, ListResourcesResult, ListToolsResult, MetaObject,
+            PaginatedRequestParams, ProtocolVersion, ReadResourceRequestParams,
+            ReadResourceResponse, ReadResourceResult, Resource, ResourceContents,
+            ServerCapabilities, ServerInfo,
         },
         schemars,
         service::RequestContext,
@@ -1266,13 +1267,18 @@ Examples (4 patterns the agent should recognize):
         async fn list_resources(
             &self,
             _request: Option<PaginatedRequestParams>,
-            _context: RequestContext<RoleServer>,
+            context: RequestContext<RoleServer>,
         ) -> Result<ListResourcesResult, ErrorData> {
-            Ok(ListResourcesResult::with_all_items(vec![
+            let result = ListResourcesResult::with_all_items(vec![
                 Resource::new("schema://pond", "pond search schema"),
                 Resource::new("schema://pond-sql", "pond SQL table schema"),
                 Resource::new("stats://pond", "pond corpus stats"),
-            ]))
+            ]);
+            Ok(if wants_cache_hints(&context) {
+                result.with_ttl_ms(0).with_cache_scope(CacheScope::Public)
+            } else {
+                result
+            })
         }
 
         async fn read_resource(
@@ -1403,15 +1409,32 @@ Examples (4 patterns the agent should recognize):
 
         async fn list_tools(
             &self,
-            request: Option<PaginatedRequestParams>,
+            _request: Option<PaginatedRequestParams>,
             context: RequestContext<RoleServer>,
         ) -> Result<ListToolsResult, ErrorData> {
-            let _ = (request, context);
             let mut result = ListToolsResult::with_all_items(self.tool_router.list_all());
             annotate_tool_limits(&mut result);
             annotate_search_mode_with(&mut result, crate::embed::embeddings_enabled());
-            Ok(result)
+            Ok(if wants_cache_hints(&context) {
+                result.with_ttl_ms(0).with_cache_scope(CacheScope::Public)
+            } else {
+                result
+            })
         }
+    }
+
+    /// SEP-2549 makes `ttlMs` and `cacheScope` required on list results once
+    /// the client negotiates 2026-07-28, and a strict client (Claude Code)
+    /// rejects the whole response without them - dropping every tool while the
+    /// connection still looks healthy. rmcp stamps them in the handler macros
+    /// (rust-sdk#1120), but pond overrides `list_tools` and `list_resources`,
+    /// so the override has to stamp them itself. Callers pair this with
+    /// `ttl_ms = 0` (immediately stale): the tool surface varies with instance
+    /// config, so a cached list would advertise the wrong one.
+    fn wants_cache_hints(context: &RequestContext<RoleServer>) -> bool {
+        context
+            .protocol_version()
+            .is_some_and(|version| version >= ProtocolVersion::V_2026_07_28)
     }
 
     /// `pond_search` description with the whole `mode=` sentence removed - what
@@ -1653,6 +1676,92 @@ Examples (4 patterns the agent should recognize):
                 );
                 client.cancel().await?;
                 server_task.await??;
+                anyhow::Ok(())
+            })
+            .await?
+        }
+
+        /// Spin pond's MCP server over an in-memory duplex and return what a
+        /// client sees on the two list surfaces, negotiating either the
+        /// 2026-07-28 discovery handshake or the classic one.
+        async fn list_results(
+            modern: bool,
+        ) -> anyhow::Result<(ListToolsResult, ListResourcesResult)> {
+            use rmcp::{ClientLifecycleMode, ClientServiceExt, model::ProtocolVersion};
+
+            let temp = tempfile::TempDir::new()?;
+            let server = PondMcp::new(AppState {
+                store: Arc::new(crate::sessions::Store::open_local(temp.path()).await?),
+                embedder: Arc::new(crate::embed::LazyEmbedder::candle()),
+                search: crate::config::SearchConfig::default(),
+            });
+            let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+            let server_task = tokio::spawn(async move {
+                server.serve(server_io).await?.waiting().await?;
+                anyhow::Ok(())
+            });
+            let client = if modern {
+                ().serve_with_lifecycle(
+                    client_io,
+                    ClientLifecycleMode::Discover {
+                        preferred_versions: vec![ProtocolVersion::V_2026_07_28],
+                    },
+                )
+                .await?
+            } else {
+                ().serve(client_io).await?
+            };
+            let tools = client.list_tools(None).await?;
+            let resources = client.list_resources(None).await?;
+            client.cancel().await?;
+            server_task.await??;
+            Ok((tools, resources))
+        }
+
+        /// SEP-2549 makes `ttlMs` and `cacheScope` required on list results at
+        /// 2026-07-28, and a strict client rejects the whole response without
+        /// them - Claude Code showed this as a connected pond MCP server
+        /// carrying zero tools and zero resources. `list_all_tools` in the
+        /// discovery test above cannot catch it: rmcp's own client parses the
+        /// fields as optional, so only asserting the envelope fails.
+        #[tokio::test]
+        async fn modern_list_results_carry_the_required_cache_hints() -> anyhow::Result<()> {
+            tokio::time::timeout(std::time::Duration::from_secs(30), async {
+                let (tools, resources) = list_results(true).await?;
+                assert_eq!(
+                    (
+                        tools.ttl_ms,
+                        tools.cache_scope,
+                        resources.ttl_ms,
+                        resources.cache_scope,
+                    ),
+                    (
+                        Some(0),
+                        Some(CacheScope::Public),
+                        Some(0),
+                        Some(CacheScope::Public),
+                    )
+                );
+                anyhow::Ok(())
+            })
+            .await?
+        }
+
+        /// A classic client keeps the pre-SEP wire shape: the hints are absent,
+        /// not null.
+        #[tokio::test]
+        async fn legacy_list_results_omit_the_cache_hints() -> anyhow::Result<()> {
+            tokio::time::timeout(std::time::Duration::from_secs(30), async {
+                let (tools, resources) = list_results(false).await?;
+                assert_eq!(
+                    (
+                        tools.ttl_ms,
+                        tools.cache_scope,
+                        resources.ttl_ms,
+                        resources.cache_scope,
+                    ),
+                    (None, None, None, None)
+                );
                 anyhow::Ok(())
             })
             .await?


### PR DESCRIPTION
## Summary

A client that negotiates protocol `2026-07-28` gets **zero tools and no readable resources** from pond, while the connection itself looks perfectly healthy. SEP-2549 makes `ttlMs` and `cacheScope` required on every cacheable result, pond omits both, and a strict client rejects the whole response.

Observed in production against `pond serve` 0.17.2, from Claude Code 2.1.258 (`~/.cache/claude-cli-nodejs/<project>/mcp-logs-pond/`):

```
"Successfully connected (transport: http) in 163ms"
"negotiatedProtocolVersion":"2026-07-28"
...
{"error":"Failed to fetch tools: Invalid result for tools/list: [
   {"path":["ttlMs"],      "message":"expected number, received undefined"},
   {"path":["cacheScope"], "message":"expected one of \"public\"|\"private\""} ]}
{"error":"Failed to fetch resources: Invalid result for resources/list: [ ...same... ]}
```

It retries three times, gives up, and the agent behaves as if pond is not wired at all. The same schema check rejects `resources/read`, which is what breaks `schema://pond-sql` - the doc `pond_sql` tells agents to read first - and every `pond-sql-export://` artifact.

## Root cause

rmcp already fixed this for servers that use the documented handler macros -- [rust-sdk#1114](https://github.com/modelcontextprotocol/rust-sdk/issues/1114), fixed by [rust-sdk#1120](https://github.com/modelcontextprotocol/rust-sdk/pull/1120), shipped in rmcp 3.1.1. pond is on 3.2.0, so it has the fix.

It just never reaches the wire, because pond overrides the handlers the fix lives in, or relies on rmcp defaults that never got it:

| Surface | pond's handler | Hints before |
|---|---|---|
| `tools/list` | override (tool limits, `pond_search` rewrite) | none |
| `resources/list` | override (the three resources) | none |
| `resources/read` | override (docs, stats, exports) | none |
| `resources/templates/list` | rmcp default (`handler/server.rs:396`) | none |

Every one builds its result with `with_all_items` / `ReadResourceResult::new` / `::default()`, which leave `ttl_ms: None, cache_scope: None`; rmcp's own doc on those fields says "Required by spec version 2026-07-28". The spec requires them on all four: [caching](https://modelcontextprotocol.io/specification/draft/server/utilities/caching) says servers MUST include hints on them, and `schema/2026-07-28/schema.ts` makes both `CacheableResult` fields non-optional.

So this is pond's bug, not rmcp's; no rmcp bump helps. It was introduced in v0.17.1 by #223 (rmcp 1.7 -> 3.2.0), which is what made pond advertise `2026-07-28` in the first place. Before that, clients fell back to `2025-11-25` and never asked for the fields.

## What changed

`cache_hints(&context, scope)` returns the `(ttl_ms, cache_scope)` pair, gated on the negotiated version `>= 2026-07-28` exactly like #1120. Each handler assigns it in one line. Legacy clients keep the exact pre-SEP wire shape - both fields unset.

- `tools/list`, `resources/list`, `resources/templates/list`: `public`.
- `resources/read`: stamped once after the match - `public` for `schema://pond` and `schema://pond-sql` (identical for every caller), `private` for `stats://pond` and `pond-sql-export://` (the store's own data, which a shared cache must not hand to another caller).
- `list_resource_templates` is overridden to return the empty list with hints, since rmcp's default carries none.

`ttlMs` is `0` (immediately stale) everywhere, via `CACHE_HINT_TTL_MS`. Nothing listed changes within one process, but a shared gateway may serve a `public` result across pond instances, whose config (the `pond_search` surface) and data differ. `0` also matches what clients did before: no hint meant no caching, so request volume is unchanged.

`server/discover` needed nothing - rmcp already stamps it.

## Tests

One `connect(modern)` helper now backs both the existing discovery test and the new ones. `cache_hints_seen(modern)` collects `(ttl_ms, cache_scope)` from all five cacheable calls - the three lists plus one read per scope arm:

- `modern_results_carry_the_required_cache_hints` -- the expected pair on every surface at `2026-07-28`.
- `legacy_results_omit_the_cache_hints` -- both unset on the classic handshake.

Verified to fail without the fix: with `cache_hints` forced to `(None, None)`, the modern test reports all five surfaces unset.

Note why the existing `discovery_startup_exposes_pond_tools` stayed green through all of this: it asserts via `list_all_tools()`, which returns only the items, and rmcp's own client parses `ttlMs` / `cacheScope` as optional. Only a strict client notices, so the new tests assert on the envelope rather than the tool names.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all green.
- End to end with a real strict client: this branch's `pond serve` against Claude Code 2.1.270, negotiating `2026-07-28`, sees all four tools, three resources, and reads `schema://pond-sql` and `stats://pond` successfully. On the first commit alone, the reads still failed with `Invalid result for resources/read: Invalid input for ttlMs (expected number) and cacheScope (expected "public" or "private")`.

## Release note

Clients that negotiate MCP protocol 2026-07-28, such as recent Claude Code, see pond's tools again and can read its resources. pond omitted the ttlMs and cacheScope fields that version requires, so strict clients rejected its lists and resource reads.
